### PR TITLE
Story/io 18/project phase to planning list

### DIFF
--- a/src/components/Planning/PhaseDialog/PhaseDialog.tsx
+++ b/src/components/Planning/PhaseDialog/PhaseDialog.tsx
@@ -4,7 +4,7 @@ import usePhaseForm from '@/forms/usePhaseForm';
 import { IListItem } from '@/interfaces/common';
 import { IPhaseForm } from '@/interfaces/formInterfaces';
 import { IProject } from '@/interfaces/projectInterfaces';
-import { patchProjectThunk } from '@/reducers/projectSlice';
+import { silentPatchProjectThunk } from '@/reducers/projectSlice';
 import { Button } from 'hds-react/components/Button';
 import { IconCheck, IconCross, IconPlaybackRecord } from 'hds-react/icons';
 import { FC, memo, useCallback, useEffect, useMemo, useRef } from 'react';
@@ -50,9 +50,9 @@ const PhaseDialog: FC<IPhaseDialogProps> = ({ project, phases, close, atElement 
 
   const onSubmit = useCallback(
     async (form: IPhaseForm) => {
-      id && dispatch(patchProjectThunk({ data: form, id: id }));
+      id && dispatch(silentPatchProjectThunk({ data: form, id: id })).then(() => close());
     },
-    [dispatch, id],
+    [close, dispatch, id],
   );
 
   const isElementOutOfView = !!(!isInViewPort && dimensions);

--- a/src/reducers/projectSlice.ts
+++ b/src/reducers/projectSlice.ts
@@ -144,7 +144,16 @@ export const projectSlice = createSlice({
     );
     // SILENT PATCH
     builder.addCase(silentPatchProjectThunk.fulfilled, (state, action: PayloadAction<IProject>) => {
-      return { ...state, selectedProject: action.payload, updated: getCurrentTime() };
+      // All projects also need to be updated to get changes into the planning list
+      const updatedProjectList: Array<IProject> = state.projects.map((p) =>
+        p.id === action.payload.id ? action.payload : p,
+      );
+      return {
+        ...state,
+        selectedProject: action.payload,
+        projects: [...updatedProjectList],
+        updated: getCurrentTime(),
+      };
     });
     builder.addCase(
       silentPatchProjectThunk.rejected,

--- a/src/reducers/projectSlice.ts
+++ b/src/reducers/projectSlice.ts
@@ -146,7 +146,7 @@ export const projectSlice = createSlice({
     builder.addCase(silentPatchProjectThunk.fulfilled, (state, action: PayloadAction<IProject>) => {
       // All projects also need to be updated to get changes into the planning list
       const updatedProjectList: Array<IProject> = state.projects.map((p) =>
-        p.id === action.payload.id ? action.payload : p,
+        p.id === action.payload?.id ? action.payload : p,
       );
       return {
         ...state,


### PR DESCRIPTION
- close phase dialog when patching phase
- remove notification when patching phase from planning list
- update list view phase when patching phase from project card form
- removed unnecessary debugs from projectCardBasics.test.tsx
- removed timeout extensions from projectCardBasics.test.tsx