### PR TITLE
Story/io 316/direct non programmed projects to project form from search results

### DIFF
--- a/src/components/SearchResults/SearchResultsCard.tsx
+++ b/src/components/SearchResults/SearchResultsCard.tsx
@@ -32,6 +32,10 @@ const SearchResultsCard: FC<ISearchResultListItem> = ({
                 text={t(`searchTag.${type}`)}
               />
             )}
+            {/** TODO: if project is not programmed &&
+             * 
+             <CustomTag color={'var(--color-bus-light	)'} text={t(`searchTag.notProgrammed`)} />
+             */}
           </div>
           {phase && (
             <CustomTag

--- a/src/components/SearchResults/SearchResultsCard.tsx
+++ b/src/components/SearchResults/SearchResultsCard.tsx
@@ -14,6 +14,7 @@ const SearchResultsCard: FC<ISearchResultListItem> = ({
   phase,
   breadCrumbs,
   link,
+  programmed,
 }) => {
   const { t } = useTranslation();
   const iconGroup = useMemo(() => <IconScrollGroup size="xs" />, []);
@@ -32,10 +33,9 @@ const SearchResultsCard: FC<ISearchResultListItem> = ({
                 text={t(`searchTag.${type}`)}
               />
             )}
-            {/** TODO: if project is not programmed &&
-             * 
-             <CustomTag color={'var(--color-bus-light	)'} text={t(`searchTag.notProgrammed`)} />
-             */}
+            {type === 'projects' && !programmed && (
+              <CustomTag color={'var(--color-bus-light	)'} text={t(`searchTag.notProgrammed`)} />
+            )}
           </div>
           {phase && (
             <CustomTag

--- a/src/hooks/useSearchResultsList.ts
+++ b/src/hooks/useSearchResultsList.ts
@@ -18,19 +18,25 @@ const buildBreadCrumbs = (
       (p) => classes.find((c) => c.id === p)?.name ?? districts.find((d) => d.id === p)?.name ?? '',
     );
 
+const buildLink = (r: ISearchResultPayloadItem) => {
+  if (r.type === 'projects') {
+    // if programmed is false return `/project/${r.id}/basics`
+    return `/planning/${r.path}/?project=${r.id}`;
+  }
+
+  return `/planning/${r.path}`;
+};
 const buildSearchResultsList = (
   searchResults: Array<ISearchResultPayloadItem>,
   classes: Array<IClass>,
   districts: Array<ILocation>,
 ): Array<ISearchResultListItem> => {
   const parsedResults = searchResults.map((r) => {
-    const link =
-      r.type === 'projects' ? `/planning/${r.path}/?project=${r.id}` : `/planning/${r.path}`;
     return {
       ...r,
       phase: r.phase?.value ?? null,
       breadCrumbs: buildBreadCrumbs(r.path, classes, districts),
-      link,
+      link: buildLink(r),
     };
   });
 

--- a/src/hooks/useSearchResultsList.ts
+++ b/src/hooks/useSearchResultsList.ts
@@ -19,13 +19,18 @@ const buildBreadCrumbs = (
     );
 
 const buildLink = (r: ISearchResultPayloadItem) => {
-  if (r.type === 'projects') {
-    // if programmed is false return `/project/${r.id}/basics`
+  // Programmed projects will navigate to planning view and get the ?project= param
+  if (r.type === 'projects' && r.programmed) {
     return `/planning/${r.path}/?project=${r.id}`;
   }
-
+  // Non-programmed projects will navigate to project form
+  else if (r.type === 'projects') {
+    return `/project/${r.id}/basics`;
+  }
+  // Default will navigate to planning view without the ?project= param
   return `/planning/${r.path}`;
 };
+
 const buildSearchResultsList = (
   searchResults: Array<ISearchResultPayloadItem>,
   classes: Array<IClass>,

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -273,7 +273,8 @@
     "programmedNo": "Ohjelmoitu: ei",
     "programmedYes": "Ohjelmoitu: kyllä",
     "programmedYearMin": "Ohjelmoitu vuosi min {{label}}",
-    "programmedYearMax": "Ohjelmoitu vuosi max {{label}}"
+    "programmedYearMax": "Ohjelmoitu vuosi max {{label}}",
+    "notProgrammed": "Ei ohjelmoitu"
   },
   "projectProgrammedForm": {
     "addProjectsToProgramming": "Tuo uusi hanke listalle",

--- a/src/interfaces/searchInterfaces.ts
+++ b/src/interfaces/searchInterfaces.ts
@@ -10,6 +10,7 @@ export interface ISearchResultPayloadItem {
   type: ISearchResultsType;
   hashTags: Array<IListItem>;
   phase: IListItem | null;
+  programmed: boolean | null;
 }
 
 export interface IProgrammedProjectSuggestions {

--- a/src/mocks/mockSearch.ts
+++ b/src/mocks/mockSearch.ts
@@ -46,6 +46,7 @@ export const mockSearchResults: { data: ISearchResults } = {
         name: 'Planning Project 1',
         id: 'planning-project-1',
         type: 'projects',
+        programmed: true,
         hashTags: [
           {
             id: '5b970a63-1d3b-4ddb-bd1a-658c8a5d67b4',
@@ -63,12 +64,22 @@ export const mockSearchResults: { data: ISearchResults } = {
         path: 'test-master-class-1/test-class-1/',
       },
       {
+        name: 'Non programmed project',
+        id: 'planning-project-2',
+        type: 'projects',
+        hashTags: [],
+        phase: null,
+        path: '',
+        programmed: false,
+      },
+      {
         name: 'Koillinen',
         id: '507e3e63-0c09-4c19-8d09-43549dcc65c8',
         type: 'classes',
         hashTags: [],
         phase: null,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/507e3e63-0c09-4c19-8d09-43549dcc65c8',
+        programmed: null,
       },
     ],
   },
@@ -87,6 +98,7 @@ export const mockLongSearchResults: { data: ISearchResults } = {
         type: 'projects',
         hashTags: [],
         phase: null,
+        programmed: true,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/55c6accb-80a4-4cb8-ad5b-8f605459e537',
       },
       {
@@ -95,6 +107,7 @@ export const mockLongSearchResults: { data: ISearchResults } = {
         type: 'projects',
         hashTags: [],
         phase: null,
+        programmed: true,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/55c6accb-80a4-4cb8-ad5b-8f605459e537',
       },
       {
@@ -103,6 +116,7 @@ export const mockLongSearchResults: { data: ISearchResults } = {
         type: 'projects',
         hashTags: [],
         phase: null,
+        programmed: true,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/55c6accb-80a4-4cb8-ad5b-8f605459e537',
       },
       {
@@ -111,6 +125,7 @@ export const mockLongSearchResults: { data: ISearchResults } = {
         type: 'projects',
         hashTags: [],
         phase: null,
+        programmed: true,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/55c6accb-80a4-4cb8-ad5b-8f605459e537',
       },
       {
@@ -119,6 +134,7 @@ export const mockLongSearchResults: { data: ISearchResults } = {
         type: 'projects',
         hashTags: [],
         phase: null,
+        programmed: true,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/55c6accb-80a4-4cb8-ad5b-8f605459e537',
       },
       {
@@ -127,6 +143,7 @@ export const mockLongSearchResults: { data: ISearchResults } = {
         type: 'projects',
         hashTags: [],
         phase: null,
+        programmed: true,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/55c6accb-80a4-4cb8-ad5b-8f605459e537',
       },
       {
@@ -135,6 +152,7 @@ export const mockLongSearchResults: { data: ISearchResults } = {
         type: 'projects',
         hashTags: [],
         phase: null,
+        programmed: true,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/55c6accb-80a4-4cb8-ad5b-8f605459e537',
       },
       {
@@ -143,6 +161,7 @@ export const mockLongSearchResults: { data: ISearchResults } = {
         type: 'projects',
         hashTags: [],
         phase: null,
+        programmed: true,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/55c6accb-80a4-4cb8-ad5b-8f605459e537',
       },
       {
@@ -151,6 +170,7 @@ export const mockLongSearchResults: { data: ISearchResults } = {
         type: 'projects',
         hashTags: [],
         phase: null,
+        programmed: true,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/55c6accb-80a4-4cb8-ad5b-8f605459e537',
       },
       {
@@ -159,6 +179,7 @@ export const mockLongSearchResults: { data: ISearchResults } = {
         type: 'projects',
         hashTags: [],
         phase: null,
+        programmed: true,
         path: '7b69a4ae-5950-4175-a142-66dc9c6306a4/c6294258-41b1-4ad6-afdf-0b10849ca000/55c6accb-80a4-4cb8-ad5b-8f605459e537',
       },
     ],

--- a/src/views/SearchResultsView/SearchResultsView.test.tsx
+++ b/src/views/SearchResultsView/SearchResultsView.test.tsx
@@ -303,11 +303,11 @@ describe('SearchResultsView', () => {
     it('renders all elements if there are results', async () => {
       const { container, findAllByText, findByTestId } = await render(searchActiveState);
 
-      expect(container.getElementsByClassName('search-result-card').length).toBe(2);
-      expect(container.getElementsByClassName('search-result-breadcrumbs').length).toBe(2);
-      expect(container.getElementsByClassName('search-result-title-container').length).toBe(2);
-      expect(container.getElementsByClassName('search-result-title').length).toBe(2);
-      expect(container.getElementsByClassName('custom-tag-container').length).toBe(3);
+      expect(container.getElementsByClassName('search-result-card').length).toBe(3);
+      expect(container.getElementsByClassName('search-result-breadcrumbs').length).toBe(3);
+      expect(container.getElementsByClassName('search-result-title-container').length).toBe(3);
+      expect(container.getElementsByClassName('search-result-title').length).toBe(3);
+      expect(container.getElementsByClassName('custom-tag-container').length).toBe(4);
 
       const projectCard = container.getElementsByClassName('search-result-card')[0];
       const projectChildren = projectCard.childNodes;

--- a/src/views/SearchResultsView/SearchResultsView.test.tsx
+++ b/src/views/SearchResultsView/SearchResultsView.test.tsx
@@ -18,6 +18,8 @@ import { Route } from 'react-router';
 import PlanningView from '../PlanningView';
 import { mockGetResponseProvider } from '@/utils/mockGetResponseProvider';
 import mockPlanningViewProjects from '@/mocks/mockPlanningViewProjects';
+import { ProjectBasics } from '@/components/Project/ProjectBasics';
+import ProjectView from '../ProjectView';
 
 jest.mock('axios');
 jest.mock('react-i18next', () => mockI18next());
@@ -79,6 +81,9 @@ const render = async (customState?: object) =>
   await act(async () =>
     renderWithProviders(
       <>
+        <Route path="/project/:projectId?" element={<ProjectView />}>
+          <Route path="basics" element={<ProjectBasics />} />
+        </Route>
         <Route path="/" element={<SearchResultsView />} />
         <Route path="/planning" element={<PlanningView />}>
           <Route path=":masterClassId" element={<PlanningView />}>
@@ -211,7 +216,7 @@ describe('SearchResultsView', () => {
     it('renders the list and all search results if there are results', async () => {
       const { findByTestId, container } = await render(searchActiveState);
       expect(await findByTestId('search-result-list')).toBeInTheDocument();
-      expect(container.getElementsByClassName('search-result-card').length).toBe(2);
+      expect(container.getElementsByClassName('search-result-card').length).toBe(3);
       expect(await findByTestId('search-order-dropdown')).toBeInTheDocument();
     });
   });
@@ -319,7 +324,7 @@ describe('SearchResultsView', () => {
         '/planning/test-master-class-1/test-class-1//?project=planning-project-1',
       );
 
-      const classCard = container.getElementsByClassName('search-result-card')[1];
+      const classCard = container.getElementsByClassName('search-result-card')[2];
       const classChildren = classCard.childNodes;
 
       // Title and class tag
@@ -358,6 +363,16 @@ describe('SearchResultsView', () => {
           ),
         ).toBeTruthy();
       });
+    });
+
+    it('navigates to the project form when clicking a result project that is not programmed: ', async () => {
+      const { container, user, findByTestId } = await render(searchActiveState);
+
+      const projectCard = container.getElementsByClassName('search-result-card')[1];
+
+      await user.click(projectCard);
+
+      expect(await findByTestId('project-basics-form')).toBeInTheDocument();
     });
   });
 

--- a/src/views/SearchResultsView/SearchResultsView.test.tsx
+++ b/src/views/SearchResultsView/SearchResultsView.test.tsx
@@ -20,6 +20,7 @@ import { mockGetResponseProvider } from '@/utils/mockGetResponseProvider';
 import mockPlanningViewProjects from '@/mocks/mockPlanningViewProjects';
 import { ProjectBasics } from '@/components/Project/ProjectBasics';
 import ProjectView from '../ProjectView';
+import { mockProjectPhases } from '@/mocks/mockLists';
 
 jest.mock('axios');
 jest.mock('react-i18next', () => mockI18next());
@@ -74,6 +75,10 @@ const searchActiveState = {
     ...store.getState().hashTags,
     hashTags: mockHashTags.data.hashTags,
     popularHashTags: mockHashTags.data.popularHashTags,
+  },
+  lists: {
+    ...store.getState().lists,
+    phases: mockProjectPhases.data,
   },
 };
 
@@ -372,7 +377,7 @@ describe('SearchResultsView', () => {
 
       await user.click(projectCard);
 
-      expect(await findByTestId('project-basics-form')).toBeInTheDocument();
+      expect(await findByTestId('project-form')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
- Added a tag for projects that are not programmed
- Navigate not programmed projects to project form instead of planning view 
- **Needs to be merged with the backend fix: https://github.com/City-of-Helsinki/infraohjelmointi-api/tree/fix/search-results-projects-response**