### PR TITLE
Story/io 303/date picker fix

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectFormBanner.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectFormBanner.tsx
@@ -2,8 +2,9 @@ import { Button } from 'hds-react';
 import { BaseSyntheticEvent, FC, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 interface IProjectFormbannerProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onSubmit: () => (e?: BaseSyntheticEvent<object, any, any> | undefined) => Promise<void>;
+  onSubmit: () =>
+    | ((e?: BaseSyntheticEvent<object, unknown, unknown> | undefined) => Promise<void>)
+    | undefined;
   isDirty: boolean;
 }
 const ProjectFormBanner: FC<IProjectFormbannerProps> = ({ onSubmit, isDirty }) => {

--- a/src/components/shared/DateField.tsx
+++ b/src/components/shared/DateField.tsx
@@ -21,20 +21,20 @@ const DateField: FC<IDateFieldProps> = ({ name, label, control, rules, readOnly 
       name={name}
       rules={rules}
       control={control as Control<FieldValues>}
-      render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => {
+      render={({ field: { onChange, value }, fieldState: { error } }) => {
         return (
           <div className="input-wrapper date-field-wrapper" id={name} data-testid={name}>
             <HDSDateInput
-              className="input-l"
+              className="input-l date-input"
               onChange={onChange}
               value={value}
-              onBlur={onBlur}
               placeholder={''}
               label={t(label)}
               language="fi"
               id={label}
               readOnly={readOnly}
               required={required}
+              initialMonth={new Date()}
               invalid={error ? true : false}
               errorText={error?.message}
             />


### PR DESCRIPTION
**Needs to be merged after the project form field validations PR: https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/57**

- fixes the date picker going back to the previous selection and year by disabling the onBlur event for ProjectForm while the date picker is open