### PR TITLE
Story/io 373/enable negative values ta muutos

### DIFF
--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
@@ -53,9 +53,6 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
   useOnClickOutsideRef(editBudgetChangeInputRef, onEditBudgetChange, editBudgetChange);
 
   const onPatchBudgetChange = () => {
-    // DEBUG
-    console.log(value);
-
     // Don't send request including empty budgetChange info
     if (!value) {
       return;
@@ -73,9 +70,6 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
       },
     };
     patchCoordinationClass(request);
-    
-    // DEBUG
-    console.log(request);
   };
 
   const isEditBudgetChangeDisabled = useMemo(

--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
@@ -69,7 +69,7 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
 
   const isEditBudgetChangeDisabled = useMemo(
     () => !isUserCoordinator(user) || mode !== 'coordination' || forcedToFrame || editBudgetChange,
-    [forcedToFrame, mode, user],
+    [forcedToFrame, mode, user, editBudgetChange],
   );
 
   return (

--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
@@ -53,6 +53,14 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
   useOnClickOutsideRef(editBudgetChangeInputRef, onEditBudgetChange, editBudgetChange);
 
   const onPatchBudgetChange = () => {
+    // DEBUG
+    console.log(value);
+
+    // Don't send request including empty budgetChange info
+    if (!value) {
+      return;
+    }
+
     const request: IClassPatchRequest = {
       id,
       data: {
@@ -65,6 +73,9 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
       },
     };
     patchCoordinationClass(request);
+    
+    // DEBUG
+    console.log(request);
   };
 
   const isEditBudgetChangeDisabled = useMemo(

--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
@@ -72,6 +72,14 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
     patchCoordinationClass(request);
   };
 
+  const checkValue = () => {
+    const inputElement = document.getElementsByClassName("budget-change-input");
+    if(!value && editBudgetChange){
+      const val = budgetChange ?? "";
+      inputElement[0].setAttribute("value", val.replace("−", "-"));
+    }
+  }
+
   const isEditBudgetChangeDisabled = useMemo(
     () => !isUserCoordinator(user) || mode !== 'coordination' || forcedToFrame || editBudgetChange,
     [forcedToFrame, mode, user, editBudgetChange],
@@ -108,7 +116,7 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
           </div>
         )}
         {editBudgetChange && (
-          <input
+          <input autoFocus
             id="edit-budget-change-input"
             className="budget-change-input"
             type="number"
@@ -116,6 +124,7 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
             ref={editBudgetChangeInputRef}
             value={value}
             onChange={onChange}
+            onFocus={checkValue}
           />
         )}
       </button>

--- a/src/hooks/useNumberInput.ts
+++ b/src/hooks/useNumberInput.ts
@@ -3,17 +3,11 @@ import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 const useNumberInput = (v?: string) => {
   const value = v ? v?.replace("−", "-") : '0';
   
-  // DEBUG
-  console.log("V " + typeof v + " " + value);
-
   const [inputValue, setInputValue] = useState<string | number | undefined>(
     parseInt(value.replace(/\s/g, '')),
   );
   
   const parsedValue = useMemo(() => inputValue?.toString(), [inputValue]);
-  
-  // DEBUG
-  console.log("i p", inputValue, parsedValue)
 
   const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
       setInputValue(e.target.value);

--- a/src/hooks/useNumberInput.ts
+++ b/src/hooks/useNumberInput.ts
@@ -1,22 +1,22 @@
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
-const useNumberInput = (value?: string) => {
+const useNumberInput = (v?: string) => {
+  const value = v ? v?.replace("−", "-") : '0';
+  
+  // DEBUG
+  console.log("V " + typeof v + " " + value);
+
   const [inputValue, setInputValue] = useState<string | number | undefined>(
-    value ? parseInt(value.replace(/\s/g, '')) : '0',
+    parseInt(value.replace(/\s/g, '')),
   );
-
+  
   const parsedValue = useMemo(() => inputValue?.toString(), [inputValue]);
+  
+  // DEBUG
+  console.log("i p", inputValue, parsedValue)
 
-  // Removes the zero value on change if there is only one zero in the value
   const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    // If the value is more than one zero set the form value normally
-    if (/^0{2,}/.exec(e.target.value)) {
       setInputValue(e.target.value);
-    }
-    // If value is just a zero replace it
-    else {
-      setInputValue(e.target.value ? e.target.value : 0);
-    }
   }, []);
 
   // Update frame budget when a new value is emitted

--- a/src/hooks/useNumberInput.ts
+++ b/src/hooks/useNumberInput.ts
@@ -15,7 +15,7 @@ const useNumberInput = (value?: string) => {
     }
     // If value is just a zero replace it
     else {
-      setInputValue(e.target.value ? +e.target.value : 0);
+      setInputValue(e.target.value ? e.target.value : 0);
     }
   }, []);
 


### PR DESCRIPTION
With this, users can

- add negative numbers
- send value updating request only when the input field includes a value when closing
- remove text from input field (before it did not allow users to remove, replaced empty input field with "0"

Issue:
- when clicking the button (number) which opens the input field, it will be empty _if_ the field was left empty previously
  - um, huh? What do you mean? How to test this?
    1) Open a TA field
    2) Clear it and close the input field (by clicking on somewhere)
    3) Re-open the same input field
    4) Because it was left empty, it stays empty

  - What should happen?
    - When user clears the input field, closes it, and re-opens it, it should show the same value as the button text does.