### PR TITLE
Story/io 384/enable negative values ta muutos

### DIFF
--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningCell.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningCell.tsx
@@ -134,6 +134,7 @@ const PlanningCell: FC<IPlanningCellProps> = ({ type, id, cell }) => {
                 </span>
                 <span
                   data-testid={`frame-budget-${id}-${year}`}
+                  id={`frame-budget-${id}-${year}`}
                   className={isFrameBudgetOverlap ? 'text-engel' : 'text-white'}
                 >
                   {budgetOverlapAlertIcon}

--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
@@ -58,6 +58,18 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
       return;
     }
 
+    const frameBudgetElement = document.getElementById(`frame-budget-${id}-${year}`);
+    const frameBudget = parseInt(frameBudgetElement?.innerHTML||'0');
+    const parsedValue = parseInt(value || '0');
+
+    console.log("Frame budget:", frameBudget);
+    console.log("value:", parsedValue);
+
+    // We don't want the frame budget to be a negative value
+    if (frameBudget + parsedValue < 0) {
+      return;
+    }
+
     const request: IClassPatchRequest = {
       id,
       data: {
@@ -73,7 +85,7 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
   };
 
   const checkValue = () => {
-    if(!value && editBudgetChange){
+    if((!value && editBudgetChange) || budgetChange != value){
       setInputValue(budgetChange);
     }
   }


### PR DESCRIPTION
- Prevent frame budget from being a negative value
- Related ticket: [https://helsinkisolutionoffice.atlassian.net/browse/IO-384](https://helsinkisolutionoffice.atlassian.net/browse/IO-384)