### PR TITLE
IO 57: title changes related to year change

### DIFF
--- a/src/hooks/useSummaryRows.ts
+++ b/src/hooks/useSummaryRows.ts
@@ -21,16 +21,18 @@ interface IPlanningSummaryTableState {
 
 export const getPlanningRowTitle = (startYear: number) => {
   const currentYear = new Date().getFullYear();
-  if (startYear === currentYear) {
+  const diff = startYear - currentYear;
+
+  if (diff === 0) {
     return "kuluva TA";
   }
-  else if (startYear === currentYear + 1) {
+  else if (diff === 1) {
     return "TAE";
   }
-  else if (startYear < currentYear) {
-    return "TP";
+  else if (diff < 0) {
+    return "TA";
   }
-  else if (startYear <= (currentYear + 3)) {
+  else if (diff <= 3) {
     return "TSE";
   } else {
     return "alustava";

--- a/src/hooks/useSummaryRows.ts
+++ b/src/hooks/useSummaryRows.ts
@@ -19,17 +19,21 @@ interface IPlanningSummaryTableState {
   cells: Array<IPlanningCell>;
 }
 
-export const getPlanningRowTitle = (index: number) => {
-  switch (index) {
-    case 0:
-      return 'kuluva TA';
-    case 1:
-      return 'TAE';
-    case 2:
-    case 3:
-      return 'TSE';
-    default:
-      return 'alustava';
+export const getPlanningRowTitle = (startYear: number) => {
+  const currentYear = new Date().getFullYear();
+  if (startYear === currentYear) {
+    return "kuluva TA";
+  }
+  else if (startYear === currentYear + 1) {
+    return "TAE";
+  }
+  else if (startYear < currentYear) {
+    return "TP";
+  }
+  else if (startYear <= (currentYear + 3)) {
+    return "TSE";
+  } else {
+    return "alustava";
   }
 };
 
@@ -41,7 +45,7 @@ const buildPlanningSummaryHeadCells = (startYear: number) => {
   for (let i = 0; i < 11; i++) {
     cells.push({
       year: startYear + i,
-      title: getPlanningRowTitle(i),
+      title: getPlanningRowTitle(startYear + i),
       isCurrentYear: startYear + i === startYear,
     });
   }
@@ -85,6 +89,7 @@ const useSummaryRows = () => {
         ...current,
         heads: buildPlanningSummaryHeadCells(startYear),
       }));
+      console.log(planningSummaryRows);
     }
   }, [startYear]);
 

--- a/src/hooks/useSummaryRows.ts
+++ b/src/hooks/useSummaryRows.ts
@@ -89,7 +89,6 @@ const useSummaryRows = () => {
         ...current,
         heads: buildPlanningSummaryHeadCells(startYear),
       }));
-      console.log(planningSummaryRows);
     }
   }, [startYear]);
 

--- a/src/views/PlanningView/PlanningView.test.tsx
+++ b/src/views/PlanningView/PlanningView.test.tsx
@@ -370,7 +370,7 @@ describe('PlanningView', () => {
       expect(getByTestId('planning-summary-head-row')).toBeInTheDocument();
 
       for (let i = 0; i < 11; i++) {
-        const title = getPlanningRowTitle(i);
+        const title = getPlanningRowTitle(year + i);
         const headCell = getByTestId(`head-${year + i}`);
         expect(headCell).toHaveTextContent((year + i).toString());
         expect(headCell).toHaveTextContent(title);


### PR DESCRIPTION
- Modified getPlanningRowTitle function to return the title based on current year and not based on index (for example: previously "kuluva TA" title was always given to the selected year and now it's give to the actual current year)
- Titles should now change automatically when the year changes
- Ticket: [https://helsinkisolutionoffice.atlassian.net/browse/IO-57](https://helsinkisolutionoffice.atlassian.net/browse/IO-57)
- "TP" title was not added cause "tilinpäätös" functionality is not implemented yet