### PR TITLE
Fix: 404 error page after login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,6 +127,8 @@ const App: FC = () => {
                 <Route path="hashtags" element={<AdminHashtags />} />
               </Route>
               <Route path="/access-denied" element={<AccessDeniedView />} />
+              <Route path="/auth/helsinki/return"></Route>
+              <Route path="/"></Route>
               <Route path="*" element={<ErrorView />} />
             </Routes>
           )}

--- a/src/components/AuthGuard/AuthGuard.tsx
+++ b/src/components/AuthGuard/AuthGuard.tsx
@@ -79,6 +79,10 @@ const AuthGuard: FC = () => {
       return;
     }
 
+    if(pathname.includes('auth/helsinki/return')) {
+      return navigate('planning');
+    }
+
     // Redirect to previous url if a non admin tries to access the admin view
     if (pathname.includes('admin') && !isUserAdmin(user)) {
       return navigate(-1);


### PR DESCRIPTION
- user is now redirected to planning view after login instead of the 404 error page
- Ticket: [https://futurice.atlassian.net/browse/HKISD-7](https://futurice.atlassian.net/browse/HKISD-7)