### PR TITLE
Fix/project card responsible persons menus

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -49,7 +49,7 @@ import { getPlanningLocationsThunk } from './reducers/locationSlice';
 import { mockHashTags } from './mocks/mockHashTags';
 import { getHashTagsThunk, sortByHashtagName } from './reducers/hashTagsSlice';
 import { Route } from 'react-router';
-import { getListsThunk } from './reducers/listsSlice';
+import { getListsThunk, sortPersons } from './reducers/listsSlice';
 import { getPlanningGroupsThunk } from './reducers/groupSlice';
 import mockProject from './mocks/mockProject';
 import { mockUser } from './mocks/mockUsers';
@@ -89,7 +89,7 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(lists.categories).toStrictEqual(mockProjectCategories.data);
-      expect(lists.responsiblePersons).toStrictEqual(mockResponsiblePersons.data);
+      expect(lists.responsiblePersons).toStrictEqual(sortPersons(mockResponsiblePersons.data));
       expect(lists.phases).toStrictEqual(mockProjectPhases.data);
       expect(lists.areas).toStrictEqual(mockProjectAreas.data);
       expect(lists.types).toStrictEqual(mockProjectTypes.data);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,6 +127,8 @@ const App: FC = () => {
                 <Route path="hashtags" element={<AdminHashtags />} />
               </Route>
               <Route path="/access-denied" element={<AccessDeniedView />} />
+              <Route path="/auth/helsinki/return" element={<></>}></Route>
+              <Route path="/" element={<></>}></Route>
               <Route path="*" element={<ErrorView />} />
             </Routes>
           )}

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectResponsiblePersonsSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectResponsiblePersonsSection.tsx
@@ -121,7 +121,9 @@ const ProjectResponsiblePersonsSection: FC<IProjectResponsiblePersonsSectionProp
           <SelectField
             {...getFieldProps('personProgramming')}
             iconKey="person"
-            options={responsiblePersons}
+            // Options is empty for now because this is not implemented yet, and we
+            // don't get this list from ProjectWise
+            options={[]}
             shouldTranslate={false}
             disabled={isInputDisabled}
           />

--- a/src/mocks/mockLists.ts
+++ b/src/mocks/mockLists.ts
@@ -297,19 +297,19 @@ export const mockResponsibleZones: { data: Array<IListItem> } = {
 export const mockResponsiblePersons: { data: Array<IListItem> } = {
   data: [
     {
-      value: 'Matti Meikäläinen',
+      value: 'Meikäläinen Matti',
       id: 'd53239df-b105-4ef0-9b20-a6f5a0281f7b',
     },
     {
-      value: 'Matti Kimari',
+      value: 'Kimari Matti',
       id: '63e71910-07de-4ba3-814f-f54315432d97',
     },
     {
-      value: 'Matti Nn',
+      value: 'Nn Matti',
       id: 'c60f6c51-8ccd-4414-ad00-b10e3e624fed',
     },
     {
-      value: 'Matti Kaalikoski',
+      value: 'Kaalikoski Matti',
       id: '92521a1d-b1b4-41c6-be4b-11d526112d15',
     },
   ],

--- a/src/reducers/listsSlice.ts
+++ b/src/reducers/listsSlice.ts
@@ -47,13 +47,17 @@ const initialState: IListState = {
   error: null,
 };
 
+// Sorting the list of responsible persons by value which has the person name with lastname first
+const sortPersons = (persons: Array<IListItem>) =>
+  [...persons].sort((a, b) => a.value < b.value ? -1 : (a.value > b.value ? 1 : 0));
+
 const getResponsiblePersons = async () => {
   try {
     const persons = await getPersons();
-    return persons.map(({ firstName, lastName, id }) => ({
-      value: `${firstName} ${lastName}`,
+    return sortPersons(persons.map(({ firstName, lastName, id }) => ({
+      value: `${lastName} ${firstName}`,
       id,
-    }));
+    })));
   } catch (e) {
     console.log('Error getting responsible persons: ', e);
     return [];

--- a/src/reducers/listsSlice.ts
+++ b/src/reducers/listsSlice.ts
@@ -48,7 +48,7 @@ const initialState: IListState = {
 };
 
 // Sorting the list of responsible persons by value which has the person name with lastname first
-const sortPersons = (persons: Array<IListItem>) =>
+export const sortPersons = (persons: Array<IListItem>) =>
   [...persons].sort((a, b) => a.value < b.value ? -1 : (a.value > b.value ? 1 : 0));
 
 const getResponsiblePersons = async () => {


### PR DESCRIPTION
- Removed the list of persons that comes from PW from the person programming list, cause we want to implement that within the tool and not fetch it from PW
- Added sorting for names, so that they are now sorted by last name