### PR TITLE
functionality to move budgets when out of project schedule

### DIFF
--- a/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/projectCellUtils.ts
+++ b/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/projectCellUtils.ts
@@ -225,14 +225,14 @@ export const getRemoveRequestData = (cell: IProjectCell): IProjectRequest => {
       updateIfValueExists('estPlanningStart', addYear(planningStart));
       updateIfValueExists('estPlanningEnd', addYear(planningEnd));
       updateIfValueExists('estConstructionStart', addYear(constructionStart));
-      req.planningStartYear = (getYear(planningEnd) || 0) + 1;
+      req.planningStartYear = (getYear(planningEnd) ?? 0) + 1;
     };
 
     const updateEndOfTimeline = () => {
       updateIfValueExists('estConstructionStart', removeYear(constructionStart));
       updateIfValueExists('estConstructionEnd', removeYear(constructionEnd));
       updateIfValueExists('estPlanningEnd', removeYear(planningEnd));
-      req.constructionEndYear = (getYear(constructionEnd) || 0) - 1;
+      req.constructionEndYear = (getYear(constructionEnd) ?? 0) - 1;
     };
 
     const updateMiddleOfTimeline = () => {

--- a/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/projectCellUtils.ts
+++ b/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/projectCellUtils.ts
@@ -225,15 +225,20 @@ export const getRemoveRequestData = (cell: IProjectCell): IProjectRequest => {
       updateIfValueExists('estPlanningStart', addYear(planningStart));
       updateIfValueExists('estPlanningEnd', addYear(planningEnd));
       updateIfValueExists('estConstructionStart', addYear(constructionStart));
-      req.planningStartYear = getYear(planningEnd) + 1;
+      req.planningStartYear = (getYear(planningEnd) || 0) + 1;
     };
 
     const updateEndOfTimeline = () => {
       updateIfValueExists('estConstructionStart', removeYear(constructionStart));
       updateIfValueExists('estConstructionEnd', removeYear(constructionEnd));
       updateIfValueExists('estPlanningEnd', removeYear(planningEnd));
-      req.constructionEndYear = getYear(constructionEnd) - 1;
+      req.constructionEndYear = (getYear(constructionEnd) || 0) - 1;
     };
+
+    const updateMiddleOfTimeline = () => {
+      updateIfValueExists('estConstructionStart', addYear(constructionStart));
+      updateIfValueExists('estPlanningEnd', removeYear(planningEnd));
+    }
 
     if (isStartOfTimeline && isEndOfTimeline) {
       updateLastCell();
@@ -241,6 +246,8 @@ export const getRemoveRequestData = (cell: IProjectCell): IProjectRequest => {
       updateStartOfTimeline();
     } else if (isEndOfTimeline) {
       updateEndOfTimeline();
+    } else {
+      updateMiddleOfTimeline();
     }
   };
 

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -27,7 +27,6 @@ import './styles.css';
 import { canUserEditProjectFormField } from '@/utils/validation';
 import { selectUser } from '@/reducers/authSlice';
 import { getProjectSapCosts } from '@/reducers/sapCostSlice';
-import useProjectRow from '@/hooks/useProjectRow';
 import { getYear } from '@/utils/dates';
 
 const ProjectForm = () => {

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -156,10 +156,8 @@ const ProjectForm = () => {
       // If new construction end year is smaller that the previous one, budget from the years that are not within the schedule need to
       // be moved backwards to the new end year
       if (constructionEndYear && data.constructionEndYear < constructionEndYear) {
-        if (constructionEndYear && data.constructionEndYear < constructionEndYear) {
-          const updatedFinances = moveBudgetBackwards(finances, constructionEndYear, data.constructionEndYear);
-          data = {...data, "finances": updatedFinances};
-        }
+        const updatedFinances = moveBudgetBackwards(finances, constructionEndYear, data.constructionEndYear);
+        data = {...data, "finances": updatedFinances};
       }
     }
     return data;

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -65,6 +65,7 @@ const ProjectForm = () => {
     }
   }
 
+  // Function to move budget/budgets to the first year that's within the project schedule
   const moveBudgetForwards = (finances: IProjectFinances, previousStartYear: number, startYear: number) => {
     let financesCopy = finances
     const numberOfYears = startYear - previousStartYear;
@@ -82,6 +83,7 @@ const ProjectForm = () => {
     return financesCopy;
   }
 
+  // Function to move budget/budgets to the last year that's within the project schedule
   const moveBudgetBackwards = (finances: IProjectFinances, previousEndYear: number, endYear: number) => {
     let financesCopy = finances;
     const numberOfYears = previousEndYear - endYear;

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -127,7 +127,6 @@ const ProjectForm = () => {
       } else if (!yearIsOverlap) {
         updatedFinances = moveBudgetBackwards(finances, previousEndYear, endYear);
       }
-      finances = updatedFinances || finances;
     }
     return updatedFinances;
   }
@@ -148,7 +147,6 @@ const ProjectForm = () => {
           updatedFinances = moveBudgetForwards(finances, previousStartYear, startYear);
         }
 
-        finances = updatedFinances || finances;
       }
       return updatedFinances;
   }

--- a/src/hooks/useProjectRow.ts
+++ b/src/hooks/useProjectRow.ts
@@ -107,7 +107,7 @@ const getTimelineDates = (
       effectivePlanningStartYear &&
       effectiveConstructionEndYear !== getYear(estPlanningEnd)
     ) {
-      return createDateToStartOfYear((getYear(estPlanningEnd) || 0) + 1);
+      return createDateToStartOfYear((getYear(estPlanningEnd) ?? 0) + 1);
     }
 
     return createDateToStartOfYear(effectiveConstructionEndYear);

--- a/src/hooks/useProjectRow.ts
+++ b/src/hooks/useProjectRow.ts
@@ -107,7 +107,7 @@ const getTimelineDates = (
       effectivePlanningStartYear &&
       effectiveConstructionEndYear !== getYear(estPlanningEnd)
     ) {
-      return createDateToStartOfYear(getYear(estPlanningEnd) + 1);
+      return createDateToStartOfYear((getYear(estPlanningEnd) || 0) + 1);
     }
 
     return createDateToStartOfYear(effectiveConstructionEndYear);
@@ -163,7 +163,7 @@ const getMonthlyDataList = (year: number, timelineDates: ITimelineDates): Array<
 
     const isStartYear = getYear(start) === year;
     const isEndYear = getYear(end) === year;
-    const isLaterYear = getYear(end) > year && getYear(start) < year;
+    const isLaterYear = (getYear(end) || 0) > year && (getYear(start) || 0) < year;
 
     let percent = isLaterYear ? '100%' : '0%';
 

--- a/src/hooks/useProjectRow.ts
+++ b/src/hooks/useProjectRow.ts
@@ -47,8 +47,8 @@ const getTimelineDates = (
   const { planningStartYear, constructionEndYear } = project;
   const { estPlanningStart, estPlanningEnd, estConstructionStart, estConstructionEnd } = dates;
 
-  const effectiveConstructionEndYear = getYear(estConstructionEnd) || constructionEndYear;
-  const effectivePlanningStartYear = getYear(estPlanningStart) || planningStartYear;
+  const effectiveConstructionEndYear = getYear(estConstructionEnd) ?? constructionEndYear;
+  const effectivePlanningStartYear = getYear(estPlanningStart) ?? planningStartYear;
 
   const getPlanningStartDate = () => {
     if (estPlanningStart) {
@@ -163,7 +163,7 @@ const getMonthlyDataList = (year: number, timelineDates: ITimelineDates): Array<
 
     const isStartYear = getYear(start) === year;
     const isEndYear = getYear(end) === year;
-    const isLaterYear = (getYear(end) || 0) > year && (getYear(start) || 0) < year;
+    const isLaterYear = (getYear(end) ?? 0) > year && (getYear(start) ?? 0) < year;
 
     let percent = isLaterYear ? '100%' : '0%';
 

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -89,8 +89,8 @@ export const getFirstDate = (date: string | null | undefined) => {
   return date ? moment(momentFromHDSDate(date)).startOf('year').format('DD.MM.YYYY') : null;
 };
 
-export const getYear = (date?: string | null): number =>
-  date ? parseInt(momentFromHDSDate(date).format('YYYY')) : 0;
+export const getYear = (date?: string | null): number | null =>
+  date ? parseInt(momentFromHDSDate(date).format('YYYY')) : null;
 
 export const updateYear = (year: number | undefined, date?: string | null) => {
   if (date && year) {


### PR DESCRIPTION
- Added functionality to move budgets from finance years when they are left out of project schedule after modifying the schedule from a project card
- Fixed a bug when trying to delete an overlap year, that isn't the end or the start of the timeline, from the timeline

- Can be tested by modifying the project schedule from a project card and seeing that the budgets move accordingly in the timeline (planning or coordinator views)
- Try to also delete an overlap year from the timeline and check that the budget moved correctly and year was deleted.