### PR TITLE
Change name of the option in project card

### DIFF
--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -50,7 +50,7 @@
     "sports": "Liikunta",
     "omaStadi": "OmaStadi",
     "projectArea": "Projektialue",
-    "park": "Puisto tai taitorakenne",
+    "park": "Puisto",
     "honkasuo": "Honkasuo",
     "kalasatama": "Kalasatama",
     "kruunuvuori": "Kruunuvuori",


### PR DESCRIPTION
Option in project card was before "Puisto tai taitorakenne" and this was fixed to be only "Puisto". 
[HKISD-17](https://futurice.atlassian.net/browse/HKISD-17)