### PR TITLE
HKISD-26 / HKISD-12: Add check for the table level

### DIFF
--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningRow.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningRow.tsx
@@ -186,7 +186,7 @@ const PlanningRow: FC<IPlanningRow & { sapCosts: Record<string, IProjectSapCost>
   the data can be found one level lower from the childrens' 'cells'. The problem with the data might happen because the districts
   that are on the subclass level, are marked as projectGroup now and they probably should be projectClass instead. TODO: investigate
   the possible problem with projectGroup/projectClass */
-  const cellDataWithFrameBudget = children && children[0] ? children[0].cells : undefined;
+  const cellDataWithFrameBudget = children[0]?.cells;
   const cellData = props.name.includes("suurpiiri") && cellDataWithFrameBudget && !search.includes("subClass") ? cellDataWithFrameBudget : cells;
   
   return (

--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningRow.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningRow.tsx
@@ -182,12 +182,13 @@ const PlanningRow: FC<IPlanningRow & { sapCosts: Record<string, IProjectSapCost>
       });
     }
   }, [searchedProjectId]);
-
-/*  districts' (suurpiiri) framebudget is not available on a subClass level in 'cells' even though it probably should, however 
-    the data can be found one level lower from the childrens' 'cells'. The problem with the data might happen because the districts
-    that are on the subclass level, are marked as projectGroup now and they probably should be projectClass instead. TODO: investigate
-    the possible problem with projectGroup/projectClass */
-const cellData = props.name.includes("suurpiiri") && children && children[0] ? children[0].cells : cells;
+/* districts' (suurpiiri) framebudget is not available on a subClass level in 'cells' even though it probably should, however 
+  the data can be found one level lower from the childrens' 'cells'. The problem with the data might happen because the districts
+  that are on the subclass level, are marked as projectGroup now and they probably should be projectClass instead. TODO: investigate
+  the possible problem with projectGroup/projectClass */
+  const cellDataWithFrameBudget = children && children[0] ? children[0].cells : undefined;
+  const cellData = props.name.includes("suurpiiri") && cellDataWithFrameBudget && !search.includes("subClass") ? cellDataWithFrameBudget : cells;
+  
   return (
     <>
       <tr className={props.type} data-testid={`row-${props.id}`}>


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-26

I added this `!search.includes("subClass")` condition for the check so that all the numbers in the Eteläinen suurpiiri row (and  in other equivalent rows) are again visible on the subClass level. We will need to investigate this issue more as the framebudget is not available on the subClass level in the frontend as it's available on the higher level.
<img width="1200" alt="image" src="https://github.com/City-of-Helsinki/infraohjelmointi-ui/assets/59826954/26f540ee-a0b2-48d9-adf6-9be0a84db44f">
