### PR TITLE
Fix/modify district choice

### DIFF
--- a/src/components/Planning/GroupDialog/GroupDialog.tsx
+++ b/src/components/Planning/GroupDialog/GroupDialog.tsx
@@ -112,7 +112,7 @@ const DialogContainer: FC<IDialogProps> = memo(
           masterClass: form.masterClass.value,
           class: form.class.value,
           subClass: form.subClass.value,
-          ...(form.district.value && !form.division.value && { 
+          ...(form.district.value && !form.division.value && {
             district: getLocationRelationId(form, hierarchyDistricts, hierarchyDivisions)
           }),
         };
@@ -195,8 +195,8 @@ const DialogContainer: FC<IDialogProps> = memo(
     const districtValidation = useCallback(
       (d: IOption, subClass: string) =>
         ((["suurpiiri", "östersundom"].some(subClassSubstring => subClass.includes(subClassSubstring))) && !subClass.includes(d.label))
-        ? t('validation.incorrectLocation', { field: 'suurpiiri' }) || '' 
-        : true,
+          ? t('validation.incorrectLocation', { field: 'suurpiiri' }) || ''
+          : true,
       [t],
     );
 
@@ -294,6 +294,7 @@ const DialogContainer: FC<IDialogProps> = memo(
                           <SelectField
                             {...formProps('district')}
                             rules={{
+                              required: (["suurpiiri", "östersundom"].some(subClassSubstring => subClassField.label.includes(subClassSubstring))) ? t('validation.required', { value: 'Suurpiiri' }) || '' : '',
                               validate: {
                                 isValidDistrict: (d: IOption) => districtValidation(d, subClassField.label),
                               },
@@ -315,10 +316,10 @@ const DialogContainer: FC<IDialogProps> = memo(
                       {/* Divider to click */}
                       <div className="advance-fields-button">
                         <button onClick={toggleAdvanceFields}>
-                          { !showAdvanceFields ? 
-                          (t(`groupForm.openAdvanceFilters`)
-                          ) : (
-                          (t(`groupForm.closeAdvanceFilters`))) }
+                          {!showAdvanceFields ?
+                            (t(`groupForm.openAdvanceFilters`)
+                            ) : (
+                              (t(`groupForm.closeAdvanceFilters`)))}
                         </button>
                         {advanceFieldIcons}
                       </div>

--- a/src/components/Planning/GroupDialog/GroupDialog.tsx
+++ b/src/components/Planning/GroupDialog/GroupDialog.tsx
@@ -90,7 +90,8 @@ const DialogContainer: FC<IDialogProps> = memo(
       return (
         !nameField ||
         !masterClassField.value ||
-        !classField.value
+        !classField.value || 
+        (["suurpiiri", "östersundom"].some(subClassSubstring => subClassField.label.includes(subClassSubstring)) && !districtField.value)
       );
     }, [
       districtField.value,
@@ -294,7 +295,7 @@ const DialogContainer: FC<IDialogProps> = memo(
                           <SelectField
                             {...formProps('district')}
                             rules={{
-                              required: (["suurpiiri", "östersundom"].some(subClassSubstring => subClassField.label.includes(subClassSubstring))) ? t('validation.required', { value: 'Suurpiiri' }) || '' : '',
+                              required: (["suurpiiri", "östersundom"].some(subClassSubstring => subClassField.label.includes(subClassSubstring))) ? t('validation.required', { value: 'Suurpiiri' }) ?? '' : '',
                               validate: {
                                 isValidDistrict: (d: IOption) => districtValidation(d, subClassField.label),
                               },


### PR DESCRIPTION
### Description
When creating a new group, district ("suurpiiri") choice was not mandatory. But this caused problems if the subClass of the group was a district at the same time.   

This change will make district choice to be mandatory in cases where subClass of the group is a district. If subClass is something else, district choice is not mandatory. 

### Testing
Path where subClass is a district is: 803 Kadut ja liikenneväylät -> Uudisrakentaminen -> Eteläinen suurpiiri. When creating a group with this path, district choice is mandatory. 

