### PR TITLE
filter colletiveSubLevels before districts in coordinator view

### DIFF
--- a/src/hooks/useCoordinationRows.ts
+++ b/src/hooks/useCoordinationRows.ts
@@ -171,6 +171,13 @@ const buildCoordinatorTableRows = (
               ...subClassRow,
               children: [
                 ...getSortedGroupRows(filteredSubClass.id, 'subClass'),
+                // Districts that come after a subClass
+                ...getDistrictRowsForParent({
+                  type: 'districtPreview',
+                  expanded: !!selectedDistrict,
+                  parent: filteredSubClass,
+                  districts: districtsBeforeCollectiveSubLevel,
+                }),
                 ...filteredCollectiveSubLevels.map((filteredCollectiveSubLevel) => {
                   const collectiveSubLevelRow = getRow({
                     item: filteredCollectiveSubLevel,
@@ -228,13 +235,6 @@ const buildCoordinatorTableRows = (
                       }),
                     ],
                   };
-                }),
-                // Districts that come after a subClass
-                ...getDistrictRowsForParent({
-                  type: 'districtPreview',
-                  expanded: !!selectedDistrict,
-                  parent: filteredSubClass,
-                  districts: districtsBeforeCollectiveSubLevel,
                 }),
               ],
             };


### PR DESCRIPTION
- Meluesteet came before districts in coordinator view -> is now the other way around
- related to ticket [https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-24](https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-24)