### PR TITLE
don't update project form if another user edits different project

### DIFF
--- a/src/views/ProjectView/ProjectView.tsx
+++ b/src/views/ProjectView/ProjectView.tsx
@@ -42,7 +42,7 @@ const ProjectView = () => {
     }
 
     // Don't update the selectedProject if the user is viewing another project
-    if (selectedProject && project.id !== selectedProject.id) {
+    if (!selectedProject || project.id !== selectedProject.id) {
       return;
     }
 


### PR DESCRIPTION
- if user was creating a new project and another user saved updated project, a new project's form got updated project's information
- this feature is created to keep project form updated if two users are updating the same project at the same time, but in this case it was acting incorrectly
  - checks correctly if selected project is empty 