### PR TITLE
HKISD-46/project card calendar

### DIFF
--- a/src/components/shared/DateField.tsx
+++ b/src/components/shared/DateField.tsx
@@ -15,6 +15,8 @@ interface IDateFieldProps {
 const DateField: FC<IDateFieldProps> = ({ name, label, control, rules, readOnly }) => {
   const required = rules?.required ? true : false;
   const { t } = useTranslation();
+  const currentDate = new Date();
+  const datePlus10Years = new Date(currentDate.getFullYear() + 10, 11, 31);
 
   return (
     <Controller
@@ -37,6 +39,7 @@ const DateField: FC<IDateFieldProps> = ({ name, label, control, rules, readOnly 
               initialMonth={new Date()}
               invalid={error ? true : false}
               errorText={error?.message}
+              maxDate={datePlus10Years}
             />
           </div>
         );


### PR DESCRIPTION
- https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-46
- changed caledars to show dates until the end of 10th year from now instead of just exactly 10 years from now
- calendar component is from hds and they default it to 10 years from now, so it's not possible to have it be limitless. We could set the end date to very far future, but I don't know if it's a better solution than this, since it still wouldn't be limitless