### PR TITLE
HKISD-34: fix hashtag saving in new projects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import Notification from '@/components/Notification';
 import Loader from '@/components/Loader';
 import { Search } from '@/components/Search';
 import { useAppDispatch, useAppSelector } from './hooks/common';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { getListsThunk } from './reducers/listsSlice';
 import {
   getCoordinationClassesThunk,
@@ -118,6 +118,15 @@ const App: FC = () => {
     }
   }, [startYear, user]);
 
+  const location = useLocation();
+  useEffect(() => {
+    /* When user creates a new project, hashtags are stored into local storage until the user saves the project. If
+      user exits the project form while creating a new project, this will empty the local storage values */
+    if (!location.pathname.includes('new')) {
+      localStorage.removeItem('hashtagsForNewProject');
+    }
+
+  },[location])
   return (
     <div>
       <Search />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import Notification from '@/components/Notification';
 import Loader from '@/components/Loader';
 import { Search } from '@/components/Search';
 import { useAppDispatch, useAppSelector } from './hooks/common';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { getListsThunk } from './reducers/listsSlice';
 import {
   getCoordinationClassesThunk,
@@ -118,15 +118,6 @@ const App: FC = () => {
     }
   }, [startYear, user]);
 
-  const location = useLocation();
-  useEffect(() => {
-    /* When user creates a new project, hashtags are stored into local storage until the user saves the project. If
-      user exits the project form while creating a new project, this will empty the local storage values */
-    if (!location.pathname.includes('new')) {
-      localStorage.removeItem('hashtagsForNewProject');
-    }
-
-  },[location])
   return (
     <div>
       <Search />

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -29,6 +29,7 @@ import { getYear } from '@/utils/dates';
 import { selectPlanningDistricts, selectPlanningDivisions, selectPlanningSubDivisions } from '@/reducers/locationSlice';
 import usePromptConfirmOnNavigate from '@/hooks/usePromptConfirmOnNavigate';
 import { t } from 'i18next';
+import { IListItem } from '@/interfaces/common';
 
 const ProjectForm = () => {
   const { formMethods, classOptions, locationOptions, selectedMasterClassName } = useProjectForm();
@@ -232,6 +233,13 @@ const ProjectForm = () => {
 
         // Post project
         if (projectMode === 'new') {
+            // when creating a new project, the hashtags that are to be saved are stored in the local storage
+            const hashTagsInLocalStorage = localStorage.getItem('hashTagsToBeSaved');
+            const hashTags: IListItem[] = hashTagsInLocalStorage && JSON.parse(hashTagsInLocalStorage);
+    
+            const hashtagIds = hashTags.map((hashtag) => hashtag.id);
+            data.hashTags = hashtagIds;
+          
           try {
             const response = await postProject({ data });
             dispatch(setSelectedProject(response));
@@ -313,35 +321,35 @@ const ProjectForm = () => {
   );
 
   return (
-      <form
-        data-testid="project-form"
-        className="project-form"
-      >
-        {/* SECTION 1 - BASIC INFO */}
-        <ProjectInfoSection {...formProps} project={project} isInputDisabled={isInputDisabled} />
-        {/* SECTION 2 - STATUS */}
-        <ProjectStatusSection {...formProps} isInputDisabled={isInputDisabled} />
-        {/* SECTION 3 - SCHEDULE */}
-        <ProjectScheduleSection {...formProps} />
-        {/* SECTION 4 - FINANCIALS */}
-        <ProjectFinancialSection
-          {...formProps}
-          classOptions={classOptions}
-          isInputDisabled={isInputDisabled}
-        />
-        {/* SECTION 5 - RESPONSIBLE PERSONS */}
-        <ProjectResponsiblePersonsSection {...formProps} isInputDisabled={isInputDisabled} />
-        {/* SECTION 6 - LOCATION */}
-        <ProjectLocationSection
-          {...formProps}
-          locationOptions={locationOptions}
-          isInputDisabled={isInputDisabled}
-        />
-        {/* SECTION 7 - PROJECT PROGRAM */}
-        <ProjectProgramSection {...formProps} />
-        {/* BANNER */}
-        <ProjectFormBanner onSubmit={submitCallback} isDirty={isDirty} />
-      </form>
+    <form
+      data-testid="project-form"
+      className="project-form"
+    >
+      {/* SECTION 1 - BASIC INFO */}
+      <ProjectInfoSection {...formProps} project={project} isInputDisabled={isInputDisabled} projectMode={projectMode} />
+      {/* SECTION 2 - STATUS */}
+      <ProjectStatusSection {...formProps} isInputDisabled={isInputDisabled} />
+      {/* SECTION 3 - SCHEDULE */}
+      <ProjectScheduleSection {...formProps} />
+      {/* SECTION 4 - FINANCIALS */}
+      <ProjectFinancialSection
+        {...formProps}
+        classOptions={classOptions}
+        isInputDisabled={isInputDisabled}
+      />
+      {/* SECTION 5 - RESPONSIBLE PERSONS */}
+      <ProjectResponsiblePersonsSection {...formProps} isInputDisabled={isInputDisabled} />
+      {/* SECTION 6 - LOCATION */}
+      <ProjectLocationSection
+        {...formProps}
+        locationOptions={locationOptions}
+        isInputDisabled={isInputDisabled}
+      />
+      {/* SECTION 7 - PROJECT PROGRAM */}
+      <ProjectProgramSection {...formProps} />
+      {/* BANNER */}
+      <ProjectFormBanner onSubmit={submitCallback} isDirty={isDirty} />
+    </form>
   );
 };
 

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -233,13 +233,6 @@ const ProjectForm = () => {
 
         // Post project
         if (projectMode === 'new') {
-            // when creating a new project, the hashtags that are to be saved are stored in the local storage
-            const hashTagsInLocalStorage = localStorage.getItem('hashtagsForNewProject');
-            const hashTags: IListItem[] = hashTagsInLocalStorage && JSON.parse(hashTagsInLocalStorage);
-    
-            const hashtagIds = hashTags ? hashTags.map((hashtag) => hashtag.id) : [];
-            data.hashTags = hashtagIds;
-          
           try {
             const response = await postProject({ data });
             dispatch(setSelectedProject(response));

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -234,7 +234,7 @@ const ProjectForm = () => {
         // Post project
         if (projectMode === 'new') {
             // when creating a new project, the hashtags that are to be saved are stored in the local storage
-            const hashTagsInLocalStorage = localStorage.getItem('hashTagsToBeSaved');
+            const hashTagsInLocalStorage = localStorage.getItem('hashtagsForNewProject');
             const hashTags: IListItem[] = hashTagsInLocalStorage && JSON.parse(hashTagsInLocalStorage);
     
             const hashtagIds = hashTags.map((hashtag) => hashtag.id);

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -29,7 +29,6 @@ import { getYear } from '@/utils/dates';
 import { selectPlanningDistricts, selectPlanningDivisions, selectPlanningSubDivisions } from '@/reducers/locationSlice';
 import usePromptConfirmOnNavigate from '@/hooks/usePromptConfirmOnNavigate';
 import { t } from 'i18next';
-import { IListItem } from '@/interfaces/common';
 
 const ProjectForm = () => {
   const { formMethods, classOptions, locationOptions, selectedMasterClassName } = useProjectForm();

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -237,7 +237,7 @@ const ProjectForm = () => {
             const hashTagsInLocalStorage = localStorage.getItem('hashtagsForNewProject');
             const hashTags: IListItem[] = hashTagsInLocalStorage && JSON.parse(hashTagsInLocalStorage);
     
-            const hashtagIds = hashTags.map((hashtag) => hashtag.id);
+            const hashtagIds = hashTags ? hashTags.map((hashtag) => hashtag.id) : [];
             data.hashTags = hashtagIds;
           
           try {

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/HashTagsContainer.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/HashTagsContainer.tsx
@@ -48,15 +48,9 @@ const HashTagsContainer: FC<IHashTagsProps> = ({ tags, onClick, onDelete, id }) 
     onDelete: onDelete ? handleOnDelete : undefined,
   };
 
-  if (!tags || tags.length === 0) {
-    return (
-      <div className="hashtags-container"></div>
-    )
-  }
-
   return (
     <div className="hashtags-container">
-      {tags.map((tag) => {
+      {tags && tags.map((tag) => {
         if (tag) {
           return (
             <div

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/HashTagsContainer.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/HashTagsContainer.tsx
@@ -50,23 +50,19 @@ const HashTagsContainer: FC<IHashTagsProps> = ({ tags, onClick, onDelete, id }) 
 
   return (
     <div className="hashtags-container">
-      {tags && tags.map((tag) => {
-        if (tag) {
-          return (
-            <div
-              key={tag.id}
-              className="hashtags-wrapper"
-              aria-label={getAriaLabel(tag.value, t, handleOnDelete, handleOnClick)}
-              data-testid={id}
-              id={tag.value}
-            >
-              <Tag {...handlers} id={tag.id}>
-                {tag.value}
-              </Tag>
-            </div>
-          );
-        }
-      })}
+      {tags && tags.map((tag) => 
+          <div
+            key={tag.id}
+            className="hashtags-wrapper"
+            aria-label={getAriaLabel(tag.value, t, handleOnDelete, handleOnClick)}
+            data-testid={id}
+            id={tag.value}
+          >
+            <Tag {...handlers} id={tag.id}>
+              {tag.value}
+            </Tag>
+          </div>
+      )}
     </div>
   );
 };

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/HashTagsContainer.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/HashTagsContainer.tsx
@@ -48,6 +48,12 @@ const HashTagsContainer: FC<IHashTagsProps> = ({ tags, onClick, onDelete, id }) 
     onDelete: onDelete ? handleOnDelete : undefined,
   };
 
+  if (!tags || tags.length === 0) {
+    return (
+      <div className="hashtags-container"></div>
+    )
+  }
+
   return (
     <div className="hashtags-container">
       {tags.map((tag) => {

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/ProjectHashTags.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/ProjectHashTags.tsx
@@ -61,14 +61,12 @@ const ProjectHashTagsDialog: FC<IProjectHashTagsDialogProps> = forwardRef(
     const { Header, Content, ActionButtons } = Dialog;
     const allHashTags = useAppSelector(selectHashTags);
     const { t } = useTranslation();
-
-    const initialHashtagsForNewProject = getHashtagsFromLocalStorage();
-
+    
     /* Here are the 'initial' values to be saved to a project. When user creates a new project and inserts hashtags 
       for the first time, those will be stored here. If the user goes back to change the hashtags when they are still 
       creating the project and they decide not to change those after all (after changing the values in the modal), 
       these values will be set to the local storage and not the 'unsaved' values */
-    const [savedHashtags] = useState(initialHashtagsForNewProject);
+    const initialHashtagsForNewProject = getHashtagsFromLocalStorage();
 
     const [formState, setFormState] = useState<IFormState>({
       hashTagsObject: {},
@@ -213,7 +211,7 @@ const ProjectHashTagsDialog: FC<IProjectHashTagsDialogProps> = forwardRef(
     const handleClose = useCallback(() => {
       if (projectMode === 'new') {
         // If dialog is closed (not saved) set the initial values (values before making changes to hashtags) back to the local storage
-        localStorage.setItem('hashtagsForNewProject', JSON.stringify(savedHashtags));
+        localStorage.setItem('hashtagsForNewProject', JSON.stringify(initialHashtagsForNewProject));
       }
       
       setFormState((current) => ({

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/ProjectHashTags.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/ProjectHashTags.tsx
@@ -42,7 +42,6 @@ interface IProjectHashTagsDialogProps {
   projectName?: string;
   projectMode: "edit" | "new";
   setHashTagsState: Dispatch<SetStateAction<IProjectHashTagsState>>;
-  state?: IProjectHashTagsState;
 }
 
 interface IFormState {
@@ -54,18 +53,12 @@ interface IFormState {
 
 const ProjectHashTagsDialog: FC<IProjectHashTagsDialogProps> = forwardRef(
   (
-    { label, projectHashTags, openDialog, onChange, toggleOpenDialog, projectId, projectName, projectMode, setHashTagsState, state },
+    { label, projectHashTags, openDialog, onChange, toggleOpenDialog, projectId, projectName, projectMode, setHashTagsState },
     ref: Ref<HTMLDivElement>,
   ) => {
     const { Header, Content, ActionButtons } = Dialog;
     const allHashTags = useAppSelector(selectHashTags);
     const { t } = useTranslation();
-
-    /* Here are the 'initial' values to be saved to a project. When user creates a new project and inserts hashtags 
-      for the first time, those will be stored here. If the user goes back to change the hashtags when they are still 
-      creating the project and they decide not to change those after all (after changing the values in the modal), 
-      these values will be set to the state and not the 'unsaved' values */
-    const initialHashtagsForNewProject = state?.projectHashTags ?? [];
 
     const [formState, setFormState] = useState<IFormState>({
       hashTagsObject: {},
@@ -192,14 +185,6 @@ const ProjectHashTagsDialog: FC<IProjectHashTagsDialogProps> = forwardRef(
     );
 
     const handleClose = useCallback(() => {
-      if (projectMode === 'new') {
-        // If dialog is closed without saving set the initial values (values before making changes to the hashtags) back to the state
-       setHashTagsState((current) => ({
-          ...current,
-          projectHashTags: initialHashtagsForNewProject
-        }));
-      }
-      
       setFormState((current) => ({
         ...current,
         hashTagsForSubmit: allHashTags.hashTags.filter(({ id }) =>
@@ -327,7 +312,6 @@ const ProjectHashTags: FC<IProjectHashTagsProps> = ({ name, label, control, proj
               projectName={projectName}
               projectMode={projectMode}
               setHashTagsState={setState}
-              state={state}
             />
           )}
         />

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
@@ -21,6 +21,7 @@ interface IProjectInfoSectionProps {
     control: Control<IProjectForm>;
   };
   isInputDisabled: boolean;
+  projectMode: "edit" | "new";
 }
 
 const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
@@ -107,6 +108,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
           label={'projectForm.hashTags'}
           control={control}
           project={project}
+          projectMode={projectMode}
         />
       </div>
     </div>

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
@@ -9,8 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { ProjectHashTags } from './ProjectHashTags';
 import { validateMaxLength, validateRequired } from '@/utils/validation';
 import { useAppSelector } from '@/hooks/common';
-import { selectIsProjectSaving } from '@/reducers/projectSlice';
-import { selectProjectMode } from '@/reducers/projectSlice';
+import { selectIsProjectSaving, selectProjectMode } from '@/reducers/projectSlice';
 
 interface IProjectInfoSectionProps {
   project: IProject | null;

--- a/src/hooks/usePromptConfirmOnNavigate.ts
+++ b/src/hooks/usePromptConfirmOnNavigate.ts
@@ -46,8 +46,6 @@ const usePromptConfirmOnNavigate = ({
         // Await for the isConfirmed to either return true or false, depending on the users input
         const confirm = await isConfirmed({ title, description });
         if (confirm !== false) {
-
-          
           push(...args);
         }
       };


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-34

When user was creating a new project, they weren't able to add hashtags for it because the hashtags were tried to be saved to a specific project right away but there were no project to which they could've been saved into.

I tried to save the hashtags to the same place where the unsaved values are stored but it was not possible (or at least not very easy) to do because of the structure of the code and I think that the hashtags were having some own state for them so they were not included to the other values of the form. I ended up creating a solution where the hashtags are temporarily stored into local storage when user is creating a project and when they want to save the project, the values are taken from the local storage. (I was also thinking if local storage should be changed to session storage or redux state, any opinions?)

I also noticed that the fix for the notes https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/141 caused a bug: if user tried to go to notes when editing a project, they got the modal that was asking if they want to continue but if the user tried to use some buttons e.g. in the side bar then the modal did not show up and they were just navigated to a new page. I added back this `usePromptConfirmOnNavigate.ts` file and deleted the new `ConfirmPrompt` files and the `getIsDirty` functions as they were not needed anymore.