### PR TITLE
HKISD-53: Add missing 'undefined' notification error title

### DIFF
--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -264,7 +264,8 @@
       "saveError": "Tallennus epäonnistui",
       "hashtagPostSuccess": "Tunniste tallennettu",
       "postError": "Luonti epäonnistui",
-      "accessDenied": "Pääsy evätty"
+      "accessDenied": "Pääsy evätty",
+      "undefined": "Virhe"
     },
     "message": {
       "formSaveSuccess": "Lomake tallennettu onnistuneesti.",


### PR DESCRIPTION
- e.status will return "undefined" if UI can't connect to API
  - show undefined as "Virhe"

Related: #146 
Ticket: https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-53