### PR TITLE
HKISD-48: Fix a calculating issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,8 +44,39 @@ import { selectStartYear, setIsPlanningLoading } from './reducers/planningSlice'
 import AccessDeniedView from './views/AccessDeniedView';
 import { isUserOnlyViewer } from './utils/userRoleHelpers';
 import MaintenanceView from './views/Maintenance';
+import { AppDispatch } from './store';
 
 const LOADING_APP_ID = 'loading-app-data';
+
+export const loadPlanningData = async (dispatch: AppDispatch, year: number) => {
+  dispatch(setIsPlanningLoading(true));
+  try {
+    await dispatch(getPlanningGroupsThunk(year));
+    await dispatch(getPlanningClassesThunk(year));
+    await dispatch(getPlanningLocationsThunk(year));
+  } catch (e) {
+    console.log('Error loading planning data: ', e);
+    dispatch(notifyError({ message: 'appDataError', type: 'notification', title: '500' }));
+  } finally {
+    dispatch(setIsPlanningLoading(false));
+  }
+};
+
+export const loadCoordinationData = async (dispatch: AppDispatch, year: number) => {
+  dispatch(setIsPlanningLoading(true));
+  try {
+    await dispatch(getCoordinationGroupsThunk(year));
+    await dispatch(getCoordinationClassesThunk(year));
+    await dispatch(getCoordinationLocationsThunk(year));
+    await dispatch(getForcedToFrameClassesThunk(year));
+    await dispatch(getForcedToFrameLocationsThunk(year));
+  } catch (e) {
+    console.log('Error loading coordination data: ', e);
+    dispatch(notifyError({ message: 'appDataError', type: 'notification', title: '500' }));
+  } finally {
+    dispatch(setIsPlanningLoading(false));
+  }
+}
 
 const App: FC = () => {
   const dispatch = useAppDispatch();
@@ -81,36 +112,6 @@ const App: FC = () => {
     }
   };
 
-  const loadPlanningData = async (year: number) => {
-    dispatch(setIsPlanningLoading(true));
-    try {
-      await dispatch(getPlanningGroupsThunk(year));
-      await dispatch(getPlanningClassesThunk(year));
-      await dispatch(getPlanningLocationsThunk(year));
-    } catch (e) {
-      console.log('Error loading planning data: ', e);
-      dispatch(notifyError({ message: 'appDataError', type: 'notification', title: '500' }));
-    } finally {
-      dispatch(setIsPlanningLoading(false));
-    }
-  };
-
-  const loadCoordinationData = async (year: number) => {
-    dispatch(setIsPlanningLoading(true));
-    try {
-      await dispatch(getCoordinationGroupsThunk(year));
-      await dispatch(getCoordinationClassesThunk(year));
-      await dispatch(getCoordinationLocationsThunk(year));
-      await dispatch(getForcedToFrameClassesThunk(year));
-      await dispatch(getForcedToFrameLocationsThunk(year));
-    } catch (e) {
-      console.log('Error loading coordination data: ', e);
-      dispatch(notifyError({ message: 'appDataError', type: 'notification', title: '500' }));
-    } finally {
-      dispatch(setIsPlanningLoading(false));
-    }
-  }
-
   // Initialize states that are used everywhere in the app
   useEffect(() => {
     initializeStates().catch(Promise.reject);
@@ -124,10 +125,10 @@ const App: FC = () => {
     }
 
     if (startYear) {
-      loadPlanningData(startYear);
+      loadPlanningData(dispatch, startYear);
       // viewers can access only planning view & planning data, so coordination data is not fetched if user has viewer role only
       if (!isUserOnlyViewer(user)) {
-        loadCoordinationData(startYear);
+        loadCoordinationData(dispatch, startYear);
       }
       dispatch(getSapCostsThunk(startYear));
     }

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectFormBanner.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectFormBanner.tsx
@@ -1,23 +1,61 @@
 import { Button, IconTrash } from 'hds-react';
-import { useAppSelector } from '@/hooks/common';
+import { useAppDispatch, useAppSelector } from '@/hooks/common';
 import { BaseSyntheticEvent, FC, memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { selectProject } from '@/reducers/projectSlice';
 import useConfirmDialog from '@/hooks/useConfirmDialog';
 import { deleteProject } from '@/services/projectServices';
 import { useNavigate } from 'react-router';
+import { getPlanningClassesThunk, getCoordinationClassesThunk, getForcedToFrameClassesThunk } from '@/reducers/classSlice';
+import { getPlanningGroupsThunk, getCoordinationGroupsThunk } from '@/reducers/groupSlice';
+import { getPlanningLocationsThunk, getCoordinationLocationsThunk, getForcedToFrameLocationsThunk } from '@/reducers/locationSlice';
+import { notifyError } from '@/reducers/notificationSlice';
+import { selectStartYear, setIsPlanningLoading } from '@/reducers/planningSlice';
 interface IProjectFormbannerProps {
   onSubmit: () =>
     | ((e?: BaseSyntheticEvent<object, unknown, unknown> | undefined) => Promise<void>)
     | undefined;
   isDirty: boolean;
 }
+
 const ProjectFormBanner: FC<IProjectFormbannerProps> = ({ onSubmit, isDirty }) => {
+  const dispatch = useAppDispatch();
+  const startYear = useAppSelector(selectStartYear);
   const { t } = useTranslation();
   const project = useAppSelector(selectProject);
   const navigate = useNavigate();
 
   const { isConfirmed } = useConfirmDialog();
+
+  const loadPlanningData = async (year: number) => {
+    dispatch(setIsPlanningLoading(true));
+    try {
+      await dispatch(getPlanningGroupsThunk(year));
+      await dispatch(getPlanningClassesThunk(year));
+      await dispatch(getPlanningLocationsThunk(year));
+    } catch (e) {
+      console.log('Error loading planning data: ', e);
+      dispatch(notifyError({ message: 'appDataError', type: 'notification', title: '500' }));
+    } finally {
+      dispatch(setIsPlanningLoading(false));
+    }
+  };
+
+  const loadCoordinationData = async (year: number) => {
+    dispatch(setIsPlanningLoading(true));
+    try {
+      await dispatch(getCoordinationGroupsThunk(year));
+      await dispatch(getCoordinationClassesThunk(year));
+      await dispatch(getCoordinationLocationsThunk(year));
+      await dispatch(getForcedToFrameClassesThunk(year));
+      await dispatch(getForcedToFrameLocationsThunk(year)); 
+    } catch (e) {
+      console.log('Error loading coordination data: ', e);
+      dispatch(notifyError({ message: 'appDataError', type: 'notification', title: '500' }));
+    } finally {
+      dispatch(setIsPlanningLoading(false));
+    }
+  }
 
   const handleProjectDelete = useCallback(async () => {
     const confirm = await isConfirmed({
@@ -30,6 +68,9 @@ const ProjectFormBanner: FC<IProjectFormbannerProps> = ({ onSubmit, isDirty }) =
     if (confirm !== false && project?.id) {
       try {
         await deleteProject(project.id);
+        loadCoordinationData(startYear);
+        loadPlanningData(startYear);
+        
         // navigate back to history or if no history, go to planning view
         if (window.history.state && window.history.state.idx > 0) {
           navigate(-1);


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-48

When user was deleting a project, the numbers were not updated because they were cached in the backend (PR for that: https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/117). In addition to removing caching we have to download the data again after user deletes the project because otherwise the data won't be updated.

I was also thinking if we should do something else than delete the cache for the summed finances but then again e.g. adjusting the length of the cache does not really solve this issue either as the data should be updated when the project is deleted, any opinions?