### PR TITLE
HKISD-23: fix construction phase detail validation

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -73,7 +73,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
           const planningRequirements = ['estPlanningEnd', 'estPlanningStart', 'personPlanning'];
           const generalConstructionRequirements = [ 'estConstructionStart', 'estConstructionEnd', 'personConstruction'];
           const combinedRequirements = [...programmedRequirements, ...planningRequirements, ...generalConstructionRequirements];
-          
+
           // Check fields that cannot be empty
           switch (phaseToSubmit) {
             case programmedPhase:
@@ -153,7 +153,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
           // Required after phase is changed to construction
           if (
             (phase.value === constructionPhase) &&
-            constructionPhaseDetail?.value === '' && constructionPhaseDetail.label === ''
+            constructionPhaseDetail?.value === ''
           ) {
             return t('validation.required', { field: t('validation.constructionPhaseDetail') });
           }

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -86,30 +86,24 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
               fields.push(...fieldsIfEmpty([...programmedRequirements, ...planningRequirements]));
               break;
             case constructionPhase:
+              fields.push(
+                ...fieldsIfEmpty([
+                ...combinedRequirements,
+                  'constructionPhaseDetail'
+                ]),
+              );
+              break;
             case warrantyPeriodPhase:
             case completedPhase:
-              if (
-                (phaseToSubmit === warrantyPeriodPhase || phaseToSubmit === completedPhase) &&
-                isBefore(getToday(), getValues('estConstructionEnd'))
-              ) {
+              if (isBefore(getToday(), getValues('estConstructionEnd'))) {
                 return t('validation.phaseTooEarly', { value: phase.label });
               }
 
-              if (phaseToSubmit !== warrantyPeriodPhase && phaseToSubmit !== completedPhase) {
-                fields.push(
-                  ...fieldsIfEmpty([
-                  ...combinedRequirements,
-                    'constructionPhaseDetail'
-                  ]),
-                );
-              } else {
-                fields.push(
-                  ...fieldsIfEmpty([
-                  ...combinedRequirements,
-                  ]),
-                );
-              }
-           
+              fields.push(
+                ...fieldsIfEmpty([
+                ...combinedRequirements,
+                ]),
+              );
               break;
           }
 

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -70,9 +70,10 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             'masterClass',
             'class',
           ];
-
           const planningRequirements = ['estPlanningEnd', 'estPlanningStart', 'personPlanning'];
-
+          const generalConstructionRequirements = [ 'estConstructionStart', 'estConstructionEnd', 'personConstruction'];
+          const combinedRequirements = [...programmedRequirements, ...planningRequirements, ...generalConstructionRequirements];
+          
           // Check fields that cannot be empty
           switch (phaseToSubmit) {
             case programmedPhase:
@@ -93,16 +94,22 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
               ) {
                 return t('validation.phaseTooEarly', { value: phase.label });
               }
-              fields.push(
-                ...fieldsIfEmpty([
-                  ...programmedRequirements,
-                  ...planningRequirements,
-                  'estConstructionStart',
-                  'estConstructionEnd',
-                  'personConstruction',
-                  'constructionPhaseDetail',
-                ]),
-              );
+
+              if (phaseToSubmit !== warrantyPeriodPhase && phaseToSubmit !== completedPhase) {
+                fields.push(
+                  ...fieldsIfEmpty([
+                  ...combinedRequirements,
+                    'constructionPhaseDetail'
+                  ]),
+                );
+              } else {
+                fields.push(
+                  ...fieldsIfEmpty([
+                  ...combinedRequirements,
+                  ]),
+                );
+              }
+           
               break;
           }
 
@@ -145,10 +152,8 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
           const phase = getValues('phase');
           // Required after phase is changed to construction
           if (
-            (phase.value === constructionPhase ||
-              phase.value === warrantyPeriodPhase ||
-              phase.value === completedPhase) &&
-            constructionPhaseDetail?.value === ''
+            (phase.value === constructionPhase) &&
+            constructionPhaseDetail?.value === '' && constructionPhaseDetail.label === ''
           ) {
             return t('validation.required', { field: t('validation.constructionPhaseDetail') });
           }
@@ -161,9 +166,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
 
   const isConstructionPhaseDetailsDisabled = useMemo(() => {
     return (
-      currentPhase !== constructionPhase &&
-      currentPhase !== warrantyPeriodPhase &&
-      currentPhase !== completedPhase
+      currentPhase !== constructionPhase
     );
   }, [currentPhase, constructionPhase, warrantyPeriodPhase, completedPhase]);
 


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-23

The construction phase detail (rakennusvaiheen tarkenne) was previously a required field in warranty phase (takuuaika) and completed phase (valmis / ylläpidossa). With these changes it's not anymore required in takuuaika and valmis / ylläpidossa fields.