### PR TITLE
HKISD-58: fix confirm modal visibility on project form

### DIFF
--- a/src/hooks/usePromptConfirmOnNavigate.ts
+++ b/src/hooks/usePromptConfirmOnNavigate.ts
@@ -5,6 +5,11 @@ import { useContext, useEffect } from 'react';
 import { UNSAFE_NavigationContext as NavigationContext } from 'react-router-dom';
 import useConfirmDialog from './useConfirmDialog';
 
+interface IArgs {
+  hash?: string;
+  pathname?: string;
+  search?: string;
+}
 const usePromptConfirmOnNavigate = ({
   title,
   description,
@@ -15,6 +20,10 @@ const usePromptConfirmOnNavigate = ({
   when: boolean;
 }) => {
   const { navigator } = useContext(NavigationContext);
+
+  // TODO: these could be gathered to some file with static data
+  const projectSideBarItems = ['#basics', '#status', '#schedule', '#financial', '#responsiblePersons', '#location', '#projectProgram'];
+ 
   const { isConfirmed } = useConfirmDialog();
 
   // Toggle a warning when trying to close the window if "when" is true
@@ -43,10 +52,16 @@ const usePromptConfirmOnNavigate = ({
 
     navigator.push = (...args: Parameters<typeof push>) => {
       const promptConfirmOnNavigate = async (args: Parameters<typeof push>) => {
-        // Await for the isConfirmed to either return true or false, depending on the users input
-        const confirm = await isConfirmed({ title, description });
-        if (confirm !== false) {
+        const argsProperties = args[0] as IArgs;
+        if (argsProperties && argsProperties.hash && projectSideBarItems.includes(argsProperties.hash)) {
+          // Do not await for the isConfirmed if user clicks some of the project form sidebar items because the "exit confirm" modal will be shown otherwise
           push(...args);
+        } else {
+          // Await for the isConfirmed to either return true or false, depending on the users input
+          const confirm = await isConfirmed({ title, description });
+          if (confirm !== false) {
+            push(...args);
+          }
         }
       };
 

--- a/src/hooks/usePromptConfirmOnNavigate.ts
+++ b/src/hooks/usePromptConfirmOnNavigate.ts
@@ -21,9 +21,6 @@ const usePromptConfirmOnNavigate = ({
 }) => {
   const { navigator } = useContext(NavigationContext);
 
-  // TODO: these could be gathered to some file with static data
-  const projectSideBarItems = ['#basics', '#status', '#schedule', '#financial', '#responsiblePersons', '#location', '#projectProgram'];
- 
   const { isConfirmed } = useConfirmDialog();
 
   // Toggle a warning when trying to close the window if "when" is true
@@ -53,7 +50,7 @@ const usePromptConfirmOnNavigate = ({
     navigator.push = (...args: Parameters<typeof push>) => {
       const promptConfirmOnNavigate = async (args: Parameters<typeof push>) => {
         const argsProperties = args[0] as IArgs;
-        if (argsProperties && argsProperties.hash && projectSideBarItems.includes(argsProperties.hash)) {
+        if (argsProperties && argsProperties.hash) {
           // Do not await for the isConfirmed if user clicks some of the project form sidebar items because the "exit confirm" modal will be shown otherwise
           push(...args);
         } else {


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-58

When user was on the project form and had edited some fields and then clicked some of these sidebar elements in order to move to a specific part of the form, the user was asked if the wanted to continue. I was able to get the value of the target url from args in usePromptConfirmOnNavigate that handles this confirmation modal but I'm not entirely sure if the args will always have the value in the future for example if we update the react-router package but I couldn't find the information form anywhere else either.

![image](https://github.com/City-of-Helsinki/infraohjelmointi-ui/assets/59826954/4746adca-a890-437e-a6aa-75b41efcc2a5)