### PR TITLE
HKISD-60: disappeared project

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -224,6 +224,18 @@ const ProjectForm = () => {
             data = updateFinances(data, project);
           }
 
+          /* If project belongs to some group and then its subclass is changed, the project will disappear as 
+             the group that it belongs to and the project exist under different subclasses */
+          if (data && data.projectClass && project.projectGroup) {
+              data = {...data, "projectGroup": null} 
+          }
+
+          /* If project is under a district and user changes the class, the district has to be removed or the
+             project will remain under that district in the new class, which isn't intended behavior */
+          if (data && data.projectClass && project.projectLocation) {
+            data = {...data, "projectLocation": null} 
+          }
+
           try {
             const response = await patchProject({ id: project?.id, data });
             if (response.status === 200) {

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -224,15 +224,15 @@ const ProjectForm = () => {
             data = updateFinances(data, project);
           }
 
-          /* If project belongs to some group and then its subclass is changed, the project will disappear as 
+          /* If project belongs to some group and then class is changed, the project will disappear as 
              the group that it belongs to and the project exist under different subclasses */
-          if (data && data.projectClass && project.projectGroup) {
+          if (data?.projectClass && project.projectGroup) {
               data = {...data, "projectGroup": null} 
           }
 
           /* If project is under a district and user changes the class, the district has to be removed or the
              project will remain under that district in the new class, which isn't intended behavior */
-          if (data && data.projectClass && project.projectLocation) {
+          if (data?.projectClass && project.projectLocation) {
             data = {...data, "projectLocation": null} 
           }
 

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -235,6 +235,10 @@ const ProjectForm = () => {
           if (data?.projectClass && project.projectLocation) {
             data = {...data, "projectLocation": null} 
           }
+          // The projectDistrict should also be deleted in order to not show it on the project form when class is changed
+          if (data?.projectClass && project.projectDistrict) {
+            data = {...data, "projectDistrict": null}
+          }
 
           try {
             const response = await patchProject({ id: project?.id, data });


### PR DESCRIPTION
https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-60

The project disappeared because it belonged to some group and when the user changed its class in the project form, the group that the project belonged to didn't exist in the new class --> we will have to delete the group information from the project.

I also noticed another problem: if the project was under some district and the user changed the class, the district had to be removed also or the project would exist under that district in that new class that it was saved into even though that class didn't have any districts inside of it. 

When you test these changes, you might need to refresh the page after updating the project values as the  project views don't necessarily get updated.