### PR TITLE
HKISD-54: Fix for not to render the district twice

### DIFF
--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningRow.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningRow.tsx
@@ -188,7 +188,13 @@ const PlanningRow: FC<IPlanningRow & { sapCosts: Record<string, IProjectSapCost>
   the possible problem with projectGroup/projectClass */
   const cellDataWithFrameBudget = children[0]?.cells;
   const cellData = props.name.includes("suurpiiri") && cellDataWithFrameBudget && !search.includes("subClass") ? cellDataWithFrameBudget : cells;
-  
+
+  /* Rows that type is districtPreview should only exist on a subClass level. If user chose a district as a subClass and then chose 
+     the same district as project's location a bit lower on the project form, the district were rendered twice in the planning view */
+  if (!search.includes('subClass') && props.name.includes('suurpiiri') && props.type === 'districtPreview') {
+    return <></>;
+  }
+
   return (
     <>
       <tr className={props.type} data-testid={`row-${props.id}`}>


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-54

I was able to reproduce this issue by

1. going to a project form
2. chose a district as a subclass at Hankkeen kustannustiedot
3. then a bit lower on the form at Hankkeen sijainti, chose the same district as project's location
4. went back to the planning view using the page's own functions.

For me it didn't render the district twice if I changed the subclass and location values more than once on the project form before saving!

The extra row's type was districtPreview and I think that it should only exist on a subClass level and the solution is based on that assumption. I could find districtPreview rows e.g. here where they are on a subClass level:
<img width="616" alt="image" src="https://github.com/City-of-Helsinki/infraohjelmointi-ui/assets/59826954/1728e522-0be0-40b7-8d14-b110b2795427">
