### PR TITLE
Remove projects fetch from reports for testing purposes in dev environment

### DIFF
--- a/src/components/Report/DownloadPdfButton.tsx
+++ b/src/components/Report/DownloadPdfButton.tsx
@@ -80,7 +80,7 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({ type, getForcedToFrame
       switch(type) {
         case 'budgetBookSummary': {
           const res = await getForcedToFrameData(year);
-          if (res && res.projects.length > 0) {
+          if (res /* && res.projects.length > 0 */) {
             const coordinatorRows = getCoordinationTableRows(res.classHierarchy, res.forcedToFrameDistricts.districts, res.initialSelections, res.projects, res.groupRes);
             document = getPdfDocument(type, divisions, forcedToFrameClasses, res.res.results, coordinatorRows);
           }
@@ -88,10 +88,10 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({ type, getForcedToFrame
         }
         case 'strategy': {
           const res = await getForcedToFrameData(year - 1);
-          if (res.projects.length > 0) {
+          //if (res.projects.length > 0) {
             const coordinatorRows = getCoordinationTableRows(res.classHierarchy, res.forcedToFrameDistricts.districts, res.initialSelections, res.projects, res.groupRes);
             document = getPdfDocument(type, divisions, forcedToFrameClasses, res.res.results, coordinatorRows);
-          }
+          //}
           break;
         }
         default: {

--- a/src/components/Report/ReportRow.tsx
+++ b/src/components/Report/ReportRow.tsx
@@ -12,7 +12,8 @@ import { IPlanningRowSelections } from '@/interfaces/planningInterfaces';
 import { getCoordinationClasses } from '@/services/classServices';
 import { getCoordinatorGroups } from '@/services/groupServices';
 import { getCoordinatorLocations } from '@/services/locationServices';
-import { getProjectsWithParams } from '@/services/projectServices';
+/* import { getProjectsWithParams } from '@/services/projectServices'; */
+import { IProjectsResponse } from '@/interfaces/projectInterfaces';
 
 interface IReportRowProps {
   type: ReportType;
@@ -27,13 +28,18 @@ const ReportRow: FC<IReportRowProps> = ({ type, divisions, classes, forcedToFram
 
   const getForcedToFrameData = async (year: number) => {
     // projects
-    const res = await getProjectsWithParams({
+    /* const res = await getProjectsWithParams({
       direct: false,
       programmed: false,
       forcedToFrame: true,
       year: year,
     }, true);
-    const projects = res.results;
+    const projects = res.results; */
+    const res: IProjectsResponse = {
+      results: [],
+      count: 0
+    }
+    const projects = res.results
 
     // classes
     const classRes = await getCoordinationClasses({


### PR DESCRIPTION
- Removes projects fetch from reports for testing purposes, will be reverted once we have tested the functionality
- only for dev environment