### PR TITLE
IO-338: added fixes

### DIFF
--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -193,16 +193,33 @@ const roundUpInTensOfThousands = (number: number) => {
   return Math.round(number / 10000) * 10000;
 }
 
+const checkDecimals = (number: number) => {
+  let numberToString = number.toString();
+
+  // Check if the number has decimals
+  if (number % 1 === 0) {
+    numberToString = numberToString + '.00';
+  }
+
+  const decimalPlaces = numberToString.split('.')[1];
+
+  // Make sure the number has two decimals
+  if (decimalPlaces.length == 1) {
+    return numberToString + '0';
+  } else {
+    return numberToString;
+  }
+}
 // Specifically for budgetBookSummaryReport
 export const convertToMillions = (value?: string | number) => {
   if (!value) return '0.00';
   const valueWithCorrectType: number = typeof value === 'string' ? Number(value.replace(/\s/g, '')): value;
   const rounded = roundUpInTensOfThousands(valueWithCorrectType);
   // convert to millions
-  const convertedNumber = rounded / 1000000;
-  // show the number with two decimals
-  const splitAtDecimal = convertedNumber === 0
-    ? '0'
-    : String(convertedNumber).split('.');
-  return splitAtDecimal === '0' ? '0.00' : `${splitAtDecimal[0]}.${splitAtDecimal[1].substring(0,2)}`;
+  let convertedNumber: number | string = rounded / 1000000;
+
+  // Check if the number has decimals and add them if it doesn't
+  convertedNumber = checkDecimals(convertedNumber);
+
+  return convertedNumber;
 };

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -203,34 +203,39 @@ export const getInvestmentPart = (forcedToFrameHierarchy: IBudgetBookSummaryTabl
 
 const getBudgetBookSummaryProperties = (coordinatorRows: IPlanningRow[]) => {
   const properties = [];
+  /* We want to show only those lower level items that start with some number or one letter and a space after that. 
+    This rule is meant for the lower level items but every item in the hierarchy in forced to frame view data should match this */
+  const nameCheckPattern = /^(\d+|\w)\s/;
   for (const c of coordinatorRows) {
     if (c.type === 'masterClass' || c.type === 'class' || c.type === 'subClass' || c.type === 'districtPreview' || c.type === 'collectiveSubLevel') {
-      const convertedClass: IBudgetBookSummaryTableRow = {
-        id: c.id,
-        name: c.name,
-        parent: null,
-        children: c.children.length && c.type !== 'districtPreview' && c.type !== 'collectiveSubLevel'  // children from the lower levels aren't needed
-          ? getBudgetBookSummaryProperties(c.children)
-          : [],
-        projects: [],
-        financeProperties: {
-          usage: '',
-          budgetEstimation: c.cells[0].frameBudget ?? '0.00',
-          budgetEstimationSuggestion: c.cells[1].frameBudget ?? '0.00',
-          budgetPlanSuggestion1: c.cells[2].frameBudget ?? '0.00',
-          budgetPlanSuggestion2: c.cells[3].frameBudget ?? '0.00',
-          initial1: c.cells[4].frameBudget ?? '0.00',
-          initial2: c.cells[5].frameBudget ?? '0.00',
-          initial3: c.cells[6].frameBudget ?? '0.00',
-          initial4: c.cells[7].frameBudget ?? '0.00',
-          initial5: c.cells[8].frameBudget ?? '0.00',
-          initial6: c.cells[9].frameBudget ?? '0.00',
-          initial7: c.cells[10].frameBudget ?? '0.00',
-        },
-        objectType: c.type,
-        type: 'class' as ReportTableRowType
+      if (nameCheckPattern.test(c.name)) {
+        const convertedClass: IBudgetBookSummaryTableRow = {
+          id: c.id,
+          name: c.name,
+          parent: null,
+          children: c.children.length && c.type !== 'districtPreview' && c.type !== 'collectiveSubLevel'  // children from the lower levels aren't needed
+            ? getBudgetBookSummaryProperties(c.children)
+            : [],
+          projects: [],
+          financeProperties: {
+            usage: '',
+            budgetEstimation: c.cells[0].frameBudget ?? '0.00',
+            budgetEstimationSuggestion: c.cells[1].frameBudget ?? '0.00',
+            budgetPlanSuggestion1: c.cells[2].frameBudget ?? '0.00',
+            budgetPlanSuggestion2: c.cells[3].frameBudget ?? '0.00',
+            initial1: c.cells[4].frameBudget ?? '0.00',
+            initial2: c.cells[5].frameBudget ?? '0.00',
+            initial3: c.cells[6].frameBudget ?? '0.00',
+            initial4: c.cells[7].frameBudget ?? '0.00',
+            initial5: c.cells[8].frameBudget ?? '0.00',
+            initial6: c.cells[9].frameBudget ?? '0.00',
+            initial7: c.cells[10].frameBudget ?? '0.00',
+          },
+          objectType: c.type,
+          type: 'class' as ReportTableRowType
+        }
+        properties.push(convertedClass);
       }
-      properties.push(convertedClass);
     }
   }
   return properties;


### PR DESCRIPTION
I fixed the substring issue with the calculations and added a check for the names of classes. We should not show items that name does not start with some number or a letter and a space on the lower levels. This check is done for every class now but I checked that in forced to frame view data, every class should start either with numbers or a letter and a space in the higher levels so the check can be done to those levels too.
