### PR TITLE
HKISD-86: description length

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
@@ -96,7 +96,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
           <TextAreaField
             {...getFieldProps('description')}
             size="l"
-            rules={validateRequired('description', t)}
+            rules={{...validateMaxLength(1000,t), ...validateRequired('description', t)}}
             formSaved={isSaving}
           />
         </div>


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-86
The maximum length of this field is 1000 characters, which hasn't been communicated anywhere. This rule will add a notification text when the user exceeds the maximum length. We should check the other fields too if there are similar restrictions that could be communicated by using the already existing rules.
<img width="300" alt="image" src="https://github.com/City-of-Helsinki/infraohjelmointi-ui/assets/59826954/8b6ccc5a-50b8-498e-bdc1-90927f638248">
