### PR TITLE
IO-334/fixes for construction report

### DIFF
--- a/src/components/Report/DownloadCsvButton.tsx
+++ b/src/components/Report/DownloadCsvButton.tsx
@@ -1,7 +1,7 @@
 import { Button, IconDownload } from 'hds-react';
 import { FC, memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IBudgetBookSummaryCsvRow, IConstructionProgramCsvRow, ReportType, getForcedToFrameDataType, Reports } from '@/interfaces/reportInterfaces';
+import { IBudgetBookSummaryCsvRow, IConstructionProgramCsvRow, ReportType, getForcedToFrameDataType, Reports, getPlanningDataType } from '@/interfaces/reportInterfaces';
 import { getReportData } from '@/utils/reportHelpers';
 import { CSVDownload } from 'react-csv';
 import './styles.css';
@@ -15,7 +15,7 @@ interface IDownloadCsvButtonProps {
   type: ReportType;
   categories: IListItem[],
   getForcedToFrameData: (year: number) => getForcedToFrameDataType;
-  getPlanningData: (year: number) => any;
+  getPlanningData: (year: number) => getPlanningDataType;
   }
 
 const downloadIcon = <IconDownload />;
@@ -63,7 +63,7 @@ const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({ type, categories, getF
               districts: res.planningDistricts.districts,
               otherClassifications: res.classHierarchy.otherClassifications,
               otherClassificationSubLevels: [],
-              divisions: res.planningDistricts.divisions,
+              divisions: res.planningDistricts.divisions ?? [],
               groups: res.groupRes
             }, res.projects, res.initialSelections, res.planningDistricts.subDivisions);
             setCsvData(await getReportData(t, Reports.ConstructionProgram, categories, planningRows));

--- a/src/components/Report/DownloadCsvButton.tsx
+++ b/src/components/Report/DownloadCsvButton.tsx
@@ -1,7 +1,7 @@
 import { Button, IconDownload } from 'hds-react';
 import { FC, memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IBudgetBookSummaryCsvRow, IConstructionProgramCsvRow, ReportType, getForcedToFrameDataType, Reports, getPlanningDataType, IPlanningData } from '@/interfaces/reportInterfaces';
+import { IBudgetBookSummaryCsvRow, IConstructionProgramCsvRow, ReportType, getForcedToFrameDataType, Reports, IPlanningData } from '@/interfaces/reportInterfaces';
 import { getReportData } from '@/utils/reportHelpers';
 import { CSVDownload } from 'react-csv';
 import './styles.css';
@@ -15,7 +15,7 @@ interface IDownloadCsvButtonProps {
   type: ReportType;
   categories: IListItem[];
   getForcedToFrameData: (year: number) => getForcedToFrameDataType;
-  getPlanningData: (year: number) => getPlanningDataType;
+  getPlanningData: (year: number) => Promise<IPlanningData>;
   getPlanningRows: (res: IPlanningData) => IPlanningRow[];
   }
 

--- a/src/components/Report/DownloadCsvButton.tsx
+++ b/src/components/Report/DownloadCsvButton.tsx
@@ -2,8 +2,6 @@ import { Button, IconDownload } from 'hds-react';
 import { FC, memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IBudgetBookSummaryCsvRow, IConstructionProgramCsvRow, ReportType, getForcedToFrameDataType, Reports } from '@/interfaces/reportInterfaces';
-import { IClassHierarchy, ICoordinatorClassHierarchy } from '@/reducers/classSlice';
-import { ILocation } from '@/interfaces/locationInterfaces';
 import { getReportData } from '@/utils/reportHelpers';
 import { CSVDownload } from 'react-csv';
 import './styles.css';
@@ -11,14 +9,13 @@ import { useAppDispatch } from '@/hooks/common';
 import { clearLoading, setLoading } from '@/reducers/loaderSlice';
 import { getCoordinationTableRows } from '@/hooks/useCoordinationRows';
 import { IListItem } from '@/interfaces/common';
+import { buildPlanningTableRows } from '@/hooks/usePlanningRows';
 
 interface IDownloadCsvButtonProps {
   type: ReportType;
-  categories: IListItem[];
+  categories: IListItem[],
   getForcedToFrameData: (year: number) => getForcedToFrameDataType;
-  divisions: Array<ILocation>;
-  classes: IClassHierarchy;
-  forcedToFrameClasses: ICoordinatorClassHierarchy;
+  getPlanningData: (year: number) => any;
   }
 
 const downloadIcon = <IconDownload />;
@@ -28,7 +25,7 @@ const downloadIcon = <IconDownload />;
  *
  * The styles are a bit funky since pdf-react doesn't support grid or table.
  */
-const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({ type, categories, getForcedToFrameData, divisions, classes, forcedToFrameClasses }) => {
+const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({ type, categories, getForcedToFrameData, getPlanningData }) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const [csvData, setCsvData] = useState<Array<IConstructionProgramCsvRow | IBudgetBookSummaryCsvRow>>([]);
@@ -41,32 +38,39 @@ const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({ type, categories, getF
     }
   }, [csvData]);
 
-  const getCsvData = useCallback(async (categories: IListItem[]) => {
+  const getCsvData = useCallback(async () => {
     try {
       dispatch(setLoading({ text: 'Loading csv data', id: LOADING_CSV_DATA }));
       switch (type) {
         case Reports.BudgetBookSummary:
-        case Reports.Strategy: {
+        case Reports.Strategy:
+        case Reports.OperationalEnvironmentAnalysis: {
           const res = await getForcedToFrameData(year);
           if (res && res.projects.length > 0) {
             const coordinatorRows = getCoordinationTableRows(res.classHierarchy, res.forcedToFrameDistricts.districts, res.initialSelections, res.projects, res.groupRes);
-            setCsvData(await getReportData(forcedToFrameClasses, divisions, t, type, categories, coordinatorRows));
+            setCsvData(await getReportData(t, type, categories, coordinatorRows));
           }
           break;
         }
-        case Reports.ConstructionProgram:
-          setCsvData(await getReportData(classes, divisions, t, Reports.ConstructionProgram, categories));
-          break;
-        case Reports.OperationalEnvironmentAnalysis: {
-          const res = await getForcedToFrameData(year);
-          
-          const coordinatorRows = getCoordinationTableRows(res.classHierarchy, res.forcedToFrameDistricts.districts, res.initialSelections, res.projects, res.groupRes);
-          setCsvData(await getReportData(forcedToFrameClasses, divisions, t, Reports.OperationalEnvironmentAnalysis, categories, coordinatorRows));
+        case Reports.ConstructionProgram: {
+          const res = await getPlanningData(year);
+          if (res && res.projects.length > 0) {
+            const planningRows = buildPlanningTableRows({
+              masterClasses: res.classHierarchy.masterClasses,
+              classes: res.classHierarchy.classes,
+              subClasses: res.classHierarchy.subClasses,
+              collectiveSubLevels: [],
+              districts: res.planningDistricts.districts,
+              otherClassifications: res.classHierarchy.otherClassifications,
+              otherClassificationSubLevels: [],
+              divisions: res.planningDistricts.divisions,
+              groups: res.groupRes
+            }, res.projects, res.initialSelections, res.planningDistricts.subDivisions);
+            setCsvData(await getReportData(t, Reports.ConstructionProgram, categories, planningRows));
+          }
           break;
         }
         default:
-          // In the MVP stage we only had time to implement the construction program report, the other
-          // report cases should come here
           break;
       }
     } catch (e) {
@@ -82,7 +86,7 @@ const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({ type, categories, getF
         <Button
           iconLeft={downloadIcon}
           variant="secondary"
-          onClick={() => getCsvData(categories)}
+          onClick={() => getCsvData()}
           disabled={(type === Reports.FinancialStatement)}
         >
           {t('downloadCsv', { name: t(`report.${type}.documentName`) })}

--- a/src/components/Report/DownloadPdfButton.tsx
+++ b/src/components/Report/DownloadPdfButton.tsx
@@ -1,7 +1,7 @@
 import { Button, IconDownload } from 'hds-react';
 import { FC, memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IPlanningData, ReportType, Reports, getForcedToFrameDataType, getPlanningDataType } from '@/interfaces/reportInterfaces';
+import { IPlanningData, ReportType, Reports, getForcedToFrameDataType  } from '@/interfaces/reportInterfaces';
 import { pdf } from '@react-pdf/renderer';
 import saveAs from 'file-saver';
 import { Page, Document } from '@react-pdf/renderer';
@@ -51,7 +51,7 @@ const downloadIcon = <IconDownload />;
 interface IDownloadPdfButtonProps {
   type: ReportType;
   getForcedToFrameData: (year: number) => getForcedToFrameDataType;
-  getPlanningData: (year: number) => getPlanningDataType;
+  getPlanningData: (year: number) => Promise<IPlanningData>;
   getPlanningRows: (res: IPlanningData) => IPlanningRow[];
   categories: IListItem[];
 }

--- a/src/components/Report/DownloadPdfButton.tsx
+++ b/src/components/Report/DownloadPdfButton.tsx
@@ -1,7 +1,7 @@
 import { Button, IconDownload } from 'hds-react';
 import { FC, memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ReportType, Reports, getForcedToFrameDataType } from '@/interfaces/reportInterfaces';
+import { ReportType, Reports, getForcedToFrameDataType, getPlanningDataType } from '@/interfaces/reportInterfaces';
 import { pdf } from '@react-pdf/renderer';
 import saveAs from 'file-saver';
 import { Page, Document } from '@react-pdf/renderer';
@@ -53,7 +53,7 @@ interface IDownloadPdfButtonProps {
   type: ReportType;
   categories: IListItem[];
   getForcedToFrameData: (year: number) => getForcedToFrameDataType;
-  getPlanningData: (year: number) => any;
+  getPlanningData: (year: number) => getPlanningDataType;
 }
 
 /**
@@ -95,7 +95,7 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({ type, getForcedToFrame
               districts: res.planningDistricts.districts,
               otherClassifications: res.classHierarchy.otherClassifications,
               otherClassificationSubLevels: [],
-              divisions: res.planningDistricts.divisions,
+              divisions: res.planningDistricts.divisions ?? [],
               groups: res.groupRes
             }, res.projects, res.initialSelections, res.planningDistricts.subDivisions);
             document = getPdfDocument(type, categories, planningRows);

--- a/src/components/Report/PdfReports/ReportTable.tsx
+++ b/src/components/Report/PdfReports/ReportTable.tsx
@@ -1,7 +1,7 @@
 import { FC, memo } from 'react';
 import { View, StyleSheet } from '@react-pdf/renderer';
 import ConstructionProgramTableHeader from './ConstructionProgramTableHeader';
-import { convertToReportRows, flattenBudgetBookSummaryTableRows, flattenStrategyTableRows, flattenOperationalEnvironmentAnalysisTableRows, getReportRows } from '@/utils/reportHelpers';
+import { convertToReportRows, flattenBudgetBookSummaryTableRows, flattenStrategyTableRows, flattenOperationalEnvironmentAnalysisTableRows } from '@/utils/reportHelpers';
 import TableRow from './TableRow';
 import { IBasicReportData, IBudgetBookSummaryTableRow, IOperationalEnvironmentAnalysisTableRow, ReportType, Reports } from '@/interfaces/reportInterfaces';
 import BudgetBookSummaryTableHeader from './BudgetBookSummaryTableHeader';
@@ -32,9 +32,7 @@ const ReportTable: FC<IConstructionProgramTableProps> = ({
   reportType,
   data
 }) => {
-  const reportRows = data.coordinatorRows
-    ? convertToReportRows(data.coordinatorRows, reportType, data.categories)
-    : getReportRows(reportType, data.classes, data.divisions, data.projects);
+  const reportRows = convertToReportRows(data.rows, reportType, data.categories);
 
   // We need to use one dimensional data for budgetBookSummary to style the report more easily
   const flattenedRows = (reportType === Reports.BudgetBookSummary || reportType === Reports.OperationalEnvironmentAnalysis) ? getFlattenedRows(reportRows as (IBudgetBookSummaryTableRow | IOperationalEnvironmentAnalysisTableRow)[], reportType) : [];

--- a/src/components/Report/PdfReports/ReportTable.tsx
+++ b/src/components/Report/PdfReports/ReportTable.tsx
@@ -1,9 +1,9 @@
 import { FC, memo } from 'react';
 import { View, StyleSheet } from '@react-pdf/renderer';
 import ConstructionProgramTableHeader from './ConstructionProgramTableHeader';
-import { convertToReportRows, flattenBudgetBookSummaryTableRows, flattenStrategyTableRows, flattenOperationalEnvironmentAnalysisTableRows } from '@/utils/reportHelpers';
+import { convertToReportRows, flattenBudgetBookSummaryTableRows, flattenStrategyTableRows, flattenOperationalEnvironmentAnalysisTableRows, flattenConstructionProgramTableRows } from '@/utils/reportHelpers';
 import TableRow from './TableRow';
-import { IBasicReportData, IBudgetBookSummaryTableRow, IOperationalEnvironmentAnalysisTableRow, ReportType, Reports } from '@/interfaces/reportInterfaces';
+import { IBasicReportData, IBudgetBookSummaryTableRow, IConstructionProgramTableRow, IOperationalEnvironmentAnalysisTableRow, ReportType, Reports } from '@/interfaces/reportInterfaces';
 import BudgetBookSummaryTableHeader from './BudgetBookSummaryTableHeader';
 import StrategyTableHeader from './StrategyTableHeader';
 import OperationalEnvironmentAnalysisTableHeader from './OperationalEnvironmentAnalysisTableHeader';
@@ -20,11 +20,13 @@ interface IConstructionProgramTableProps {
   data: IBasicReportData;
 }
 
-const getFlattenedRows = (reportRows: (IBudgetBookSummaryTableRow | IOperationalEnvironmentAnalysisTableRow)[], reportType: ReportType) => {
+const getFlattenedRows = (reportRows: (IBudgetBookSummaryTableRow | IOperationalEnvironmentAnalysisTableRow | IConstructionProgramTableRow)[], reportType: ReportType) => {
   if (reportType === Reports.BudgetBookSummary) {
     return flattenBudgetBookSummaryTableRows(reportRows as IBudgetBookSummaryTableRow[]);
-  } else {
+  } else if (reportType === Reports.OperationalEnvironmentAnalysis) {
     return flattenOperationalEnvironmentAnalysisTableRows(reportRows as IOperationalEnvironmentAnalysisTableRow[]);
+  } else {
+    return flattenConstructionProgramTableRows(reportRows);
   }
 }
 
@@ -35,7 +37,7 @@ const ReportTable: FC<IConstructionProgramTableProps> = ({
   const reportRows = convertToReportRows(data.rows, reportType, data.categories);
 
   // We need to use one dimensional data for budgetBookSummary to style the report more easily
-  const flattenedRows = (reportType === Reports.BudgetBookSummary || reportType === Reports.OperationalEnvironmentAnalysis) ? getFlattenedRows(reportRows as (IBudgetBookSummaryTableRow | IOperationalEnvironmentAnalysisTableRow)[], reportType) : [];
+  const flattenedRows = (reportType === Reports.BudgetBookSummary || reportType === Reports.OperationalEnvironmentAnalysis || reportType === Reports.ConstructionProgram) ? getFlattenedRows(reportRows as (IBudgetBookSummaryTableRow | IOperationalEnvironmentAnalysisTableRow | IConstructionProgramTableRow)[], reportType) : [];
   const strategyReportRows = reportType === Reports.Strategy ? flattenStrategyTableRows(reportRows) : [];
 
 
@@ -56,13 +58,7 @@ const ReportTable: FC<IConstructionProgramTableProps> = ({
     <View>
       <View style={styles.table}>
         <View fixed>{tableHeader}</View>
-        { reportType === Reports.BudgetBookSummary || reportType === Reports.Strategy || reportType === Reports.OperationalEnvironmentAnalysis?
-          <TableRow flattenedRows={reportType === Reports.BudgetBookSummary || reportType === Reports.OperationalEnvironmentAnalysis ? flattenedRows : strategyReportRows} depth={0} reportType={reportType}/>
-        :
-        reportRows?.map((r, i) => (
-          <TableRow key={r.id ?? i} row={r} index={i} depth={0} reportType={reportType}/>
-        ))
-        }
+        <TableRow flattenedRows={reportType === Reports.Strategy ? strategyReportRows : flattenedRows} reportType={reportType}/>
       </View>
     </View>
   );

--- a/src/components/Report/PdfReports/TableRow.tsx
+++ b/src/components/Report/PdfReports/TableRow.tsx
@@ -1,4 +1,4 @@
-import { IBudgetBookSummaryCsvRow, IConstructionProgramTableRow, IFlattenedBudgetBookSummaryProperties, IOperationalEnvironmentAnalysisCsvRow, IFlattenedOperationalEnvironmentAnalysisProperties, IStrategyTableRow, IOperationalEnvironmentAnalysisTableRow, ReportType, Reports } from '@/interfaces/reportInterfaces';
+import { IBudgetBookSummaryCsvRow, IConstructionProgramTableRow, IFlattenedBudgetBookSummaryProperties, IOperationalEnvironmentAnalysisCsvRow, IFlattenedOperationalEnvironmentAnalysisProperties, ReportType, Reports } from '@/interfaces/reportInterfaces';
 import { View, StyleSheet, Text } from '@react-pdf/renderer';
 import { FC, memo } from 'react';
 

--- a/src/components/Report/ReportRow.tsx
+++ b/src/components/Report/ReportRow.tsx
@@ -2,29 +2,24 @@ import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReportType } from '@/interfaces/reportInterfaces';
 import { IClassHierarchy, ICoordinatorClassHierarchy, separateClassesIntoHierarchy } from '@/reducers/classSlice';
-import { ILocation } from '@/interfaces/locationInterfaces';
 import DownloadPdfButton from './DownloadPdfButton';
 import DownloadCsvButton from './DownloadCsvButton';
 import './styles.css';
 import './pdfFonts';
 import { separateLocationsIntoHierarchy } from '@/reducers/locationSlice';
 import { IPlanningRowSelections } from '@/interfaces/planningInterfaces';
-import { getCoordinationClasses } from '@/services/classServices';
-import { getCoordinatorGroups } from '@/services/groupServices';
-import { getCoordinatorLocations } from '@/services/locationServices';
+import { getCoordinationClasses, getPlanningClasses } from '@/services/classServices';
+import { getCoordinatorGroups, getPlanningGroups } from '@/services/groupServices';
+import { getCoordinatorLocations, getPlanningLocations } from '@/services/locationServices';
 import { getProjectsWithParams } from '@/services/projectServices';
 import { useAppSelector } from '@/hooks/common';
 import { selectCategories } from '@/reducers/listsSlice';
 
 interface IReportRowProps {
   type: ReportType;
-  // We have to pass classes and locations as props to the react-pdf documents, since they are not wrapped in the redux context
-  divisions: Array<ILocation>;
-  classes: IClassHierarchy;
-  forcedToFrameClasses: ICoordinatorClassHierarchy;
 }
 
-const ReportRow: FC<IReportRowProps> = ({ type, divisions, classes, forcedToFrameClasses }) => {
+const ReportRow: FC<IReportRowProps> = ({ type }) => {
   const { t } = useTranslation();
   const categories = useAppSelector(selectCategories);
   const getForcedToFrameData = async (year: number) => {
@@ -67,6 +62,40 @@ const ReportRow: FC<IReportRowProps> = ({ type, divisions, classes, forcedToFram
     return { res, projects, classHierarchy, forcedToFrameDistricts, groupRes, initialSelections }
   }
 
+  const getPlanningData = async (year: number) => {
+    // projects
+    const res = await getProjectsWithParams({
+      direct: false,
+      programmed: false,
+      forcedToFrame: false,
+      year: year,
+    });
+    const projects = res.results;
+
+    // classes
+    const classRes = await getPlanningClasses(year);
+    const classHierarchy = separateClassesIntoHierarchy(classRes, false) as IClassHierarchy;
+
+    // districts
+    const locationRes = await getPlanningLocations(year);
+    const planningDistricts = separateLocationsIntoHierarchy(locationRes, false);
+
+    // groups
+    const groupRes = await getPlanningGroups(year);
+
+    // selections
+    const initialSelections: IPlanningRowSelections = {
+      selectedMasterClass: null,
+      selectedClass: null,
+      selectedSubClass: null,
+      selectedDistrict: null,
+      selectedCollectiveSubLevel: null,
+      selectedSubLevelDistrict: null,
+      selectedOtherClassification: null
+    }
+    return { res, projects, classHierarchy, planningDistricts, groupRes, initialSelections }
+  }
+
   return (
     <div className="report-row-container" data-testid={`report-row-${type}`}>
       {/* report title */}
@@ -74,9 +103,9 @@ const ReportRow: FC<IReportRowProps> = ({ type, divisions, classes, forcedToFram
         {t(`report.${type}.rowTitle`)}
       </h3>
       {/* download pdf button */}
-      <DownloadPdfButton type={type} categories={categories} getForcedToFrameData={getForcedToFrameData} divisions={divisions} classes={classes} forcedToFrameClasses={forcedToFrameClasses} />
+      <DownloadPdfButton type={type} categories={categories} getForcedToFrameData={getForcedToFrameData} getPlanningData={getPlanningData} />
       {/* download csv button */}
-      <DownloadCsvButton type={type} categories={categories} getForcedToFrameData={getForcedToFrameData} divisions={divisions} classes={classes} forcedToFrameClasses={forcedToFrameClasses} />
+      <DownloadCsvButton type={type} categories={categories} getForcedToFrameData={getForcedToFrameData} getPlanningData={getPlanningData} />
     </div>
   );
 };

--- a/src/components/Report/ReportRow.tsx
+++ b/src/components/Report/ReportRow.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ReportType } from '@/interfaces/reportInterfaces';
+import { IPlanningData, ReportType } from '@/interfaces/reportInterfaces';
 import { IClassHierarchy, ICoordinatorClassHierarchy, separateClassesIntoHierarchy } from '@/reducers/classSlice';
 import DownloadPdfButton from './DownloadPdfButton';
 import DownloadCsvButton from './DownloadCsvButton';
@@ -14,6 +14,7 @@ import { getCoordinatorLocations, getPlanningLocations } from '@/services/locati
 import { getProjectsWithParams } from '@/services/projectServices';
 import { useAppSelector } from '@/hooks/common';
 import { selectCategories } from '@/reducers/listsSlice';
+import { buildPlanningTableRows } from '@/hooks/usePlanningRows';
 
 interface IReportRowProps {
   type: ReportType;
@@ -96,6 +97,21 @@ const ReportRow: FC<IReportRowProps> = ({ type }) => {
     return { res, projects, classHierarchy, planningDistricts, groupRes, initialSelections }
   }
 
+  const getPlanningRows = (res: IPlanningData) => {
+    const planningRows = buildPlanningTableRows({
+      masterClasses: res.classHierarchy.masterClasses,
+      classes: res.classHierarchy.classes,
+      subClasses: res.classHierarchy.subClasses,
+      collectiveSubLevels: [],
+      districts: res.planningDistricts.districts,
+      otherClassifications: res.classHierarchy.otherClassifications,
+      otherClassificationSubLevels: [],
+      divisions: res.planningDistricts.divisions ?? [],
+      groups: res.groupRes
+    }, res.projects, res.initialSelections, res.planningDistricts.subDivisions);
+    return planningRows;
+  }
+
   return (
     <div className="report-row-container" data-testid={`report-row-${type}`}>
       {/* report title */}
@@ -103,9 +119,9 @@ const ReportRow: FC<IReportRowProps> = ({ type }) => {
         {t(`report.${type}.rowTitle`)}
       </h3>
       {/* download pdf button */}
-      <DownloadPdfButton type={type} categories={categories} getForcedToFrameData={getForcedToFrameData} getPlanningData={getPlanningData} />
+      <DownloadPdfButton type={type} categories={categories} getForcedToFrameData={getForcedToFrameData} getPlanningData={getPlanningData} getPlanningRows={getPlanningRows} />
       {/* download csv button */}
-      <DownloadCsvButton type={type} categories={categories} getForcedToFrameData={getForcedToFrameData} getPlanningData={getPlanningData} />
+      <DownloadCsvButton type={type} categories={categories} getForcedToFrameData={getForcedToFrameData} getPlanningData={getPlanningData} getPlanningRows={getPlanningRows}/>
     </div>
   );
 };

--- a/src/hooks/usePlanningRows.ts
+++ b/src/hooks/usePlanningRows.ts
@@ -57,7 +57,7 @@ const sortLocationsByName = (list: Array<ILocation>) =>
  * @param state the current state of the planningRows-hook
  * @returns a list of planning rows for the planning table
  */
-const buildPlanningTableRows = (
+export const buildPlanningTableRows = (
   list: IPlanningRowList,
   projects: Array<IProject>,
   selections: IPlanningRowSelections,

--- a/src/interfaces/planningInterfaces.ts
+++ b/src/interfaces/planningInterfaces.ts
@@ -2,6 +2,7 @@ import { IClass } from './classInterfaces';
 import { IGroup } from './groupInterfaces';
 import { ILocation } from './locationInterfaces';
 import { IProject } from './projectInterfaces';
+import { IBudgetBookFinanceProperties, IOperationalEnvironmentAnalysisFinanceProperties } from './reportInterfaces';
 
 // This types are used to create search params and style the rows differently
 export type PlanningRowType =
@@ -86,6 +87,11 @@ export interface IPlanningRow extends IPlanningSums {
   defaultExpanded: boolean;
   urlSearchParam: { [key: string]: string } | null;
   cells: Array<IPlanningCell>;
+  projects?: [];
+  parent?: string;
+  objectType?: string;
+  financeProperties?: IBudgetBookFinanceProperties;
+  frameBudgets?: IOperationalEnvironmentAnalysisFinanceProperties;
 }
 
 export type PlanningMode = 'planning' | 'coordination';

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -39,6 +39,27 @@ export type getPlanningDataType = Promise<{
     groupRes: IGroup[];
     initialSelections: IPlanningRowSelections}>;
 
+export type IPlanningData = {
+  res: IProjectsResponse;
+  projects: IProject[];
+  classHierarchy: IClassHierarchy;
+  planningDistricts: {
+    districts: ILocation[];
+    year: number;
+    allLocations?: undefined;
+    divisions?: undefined;
+    subDivisions?: undefined;
+  } | {
+    districts: ILocation[];
+    allLocations: ILocation[];
+    divisions: ILocation[];
+    subDivisions: ILocation[];
+    year: number;
+  };
+  groupRes: IGroup[];
+  initialSelections: IPlanningRowSelections;
+}
+
 export const reports = [
   'operationalEnvironmentAnalysis',
   'strategy',

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -19,26 +19,6 @@ export type getForcedToFrameDataType = Promise<{
     groupRes: IGroup[];
     initialSelections: IPlanningRowSelections}>;
 
-export type getPlanningDataType = Promise<{
-  res: IProjectsResponse;
-    projects: IProject[];
-    classHierarchy: IClassHierarchy;
-    planningDistricts: {
-      districts: ILocation[];
-      year: number;
-      allLocations?: ILocation[];
-      divisions?: ILocation[];
-      subDivisions?: ILocation[];
-  } | {
-      districts: ILocation[];
-      allLocations: ILocation[];
-      divisions: ILocation[];
-      subDivisions: ILocation[];
-      year: number;
-  };
-    groupRes: IGroup[];
-    initialSelections: IPlanningRowSelections}>;
-
 export type IPlanningData = {
   res: IProjectsResponse;
   projects: IProject[];
@@ -94,7 +74,7 @@ export enum Reports {
 
 export type ReportType = (typeof reports)[number];
 
-export type ReportTableRowType = 'class' | 'project' | 'investmentpart' | 'location' | 'crossingPressure' | 'taeTseFrame' | 'category';
+export type ReportTableRowType = 'class' | 'project' | 'investmentpart' | 'location' | 'crossingPressure' | 'taeTseFrame' | 'category' | 'group' | 'districtPreview';
 
 export interface IBasicReportData {
   categories: IListItem[];
@@ -147,6 +127,7 @@ export interface IBudgetBookFinanceProperties {
 export interface IFlattenedBudgetBookSummaryProperties extends IBudgetBookFinanceProperties {
   id: string;
   name: string;
+  type: string;
 }
 
 export interface IStrategyTableRow extends ITableRowEssentials {

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -56,11 +56,8 @@ export type ReportType = (typeof reports)[number];
 export type ReportTableRowType = 'class' | 'project' | 'investmentpart' | 'location' | 'crossingPressure' | 'taeTseFrame' | 'category';
 
 export interface IBasicReportData {
-  divisions: Array<ILocation>;
-  projects: Array<IProject>;
-  classes: IClassHierarchy;
-  categories?: IListItem[];
-  coordinatorRows?: IPlanningRow[];
+  categories: IListItem[];
+  rows: IPlanningRow[];
 }
 
 interface ITableRowEssentials {

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -26,9 +26,9 @@ export type getPlanningDataType = Promise<{
     planningDistricts: {
       districts: ILocation[];
       year: number;
-      allLocations?: undefined;
-      divisions?: undefined;
-      subDivisions?: undefined;
+      allLocations?: ILocation[];
+      divisions?: ILocation[];
+      subDivisions?: ILocation[];
   } | {
       districts: ILocation[];
       allLocations: ILocation[];
@@ -46,9 +46,9 @@ export type IPlanningData = {
   planningDistricts: {
     districts: ILocation[];
     year: number;
-    allLocations?: undefined;
-    divisions?: undefined;
-    subDivisions?: undefined;
+    allLocations?: ILocation[];
+    divisions?: ILocation[];
+    subDivisions?: ILocation[];
   } | {
     districts: ILocation[];
     allLocations: ILocation[];

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -19,6 +19,26 @@ export type getForcedToFrameDataType = Promise<{
     groupRes: IGroup[];
     initialSelections: IPlanningRowSelections}>;
 
+export type getPlanningDataType = Promise<{
+  res: IProjectsResponse;
+    projects: IProject[];
+    classHierarchy: IClassHierarchy;
+    planningDistricts: {
+      districts: ILocation[];
+      year: number;
+      allLocations?: undefined;
+      divisions?: undefined;
+      subDivisions?: undefined;
+  } | {
+      districts: ILocation[];
+      allLocations: ILocation[];
+      divisions: ILocation[];
+      subDivisions: ILocation[];
+      year: number;
+  };
+    groupRes: IGroup[];
+    initialSelections: IPlanningRowSelections}>;
+
 export const reports = [
   'operationalEnvironmentAnalysis',
   'strategy',

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -74,7 +74,7 @@ export enum Reports {
 
 export type ReportType = (typeof reports)[number];
 
-export type ReportTableRowType = 'class' | 'project' | 'investmentpart' | 'location' | 'crossingPressure' | 'taeTseFrame' | 'category' | 'group' | 'districtPreview';
+export type ReportTableRowType = 'class' | 'project' | 'investmentpart' | 'location' | 'crossingPressure' | 'taeTseFrame' | 'category' | 'group' | 'districtPreview' | 'changePressure' | 'taeFrame';
 
 export interface IBasicReportData {
   categories: IListItem[];

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -179,10 +179,10 @@ export const calculateProjectRowSums = (project: IProject): IProjectSums => {
 
 export const calcPercentage = (value: number, total: number) => Math.round((value / total) * 100);
 
-export const keurToMillion = (value?: string | null) => {
+export const keurToMillion = (value?: string | null | number) => {
   if (!value) return '0,0';
 
-  const valueAsNumber = parseFloat(value);
+  const valueAsNumber = typeof(value) !== "number" ? parseFloat(value.replace(/\s/g, '')) : value;
   const millionValue = (valueAsNumber / 1000).toFixed(1);
 
   return millionValue.toString().replace('.', ',');

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -460,10 +460,9 @@ const getExtraRows = (project: IPlanningRow, categoriesFromSlice: IListItem[] | 
 
 const getGroupStartYear = (projects: IProject[]) => {
   let earliestPlanningStartYear: number | null = null;
+  const isEarlier = (p: IProject) => {return (!earliestPlanningStartYear && p.planningStartYear) || (p.planningStartYear && earliestPlanningStartYear && p.planningStartYear < earliestPlanningStartYear)};
   for (const p of projects) {
-    if (!earliestPlanningStartYear && p.planningStartYear) {
-      earliestPlanningStartYear = p.planningStartYear
-    } else if (p.planningStartYear && earliestPlanningStartYear && p.planningStartYear < earliestPlanningStartYear) {
+    if (isEarlier(p)) {
       earliestPlanningStartYear = p.planningStartYear
     }
   }
@@ -472,10 +471,9 @@ const getGroupStartYear = (projects: IProject[]) => {
 
 const getGroupEndYear = (projects: IProject[]) => {
   let latestConstructionEndYear: number | null = null;
+  const isLater = (p: IProject) => {return ((!latestConstructionEndYear && p.constructionEndYear) || (p.constructionEndYear && latestConstructionEndYear && p.constructionEndYear > latestConstructionEndYear))};
   for (const p of projects) {
-    if (!latestConstructionEndYear && p.constructionEndYear) {
-      latestConstructionEndYear = p.constructionEndYear
-    } else if (p.constructionEndYear && latestConstructionEndYear && p.constructionEndYear > latestConstructionEndYear) {
+    if (isLater(p)) {
       latestConstructionEndYear = p.constructionEndYear
     }
   }

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -537,7 +537,8 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
     case Reports.ConstructionProgram: {
       const planningHierarchy = [];
       for (const c of rows) {
-        if (c.type === 'group' && c.costEstimateBudget && parseFloat(c.costEstimateBudget) >= 1000) {
+        if (c.type === 'group' && c.costEstimateBudget && parseFloat(c.costEstimateBudget.replace(/\s/g, '')) >= 1000) {
+          console.log(c.costEstimateBudget)
           const startYear = getGroupStartYear(c.projectRows);
           const endYear = getGroupEndYear(c.projectRows);
           if (startYear && endYear && checkYearRange({
@@ -557,7 +558,7 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
             }
             planningHierarchy.push(convertedGroup);
           }
-        } else {
+        } else if (c.type !== 'group') {
           const convertedClass: IConstructionProgramTableRow = {
             id: c.id,
             name: c.name,

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -343,7 +343,7 @@ const getBudgetBookSummaryProperties = (coordinatorRows: IPlanningRow[]) => {
       if (nameCheckPattern.test(c.name)) {
         const convertedClass: IBudgetBookSummaryTableRow = {
           id: c.id,
-          name: c.name,
+          name: c.type === 'masterClass' ? c.name.toUpperCase() : c.name,
           parent: null,
           children: c.children.length && c.type !== 'districtPreview' && c.type !== 'collectiveSubLevel'  // children from the lower levels aren't needed
             ? getBudgetBookSummaryProperties(c.children)
@@ -504,7 +504,7 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
       for (const c of rows) {
         const convertedClass = {
           id: c.id,
-          name: c.name,
+          name: c.type === 'masterClass' ? c.name.toUpperCase() : c.name,
           parent: null,
           children: c.children.length ? convertToReportRows(c.children, reportType, categories) : [],
           projects: c.projectRows.length ? convertToReportProjects(c.projectRows) : [],
@@ -520,7 +520,7 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
       for (const c of rows) {
         const convertedClass = {
           id: c.id,
-          name: c.name,
+          name: c.type === 'masterClass' ? c.name.toUpperCase() : c.name,
           parent: null,
           children: c.children.length ? convertToReportRows(c.children, reportType, categories) : [],
           projects: c.projectRows.length ? convertToReportProjects(c.projectRows) : [],

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -467,7 +467,9 @@ const getExtraRows = (project: IPlanningRow, categoriesFromSlice: IListItem[] | 
 
 const getGroupStartYear = (projects: IProject[]) => {
   let earliestPlanningStartYear: number | null = null;
-  const isEarlier = (p: IProject) => {return (!earliestPlanningStartYear && p.planningStartYear) || (p.planningStartYear && earliestPlanningStartYear && p.planningStartYear < earliestPlanningStartYear)};
+  const isEarlier = (p: IProject) => {
+    return (!earliestPlanningStartYear && p.planningStartYear) || (p.planningStartYear && earliestPlanningStartYear && p.planningStartYear < earliestPlanningStartYear)
+  };
   for (const p of projects) {
     if (isEarlier(p)) {
       earliestPlanningStartYear = p.planningStartYear
@@ -478,7 +480,9 @@ const getGroupStartYear = (projects: IProject[]) => {
 
 const getGroupEndYear = (projects: IProject[]) => {
   let latestConstructionEndYear: number | null = null;
-  const isLater = (p: IProject) => {return ((!latestConstructionEndYear && p.constructionEndYear) || (p.constructionEndYear && latestConstructionEndYear && p.constructionEndYear > latestConstructionEndYear))};
+  const isLater = (p: IProject) => {
+    return ((!latestConstructionEndYear && p.constructionEndYear) || (p.constructionEndYear && latestConstructionEndYear && p.constructionEndYear > latestConstructionEndYear))
+  };
   for (const p of projects) {
     if (isLater(p)) {
       latestConstructionEndYear = p.constructionEndYear

--- a/src/views/ReportsView/ReportsView.tsx
+++ b/src/views/ReportsView/ReportsView.tsx
@@ -2,8 +2,6 @@ import { ReportRow } from '@/components/Report';
 import { reports } from '@/interfaces/reportInterfaces';
 import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useAppSelector } from '@/hooks/common';
-import { selectPlanningDivisions } from '@/reducers/locationSlice';
-import { selectBatchedForcedToFrameClasses, selectBatchedPlanningClasses } from '@/reducers/classSlice';
 import './styles.css';
 import { selectIsPlanningLoading, setStartYear } from '@/reducers/planningSlice';
 import { setLoading, clearLoading } from '@/reducers/loaderSlice';
@@ -12,11 +10,6 @@ import { useEffect } from 'react';
 const ReportsView = () => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-
-  // We have to pass classes and locations as props to the react-pdf documents, since they are not wrapped in the redux context
-  const divisions = useAppSelector(selectPlanningDivisions);
-  const classes = useAppSelector(selectBatchedPlanningClasses);
-  const forcedToFrameClasses = useAppSelector(selectBatchedForcedToFrameClasses);
   
   const year = new Date().getFullYear();
   useEffect(() => {
@@ -41,7 +34,7 @@ const ReportsView = () => {
         {t('reports')}
       </h1>
       {reports.map((r) => (
-        <ReportRow key={r} type={r} divisions={divisions} classes={classes} forcedToFrameClasses={forcedToFrameClasses} />
+        <ReportRow key={r} type={r} />
       ))}
     </div>
   );


### PR DESCRIPTION
- Report now has all groups that have a costEstimateBudget that is grater than 1 million and have at least one project that is in planning or construction phase in the next three years
- It should also have projects that have a costEstimateBudget that is grater than 1 million and don't belong to a group
- changed masterClass names to be in uppercase if the report is constructed from coordination view data
- ticket: [https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/IO/boards/302?selectedIssue=IO-334](https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/IO/boards/302?selectedIssue=IO-334)