### PR TITLE
HKISD-82: fix calculating frame budget sums

### DIFF
--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -40,7 +40,7 @@ export const calculatePlanningRowSums = (
   const budgets = Object.values(rest).reduce(
     (budgets: { sumOfPlannedBudgets: number; sumOfFrameBudgets: number }, finance) => {
       budgets.sumOfPlannedBudgets += finance.plannedBudget;
-      budgets.sumOfFrameBudgets += finance.plannedBudget;
+      budgets.sumOfFrameBudgets += finance.frameBudget;
       return budgets;
     },
     { sumOfPlannedBudgets: 0, sumOfFrameBudgets: 0 },


### PR DESCRIPTION
ticket:[https://futurice.atlassian.net/browse/HKISD-82]( https://futurice.atlassian.net/browse/HKISD-82)
- frame budget sums were previously the same as programmed budgets sum
![Screenshot 2024-04-10 at 17 11 32](https://github.com/City-of-Helsinki/infraohjelmointi-ui/assets/77616473/f288e501-230f-48d2-8d18-d12533c5fa8b)
![Screenshot 2024-04-10 at 17 11 20](https://github.com/City-of-Helsinki/infraohjelmointi-ui/assets/77616473/fb038c00-14aa-463b-8bcb-862a3df8f1f8)
