### PR TITLE
HKISD-120: fix search button

### DIFF
--- a/src/services/projectServices.ts
+++ b/src/services/projectServices.ts
@@ -54,10 +54,11 @@ export const postProject = async (request: IProjectPostRequestObject): Promise<I
 
 export const getSearchResults = async (req: ISearchRequest): Promise<ISearchResults> => {
   try {
-    const res = await axios.get(
-      req.fullPath ||
-        `${REACT_APP_API_URL}/projects/search-results/?${req.params}&limit=${req.limit}&order=${req.order}`,
-    );
+    const endOfFullPath = req.fullPath?.split("/projects")[1];
+    const url = endOfFullPath
+      ? `${REACT_APP_API_URL}/projects${endOfFullPath}`
+      : `${REACT_APP_API_URL}/projects/search-results/?${req.params}&limit=${req.limit}&order=${req.order}`;
+    const res = await axios.get(url);
     return res.data;
   } catch (e) {
     return Promise.reject(e);

--- a/src/views/SearchResultsView/SearchResultsView.test.tsx
+++ b/src/views/SearchResultsView/SearchResultsView.test.tsx
@@ -492,12 +492,12 @@ describe('SearchResultsView', () => {
       // Next page
       mockedAxios.get.mockResolvedValueOnce(mockLongSearchResults);
       await user.click(await findByTestId('search-results-pagination-next-button'));
-      expect(mockedAxios.get.mock.lastCall[0]).toBe(mockLongSearchResults.data.next);
+      expect(mockedAxios.get.mock.lastCall[0].includes('page=2')).toBe(true);
 
       // Previous page
       mockedAxios.get.mockResolvedValueOnce(mockLongSearchResults);
       await user.click(await findByTestId('search-results-pagination-previous-button'));
-      expect(mockedAxios.get.mock.lastCall[0]).toBe(mockLongSearchResults.data.previous);
+      expect(mockedAxios.get.mock.lastCall[0].includes('page=1')).toBe(true);
 
       // Page 4
       mockedAxios.get.mockResolvedValueOnce(mockLongSearchResults);


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-120

When user tried to use next or previous buttons on the search page, they got an error. I think that ensuring we use the same beginning in the search url, the problem could be fixed. If next / previous buttons were clicked, the search url started with **http** instead of **https**, which caused the error. The `req.fullPath` was used with the next / previous buttons and the `${REACT_APP_API_URL}/projects/search-results/?${req.params}&limit=${req.limit}&order=${req.order}` was used when user clicked the numbers.