### PR TITLE
HKISD-87/fix moving budgets creates zeros issue

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -73,7 +73,7 @@ const ProjectForm = () => {
     const numberOfYears = startYear - previousStartYear;
     let budgetToMove = 0.00;
     for (let i=0; i<numberOfYears; ++i) {
-      const financeYearName = getFinanceYearName(finances, previousStartYear + i);
+      const financeYearName = getFinanceYearName(finances, Number(previousStartYear) + i);
       const financeValue = finances[financeYearName];
       budgetToMove += parseFloat(financeValue as string);
       financesCopy = { ...financesCopy, [financeYearName]: "0.00"};
@@ -92,7 +92,7 @@ const ProjectForm = () => {
     const maxIndex = 10 - (endYear - finances.year);
     let budgetToMove = 0.00;
     for (let i=1; i<=numberOfYears && i<=maxIndex; ++i) {
-      const financeYearName = getFinanceYearName(finances, endYear + i);
+      const financeYearName = getFinanceYearName(finances, Number(endYear) + i);
       const financeValue = finances[financeYearName];
       budgetToMove += parseFloat(financeValue as string);
       financesCopy = { ...financesCopy, [financeYearName]: "0.00"};


### PR DESCRIPTION
- Moving planningStartYear and constructionEndYear from the project card didn't move the budgets to the closest year within the new schedule -> should be fixed now
- Ticket (specs of this problem in the comments): [https://futurice.atlassian.net/browse/HKISD-87](https://futurice.atlassian.net/browse/HKISD-87)