### PR TITLE
HKISD-131 change kustannusenuste to use budget instead of p…

### DIFF
--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -228,7 +228,6 @@ const convertToReportProjects = (projects: IProject[]): IStrategyTableRow[] => {
 }
 
 const convertToConstructionReportProjects = (projects: IProject[], divisions: Array<ILocation> | undefined): IConstructionProgramTableRow[] => {
-  console.log(projects);
   return projects
   .filter((p) => 
     p.planningStartYear && p.constructionEndYear &&

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -228,6 +228,7 @@ const convertToReportProjects = (projects: IProject[]): IStrategyTableRow[] => {
 }
 
 const convertToConstructionReportProjects = (projects: IProject[], divisions: Array<ILocation> | undefined): IConstructionProgramTableRow[] => {
+  console.log(projects);
   return projects
   .filter((p) => 
     p.planningStartYear && p.constructionEndYear &&
@@ -243,7 +244,7 @@ const convertToConstructionReportProjects = (projects: IProject[], divisions: Ar
     projects: [],
     parent: null,
     location: getDivision(divisions, p.projectLocation),
-    costForecast: keurToMillion(calculateProjectRowSums(p).availableFrameBudget),
+    costForecast: keurToMillion(p.costForecast),
     startAndEnd: `${p.planningStartYear}-${p.constructionEndYear}`,
     spentBudget: keurToMillion(p.spentBudget),
     budgetProposalCurrentYearPlus0:
@@ -589,7 +590,7 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
               parent: c.path,
               children: [],
               projects: isOnlyHeaderGroup ? convertToConstructionReportProjects(c.projectRows, divisions) : [],
-              costForecast: isOnlyHeaderGroup ? undefined : keurToMillion(c.plannedBudgets),
+              costForecast: isOnlyHeaderGroup ? undefined : keurToMillion(c.costEstimateBudget),
               startAndEnd: isOnlyHeaderGroup ? undefined : `${startYear}-${endYear}`,
               type: isOnlyHeaderGroup ? 'class' : 'group',
               ...(isOnlyHeaderGroup ? {} : convertToGroupValues(c.projectRows, divisions))

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -15,7 +15,7 @@ import {
   ICategoryArray,
   ITotals,
 } from '@/interfaces/reportInterfaces';
-import { calculateProjectRowSums, convertToMillions, keurToMillion } from './calculations';
+import { convertToMillions, keurToMillion } from './calculations';
 import { TFunction, t } from 'i18next';
 import { IPlanningCell, IPlanningRow } from '@/interfaces/planningInterfaces';
 import { split } from 'lodash';


### PR DESCRIPTION
- kustannusennuste needs to use the budget (underlined in the screenshot) numbers instead of planned budgets
- 
![Screenshot 2024-05-17 at 13 26 06](https://github.com/City-of-Helsinki/infraohjelmointi-ui/assets/77616473/2605ad85-318d-47cb-bd85-d2a69fc4b8d8)
