### PR TITLE
fix: show an exact keur number as rounded number

### DIFF
--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -24,6 +24,16 @@ export const formattedNumberToNumber = (formattedNumber?: string) => {
 };
 
 /**
+ * Round decimal number to number string
+ *
+ * @returns Rounded number as a string
+ */
+export const roundNumberToString = (number: string | number) => {
+  const numberString = String(number).replace(',', '.');
+  return Math.round(Number(numberString)).toString();
+}
+
+/**
  * Calculates the budgets for the current row. Returns nothing for a division and no deviation for groups.
  *
  * @returns
@@ -59,7 +69,7 @@ export const calculatePlanningRowSums = (
   return {
     ...(type !== 'division' && {
       plannedBudgets,
-      costEstimateBudget,
+      costEstimateBudget: roundNumberToString(costEstimateBudget),
       ...(type !== 'group' && {
         deviation: formatNumber(deviationBetweenCostEstimateAndBudget),
       }),


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-133

On hierarchy view, `cost-estimate-budget` value on group row is displayed as a decimal number. This number should be a rounded number.

- Round a decimal value (thousands).