### PR TITLE
Fix: HKISD-124 fix bug in construction end year changing

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
@@ -20,11 +20,11 @@ interface IProjectScheduleSectionProps {
   isUserProjectManager: boolean;
 }
 
-const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({ 
+const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
   getFieldProps,
   getValues,
   getFieldState,
-  isUserProjectManager 
+  isUserProjectManager
 }) => {
   const { t } = useTranslation();
 
@@ -223,11 +223,11 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
           const yearToBeSet = date?.split('.')[2];
           const yearInFormYearCell = getValues('constructionEndYear');
 
-          if (yearToBeSet !== yearInFormYearCell) {
-            if (isUserProjectManager) {
-              return t('validation.userIsNotAllowedToModifyConstructionEndYear');
-            }
-            return t('validation.constructionEndYearValidator');
+          if (!getFieldState('constructionEndYear').isDirty && yearToBeSet !== yearInFormYearCell) {
+              if (isUserProjectManager) {
+                return t('validation.userIsNotAllowedToModifyConstructionEndYear');
+              }
+              return t('validation.constructionEndYearValidator');
           }
 
           const phase = getValues('phase').value;


### PR DESCRIPTION
This PR fixes bug in yearCell. Year changing was not possible due to missing check for if constructionEndYear isDirty. 