### PR TITLE
HKISD-139: fix: add checks for project and groups budgets

### DIFF
--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -632,7 +632,7 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
       const projectsToBeShownMasterClass = (path: string | undefined | null) => path && (path.startsWith('8 01') || path.startsWith('8 04') || path.startsWith('8 08'));
       
       for (const c of rows) {
-        if (c.type === 'group' && c.costEstimateBudget && parseFloat(c.costEstimateBudget.replace(/\s/g, '')) >= 1000 ) {
+        if (c.type === 'group' && c.costEstimateBudget && parseFloat(c.costEstimateBudget.replace(/\s/g, '')) >= 1000) {
           const startYear = getGroupStartYear(c.projectRows);
           const endYear = getGroupEndYear(c.projectRows);
           if (startYear && endYear && checkYearRange({
@@ -706,7 +706,7 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
             planningHierarchy.push(emptyRow);
           }
         }
-      };
+      }
       return planningHierarchy;
     }
     default:

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -1,5 +1,5 @@
 import { ILocation } from '@/interfaces/locationInterfaces';
-import { IProject } from '@/interfaces/projectInterfaces';
+import { IProject, IProjectFinances } from '@/interfaces/projectInterfaces';
 import {
   IBudgetBookSummaryCsvRow,
   IBudgetBookSummaryTableRow,
@@ -235,6 +235,7 @@ const convertToConstructionReportProjects = (projects: IProject[], divisions: Ar
       planningStart: p.planningStartYear,
       constructionEnd: p.constructionEndYear
     }) &&
+    checkProjectHasBudgets(p.finances) &&
     parseFloat(p.costForecast) >= 1000)
   .map((p) => ({
     name: p.name,
@@ -292,6 +293,18 @@ const checkYearRange = (props: IYearCheck ) => {
   } else {
     return false;
   }
+}
+
+const checkProjectHasBudgets = (projectFinances: IProjectFinances) => {
+  return parseFloat(projectFinances.budgetProposalCurrentYearPlus0 ?? '0') > 0 ||
+    parseFloat(projectFinances.budgetProposalCurrentYearPlus1 ?? '0') > 0 ||
+    parseFloat(projectFinances.budgetProposalCurrentYearPlus2 ?? '0') > 0;
+}
+
+const checkGroupHasBudgets = (group: IConstructionProgramTableRow) => {
+  return parseFloat(group.budgetProposalCurrentYearPlus0 ?? '0') > 0 ||
+    parseFloat(group.budgetProposalCurrentYearPlus1 ?? '0') > 0 ||
+    parseFloat(group.budgetProposalCurrentYearPlus2 ?? '0') > 0
 }
 
 export const getInvestmentPart = (forcedToFrameHierarchy: IBudgetBookSummaryTableRow[]) => {
@@ -619,7 +632,7 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
       const projectsToBeShownMasterClass = (path: string | undefined | null) => path && (path.startsWith('8 01') || path.startsWith('8 04') || path.startsWith('8 08'));
       
       for (const c of rows) {
-        if (c.type === 'group' && c.costEstimateBudget && parseFloat(c.costEstimateBudget.replace(/\s/g, '')) >= 1000) {
+        if (c.type === 'group' && c.costEstimateBudget && parseFloat(c.costEstimateBudget.replace(/\s/g, '')) >= 1000 ) {
           const startYear = getGroupStartYear(c.projectRows);
           const endYear = getGroupEndYear(c.projectRows);
           if (startYear && endYear && checkYearRange({
@@ -638,7 +651,9 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
               type: isOnlyHeaderGroup ? 'class' : 'group',
               ...(isOnlyHeaderGroup ? {} : convertToGroupValues(c.projectRows, divisions))
             }
-            planningHierarchy.push(convertedGroup);
+            if (checkGroupHasBudgets(convertedGroup)) {
+              planningHierarchy.push(convertedGroup);
+            }
           }
         } else if (c.type !== 'group') {
           const convertedClass: IConstructionProgramTableRow = {
@@ -691,7 +706,7 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
             planningHierarchy.push(emptyRow);
           }
         }
-      }
+      };
       return planningHierarchy;
     }
     default:


### PR DESCRIPTION
- added check for projects and groups that if they don't have any planned budgets on current year, year + 1 or year + 2, they will not be shown on the report
- ticket: [https://futurice.atlassian.net/browse/HKISD-139](https://futurice.atlassian.net/browse/HKISD-139)