### PR TITLE
HKISD-139 fix: missing districts, groups and projects under districtPreviews

### DIFF
--- a/src/hooks/usePlanningRows.ts
+++ b/src/hooks/usePlanningRows.ts
@@ -109,7 +109,7 @@ export const buildPlanningTableRows = (
       );
     }
     // Filter groups under division or district
-    else if (type === 'division' || type == 'district') {
+    else if (type === 'division' || type == 'district' || type == 'districtPreview') {
       filteredGroups.push(...groups.filter((group) => group.locationRelation === id));
     }
 

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -74,7 +74,7 @@ export enum Reports {
 
 export type ReportType = (typeof reports)[number];
 
-export type ReportTableRowType = 'class' | 'project' | 'investmentpart' | 'location' | 'crossingPressure' | 'taeTseFrame' | 'category' | 'group' | 'districtPreview' | 'changePressure' | 'taeFrame' | 'division';
+export type ReportTableRowType = 'class' | 'project' | 'investmentpart' | 'location' | 'crossingPressure' | 'taeTseFrame' | 'category' | 'group' | 'districtPreview' | 'changePressure' | 'taeFrame' | 'division' | 'subClassDistrict';
 
 export interface IBasicReportData {
   categories?: IListItem[];

--- a/src/utils/planningRowUtils.ts
+++ b/src/utils/planningRowUtils.ts
@@ -106,6 +106,7 @@ export const filterProjectsForPlanningRow = (
       return sortByName(getProjectsForGroup()) as Array<IProject>;
     case 'district':
     case 'division':
+    case 'districtPreview':
       return sortByName(getProjectsForLocation()) as Array<IProject>;
   }
   return [];

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -396,10 +396,14 @@ const getRowType = (type: string) => {
   }
 }
 
-const getConstructionRowType = (type: string) => {
+const getConstructionRowType = (type: string, name: string) => {
   switch (type) {
-    case 'districtPreview':
-      return 'districtPreview';
+    case 'subClass':
+      if (name.includes('suurpiiri') || name.includes('östersundom')) {
+        return 'subClassDistrict';
+      } else {
+        return 'class'
+      }
     case 'division':
       return 'division';
     case 'group':
@@ -662,7 +666,7 @@ export const convertToReportRows = (rows: IPlanningRow[], reportType: ReportType
             parent: c.path,
             children: c.children.length ? convertToReportRows(c.children, reportType, categories, divisions, t) : [],
             projects: c.projectRows.length ? convertToConstructionReportProjects(c.projectRows, divisions) : [],
-            type: getConstructionRowType(c.type) as ReportTableRowType,
+            type: getConstructionRowType(c.type, c.name.toLowerCase()) as ReportTableRowType,
           }
           planningHierarchy.push(convertedClass);
           if (pathsWithExtraRows.includes(c.path)) {
@@ -877,7 +881,7 @@ const isShownOnTheReport = (tableRow: IConstructionProgramTableRow): boolean => 
 
 const processConstructionReportRows = (tableRows: IConstructionProgramTableRow[]) => {
   tableRows.forEach((tableRow) => {
-    if (tableRow.type !== 'districtPreview' && tableRow.type !== 'division' && !constructionProgramCsvRows.some(row => row.id === tableRow.id) && isShownOnTheReport(tableRow)) {
+    if (tableRow.type !== 'subClassDistrict' && tableRow.type !== 'division' && !constructionProgramCsvRows.some(row => row.id === tableRow.id) && isShownOnTheReport(tableRow)) {
       constructionProgramCsvRows.push({
         id: tableRow.id,
         name: tableRow.name,


### PR DESCRIPTION
- districts that the user has to open in planning view to be able to see groups and projects were missing from the construction report (for example jalankulun ja pyöräilyn väylät didn't have anything under it)
- ticket: [https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-139](https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-139) bug reported in the comments