### PR TITLE
fix: use comma as a decimal separator on construction reports

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
@@ -423,6 +423,7 @@ describe('projectForm', () => {
   });
 
   it('can post a new project', async () => {
+    jest.setTimeout(15000);
     const { user, findByDisplayValue, findByTestId, findByRole, store } = await render();
     const { dispatch } = store;
 

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -756,9 +756,9 @@ export const convertToReportRows = (
               type: 'info',
               name: t('report.constructionProgram.underMillionSummary'),
               parent: c.path,
-              budgetProposalCurrentYearPlus0: underMillionSummary.budgetProposalCurrentYearPlus0.toString(),
-              budgetProposalCurrentYearPlus1: underMillionSummary.budgetProposalCurrentYearPlus1.toString(),
-              budgetProposalCurrentYearPlus2: underMillionSummary.budgetProposalCurrentYearPlus2.toString(),
+              budgetProposalCurrentYearPlus0: underMillionSummary.budgetProposalCurrentYearPlus0.toString().replace('.', ','),
+              budgetProposalCurrentYearPlus1: underMillionSummary.budgetProposalCurrentYearPlus1.toString().replace('.', ','),
+              budgetProposalCurrentYearPlus2: underMillionSummary.budgetProposalCurrentYearPlus2.toString().replace('.', ','),
             }
             const emptyRow: IConstructionProgramTableRow = {
               children: [],


### PR DESCRIPTION
Report shows summary with values that uses dot as decimal separator.

- change dot decimal separator to comma.