### PR TITLE
HKISD-111: Fix operational environment analysis report

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
@@ -485,7 +485,7 @@ describe('projectForm', () => {
 
     mockedAxios.post.mockResolvedValueOnce(mockPostResponse);
 
-    let parentContainer = await findByTestId('project-form');
+    const parentContainer = await findByTestId('project-form');
     const nameField = await findByRole('textbox', { name: getFormField('name *') });
     const descriptionField = await findByRole('textbox', { name: getFormField('description *') });
 

--- a/src/components/Report/DownloadCsvButton.tsx
+++ b/src/components/Report/DownloadCsvButton.tsx
@@ -59,7 +59,7 @@ const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({ type, getForcedToFrame
           const categories = await getCategories();
           if (res && res.projects.length > 0 && categories) {
             const coordinatorRows = getCoordinationTableRows(res.classHierarchy, res.forcedToFrameDistricts.districts, res.initialSelections, res.projects, res.groupRes);
-            setCsvData(await getReportData(t, type, coordinatorRows, undefined, categories, res.projectsInWarrantyPhase));
+            setCsvData(await getReportData(t, type, coordinatorRows, undefined, undefined, categories, res.projectsInWarrantyPhase));
           }
           break;
         }

--- a/src/components/Report/DownloadCsvButton.tsx
+++ b/src/components/Report/DownloadCsvButton.tsx
@@ -59,7 +59,7 @@ const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({ type, getForcedToFrame
           const categories = await getCategories();
           if (res && res.projects.length > 0 && categories) {
             const coordinatorRows = getCoordinationTableRows(res.classHierarchy, res.forcedToFrameDistricts.districts, res.initialSelections, res.projects, res.groupRes);
-            setCsvData(await getReportData(t, type, coordinatorRows, undefined, categories));
+            setCsvData(await getReportData(t, type, coordinatorRows, undefined, categories, res.projectsInWarrantyPhase));
           }
           break;
         }

--- a/src/components/Report/DownloadPdfButton.tsx
+++ b/src/components/Report/DownloadPdfButton.tsx
@@ -15,6 +15,7 @@ import { IPlanningRow } from '@/interfaces/planningInterfaces';
 import { IListItem } from '@/interfaces/common';
 import { getDistricts } from '@/services/listServices';
 import { getProjectDistricts } from '@/reducers/listsSlice';
+import { IProject } from '@/interfaces/projectInterfaces';
 /**
  * EmptyDocument is here as a placeholder to not cause an error when rendering rows for documents that
  * still haven't been implemented.
@@ -31,10 +32,11 @@ const getPdfDocument = (
   divisions?: Array<IListItem>,
   subDivisions?: Array<IListItem>,
   categories?: IListItem[],
+  projectsInWarrantyPhase?: IProject[],
 ) => {
   const pdfDocument = {
     operationalEnvironmentAnalysis:
-      <ReportContainer data={{categories, rows}} reportType={Reports.OperationalEnvironmentAnalysis}/>,
+      <ReportContainer data={{categories, rows}} reportType={Reports.OperationalEnvironmentAnalysis} projectsInWarrantyPhase={projectsInWarrantyPhase} />,
     strategy: (
       <ReportContainer data={{rows}} reportType={Reports.Strategy}/>
     ),
@@ -92,7 +94,7 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({ type, getForcedToFrame
           const categories = await getCategories();
           if (res && res.projects.length > 0 && categories) {
             const coordinatorRows = getCoordinationTableRows(res.classHierarchy, res.forcedToFrameDistricts.districts, res.initialSelections, res.projects, res.groupRes);
-            document = getPdfDocument(type, coordinatorRows, undefined, undefined, categories);
+            document = getPdfDocument(type, coordinatorRows, undefined, undefined, categories, res.projectsInWarrantyPhase);
           }
           break;
         }

--- a/src/components/Report/PdfReports/ReportContainer.tsx
+++ b/src/components/Report/PdfReports/ReportContainer.tsx
@@ -5,6 +5,7 @@ import ReportTable from './ReportTable';
 import { FC, memo } from 'react';
 import StrategyReportFooter from './StrategyReportFooter';
 import { IBasicReportData, ReportType, Reports } from '@/interfaces/reportInterfaces';
+import { IProject } from '@/interfaces/projectInterfaces';
 
 const styles = StyleSheet.create({
   page: {
@@ -19,9 +20,10 @@ const styles = StyleSheet.create({
 interface IPdfReportContainerProps {
   reportType: ReportType;
   data: IBasicReportData;
+  projectsInWarrantyPhase?: IProject[] | undefined,
 }
 
-const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data }) => {
+const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data, projectsInWarrantyPhase }) => {
   const { t } = useTranslation();
 
   const getDocumentTitle = () => {
@@ -86,7 +88,7 @@ const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data }) => 
             reportType={reportType}
             date={reportType === Reports.OperationalEnvironmentAnalysis ? currentDate : ''}
           />
-          <ReportTable reportType={reportType} data={data} />
+          <ReportTable reportType={reportType} data={data} projectsInWarrantyPhase={projectsInWarrantyPhase} />
           {reportType === Reports.Strategy &&
             <StrategyReportFooter
               infoText={t('report.strategy.footerInfoText')}

--- a/src/components/Report/PdfReports/ReportContainer.tsx
+++ b/src/components/Report/PdfReports/ReportContainer.tsx
@@ -20,7 +20,7 @@ const styles = StyleSheet.create({
 interface IPdfReportContainerProps {
   reportType: ReportType;
   data: IBasicReportData;
-  projectsInWarrantyPhase?: IProject[] | undefined,
+  projectsInWarrantyPhase?: IProject[],
 }
 
 const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data, projectsInWarrantyPhase }) => {

--- a/src/components/Report/PdfReports/ReportTable.tsx
+++ b/src/components/Report/PdfReports/ReportTable.tsx
@@ -21,6 +21,7 @@ import BudgetBookSummaryTableHeader from './BudgetBookSummaryTableHeader';
 import StrategyTableHeader from './StrategyTableHeader';
 import OperationalEnvironmentAnalysisTableHeader from './OperationalEnvironmentAnalysisTableHeader';
 import { useTranslation } from 'react-i18next';
+import { IProject } from '@/interfaces/projectInterfaces';
 
 const styles = StyleSheet.create({
   table: {
@@ -29,9 +30,10 @@ const styles = StyleSheet.create({
   },
 });
 
-interface IConstructionProgramTableProps {
+interface IReportTableProps {
   reportType: ReportType;
   data: IBasicReportData;
+  projectsInWarrantyPhase?: IProject[];
 }
 
 const getFlattenedRows = (
@@ -47,12 +49,13 @@ const getFlattenedRows = (
   }
 }
 
-const ReportTable: FC<IConstructionProgramTableProps> = ({
+const ReportTable: FC<IReportTableProps> = ({
   reportType,
-  data
+  data,
+  projectsInWarrantyPhase
 }) => {
   const { t } = useTranslation();
-  const reportRows = convertToReportRows(data.rows, reportType, data.categories, t, data.divisions, data.subDivisions);
+  const reportRows = convertToReportRows(data.rows, reportType, data.categories, t, data.divisions, data.subDivisions, projectsInWarrantyPhase);
 
   // We need to use one dimensional data for budgetBookSummary to style the report more easily
   const flattenedRows = (

--- a/src/components/Report/ReportRow.tsx
+++ b/src/components/Report/ReportRow.tsx
@@ -33,6 +33,11 @@ const ReportRow: FC<IReportRowProps> = ({ type }) => {
     }, true);
     const projects = res.results.filter((p) => p.phase.value !== 'proposal' && p.phase.value !== 'design' && p.phase.value !== 'completed');
 
+    /* needed for the operational environment analysis report. The budgets of the projects that are in the warranty phase
+       need to be added to the sums there separately and because of that we check here which projects are in this phase
+       and do the calculations then in the reportsHelper.tsx */
+    const projectsInWarrantyPhase = res.results.filter((p) => p.phase.value === 'warrantyPeriod');
+    
     // classes
     const classRes = await getCoordinationClasses({
       forcedToFrame: forcedToFrame,
@@ -61,7 +66,7 @@ const ReportRow: FC<IReportRowProps> = ({ type }) => {
       selectedOtherClassification: null
     }
 
-    return { res, projects, classHierarchy, forcedToFrameDistricts, groupRes, initialSelections }
+    return { res, projects, projectsInWarrantyPhase, classHierarchy, forcedToFrameDistricts, groupRes, initialSelections }
   }
 
   const getCategories = async (): Promise<IListItem[]> => {

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -1,13 +1,14 @@
 import { IClassHierarchy, ICoordinatorClassHierarchy } from "@/reducers/classSlice";
 import { ILocation } from "./locationInterfaces";
 import { IProject, IProjectsResponse } from "./projectInterfaces";
-import { IPlanningRow, IPlanningRowSelections, PlanningRowType } from "./planningInterfaces";
+import { IPlanningCell, IPlanningRow, IPlanningRowSelections, PlanningRowType } from "./planningInterfaces";
 import { IGroup } from "./groupInterfaces";
 import { IListItem } from "./common";
 
 export type getForcedToFrameDataType = Promise<{ 
     res: IProjectsResponse;
     projects: IProject[];
+    projectsInWarrantyPhase?: IProject[];
     classHierarchy: ICoordinatorClassHierarchy;
     forcedToFrameDistricts: {
       districts: ILocation[];
@@ -103,7 +104,18 @@ interface ITableRowEssentials {
   name: string;
   parent: string | null | undefined;
 }
-
+export interface IChild {
+  cells: IPlanningCell[];
+  children?: IOperationalEnvironmentAnalysisTableRow[];
+  projects?: IOperationalEnvironmentAnalysisTableRow[];
+  type: ReportTableRowType;
+  parent?: string | null;
+  name: string;
+  id: string;
+  costforecast?: string;
+  frameBudgets: IOperationalEnvironmentAnalysisFinanceProperties;
+  plannedBudgets: IPlannedBudgets;
+}
 export interface IOperationalEnvironmentAnalysisFinanceProperties {
   costForecast?: string;
   TAE?: string;

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -1082,6 +1082,7 @@ export const getReportData = async (
   divisions?: IListItem[],
   subDivisions?: IListItem[],
   categories?: IListItem[],
+  projectsInWarrantyPhase?: IProject[],
 ): Promise<Array<IConstructionProgramCsvRow>
   | Array<IBudgetBookSummaryCsvRow>
   | Array<IStrategyTableCsvRow>
@@ -1089,7 +1090,7 @@ export const getReportData = async (
   const year = new Date().getFullYear();
   const previousYear = year - 1;
 
-  const reportRows = convertToReportRows(rows, reportType, categories, t, divisions, subDivisions);
+  const reportRows = convertToReportRows(rows, reportType, categories, t, divisions, subDivisions, projectsInWarrantyPhase);
 
   try {
     switch (reportType) {

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -615,8 +615,8 @@ export const convertToReportRows = (
       const forcedToFrameHierarchy = [];
 
       const sumBudgets = (number1?: string, number2?: string | null): string => {
-        const formattedNumber1 = Number(number1?.replace(/\s/g, '') || '0');
-        const formattedNumber2 = Number(number2?.replace(/\s/g, '') || '0');
+        const formattedNumber1 = Number(number1?.replace(/\s/g, '') ?? '0');
+        const formattedNumber2 = Number(number2?.replace(/\s/g, '') ?? '0');
         const sum = formattedNumber1 + formattedNumber2;
         return formatNumberToContainSpaces(sum);
       }


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-111

There were some issues with the projects that are in the warranty phase. I wrote an explanation about the problem to the ticket. To solve the issue, I had to check which projects are in the warranty phase and then add calculation logic in order to get the budgets of those projects to be added to the sum levels for example in the image below (e.g. **8 01**, **8 01 03** and **8 01 03 01**).

<img width="533" alt="image" src="https://github.com/City-of-Helsinki/infraohjelmointi-ui/assets/59826954/f274974b-2a8d-4342-8422-c8c857ced570">


**This can be tested in the following way:**
1. go to the coordination view and make sure that there is a project with some budget in the current year. Then you should take a screenshot in which you can see the numbers of different levels (e.g. **8 03**, **8 03 01** and **8 03 01 01**)
<img width="563" alt="image" src="https://github.com/City-of-Helsinki/infraohjelmointi-ui/assets/59826954/37970557-fb28-479a-9f81-4abb717576c5">

2. Go to change the project to the warranty phase
3. Go download the report and then compare the numbers of different levels in it to the ones in the screenshot. They should be the same.

In the coordination view the numbers on those levels are now smaller than in the report as the numbers in the report should now contain the budgets of the projects in the warranty phase.
