### PR TITLE
HKISD-134/phase edit for project manager

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -373,9 +373,9 @@ const ProjectForm = () => {
       {/* SECTION 1 - BASIC INFO */}
       <ProjectInfoSection {...formProps} project={project} isInputDisabled={isInputDisabled} projectMode={projectMode} />
       {/* SECTION 2 - STATUS */}
-      <ProjectStatusSection {...formProps} isInputDisabled={isInputDisabled} />
+      <ProjectStatusSection {...formProps} isInputDisabled={isInputDisabled} isUserOnlyProjectManager={isUserProjectManagerCheck} />
       {/* SECTION 3 - SCHEDULE */}
-      <ProjectScheduleSection {...formProps} isUserProjectManager={isUserProjectManagerCheck} />
+      <ProjectScheduleSection {...formProps} isUserOnlyProjectManager={isUserProjectManagerCheck} />
       {/* SECTION 4 - FINANCIALS */}
       <ProjectFinancialSection
         {...formProps}

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
@@ -17,14 +17,14 @@ interface IProjectScheduleSectionProps {
     control: Control<IProjectForm>;
   };
   getFieldState: UseFormGetFieldState<IProjectForm>;
-  isUserProjectManager: boolean;
+  isUserOnlyProjectManager: boolean;
 }
 
 const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
   getFieldProps,
   getValues,
   getFieldState,
-  isUserProjectManager
+  isUserOnlyProjectManager
 }) => {
   const { t } = useTranslation();
 
@@ -48,7 +48,7 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
           const yearInFormYearCell = getValues('planningStartYear');
 
           if (!getFieldState('planningStartYear').isDirty && yearToBeSet !== yearInFormYearCell) {
-            if (isUserProjectManager) {
+            if (isUserOnlyProjectManager) {
               return t('validation.userIsNotAllowedToModifyPlanningStartYear');
             }
             return t('validation.planningStartYearChangingValidator');
@@ -224,7 +224,7 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
           const yearInFormYearCell = getValues('constructionEndYear');
 
           if (!getFieldState('constructionEndYear').isDirty && yearToBeSet !== yearInFormYearCell) {
-            if (isUserProjectManager) {
+            if (isUserOnlyProjectManager) {
               return t('validation.userIsNotAllowedToModifyConstructionEndYear');
             }
             return t('validation.constructionEndYearValidator');

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -72,7 +72,8 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
           if (isUserOnlyProjectManager) {
             const previousPhaseIndex = getPhaseIndexByPhaseId(currentPhase, phasesWithIndexes);
             const newPhaseIndex = getPhaseIndexByPhaseId(phase.value, phasesWithIndexes);
-            if (newPhaseIndex !== undefined && previousPhaseIndex !== undefined && (newPhaseIndex < previousPhaseIndex)) {
+            const newPhaseIsBeforeCurrent = newPhaseIndex !== undefined && previousPhaseIndex !== undefined && (newPhaseIndex < previousPhaseIndex)
+            if (newPhaseIsBeforeCurrent) {
               return t('validation.userNotAllowedToChangePhaseBackwards');
             }
           }

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -141,7 +141,23 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
         },
       },
     }),
-    [t, isUserOnlyProjectManager, getValues, proposalPhase, designPhase, getPhaseIndexByPhaseId, currentPhase, programmedPhase, draftInitiationPhase, draftApprovalPhase, constructionPlanPhase, constructionWaitPhase, constructionPhase, warrantyPeriodPhase, completedPhase],
+    [
+      t,
+      isUserOnlyProjectManager,
+      getValues, 
+      proposalPhase,
+      designPhase,
+      currentPhase,
+      phasesWithIndexes,
+      programmedPhase,
+      draftInitiationPhase,
+      draftApprovalPhase,
+      constructionPlanPhase,
+      constructionWaitPhase,
+      constructionPhase,
+      warrantyPeriodPhase,
+      completedPhase
+    ],
   );
 
   const validateConstructionPhaseDetails = useMemo(

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -114,6 +114,7 @@
     "constructionEndYearValidator": "Rakentamisen päättymisvuoden voi muuttaa vain Rakentamisen valmistumisvuosi -kentästä",
     "userIsNotAllowedToModifyPlanningStartYear": "Et voi muuttaa tämän kentän vuotta, vain päivää ja kuukautta. Muuttaaksesi Suunnittelun aloitusvuosi -kenttää ota yhteys alueen ohjelmoijaan.",
     "userIsNotAllowedToModifyConstructionEndYear": "Et voi muuttaa tämän kentän vuotta, vain päivää ja kuukautta. Muuttaaksesi Rakentamisen valmistumisvuosi -kenttää ota yhteys alueen ohjelmoijaan.",
+    "userNotAllowedToChangePhaseBackwards": "Projektipäällikkönä voit muuttaa vaihetta vain eteenpäin",
     "estPlanningStart": "Suunnittelu alkaa",
     "estPlanningEnd": "Suunnittelu päättyy",
     "estConstructionStart": "Rakentaminen alkaa",

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -44,6 +44,7 @@ export interface IListItem {
   id: string;
   value: string;
   parent?: string;
+  index?: number;
 }
 
 export type ListType =

--- a/src/reducers/authSlice.ts
+++ b/src/reducers/authSlice.ts
@@ -1,5 +1,5 @@
 import { IError } from '@/interfaces/common';
-import { IUser, UserRole } from '@/interfaces/userInterfaces';
+import { IUser, /* UserRole */ } from '@/interfaces/userInterfaces';
 import { getUser } from '@/services/userServices';
 import { RootState } from '@/store';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';

--- a/src/reducers/authSlice.ts
+++ b/src/reducers/authSlice.ts
@@ -1,5 +1,5 @@
 import { IError } from '@/interfaces/common';
-import { IUser, /* UserRole */ } from '@/interfaces/userInterfaces';
+import { IUser, UserRole } from '@/interfaces/userInterfaces';
 import { getUser } from '@/services/userServices';
 import { RootState } from '@/store';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';

--- a/src/reducers/listsSlice.ts
+++ b/src/reducers/listsSlice.ts
@@ -130,5 +130,6 @@ export const selectProjectDistricts = (state: RootState) => state.lists.projectD
 export const selectProjectDivisions = (state: RootState) => state.lists.projectDivisions;
 export const selectProjectSubDivisions = (state: RootState) => state.lists.projectSubDivisions;
 export const selectCategories = (state: RootState) => state.lists.categories;
+export const selectProjectPhases = (state: RootState) => state.lists.phases;
 
 export default listsSlice.reducer;


### PR DESCRIPTION
- changed project manager role's accesses so that they can only modify project phase forwards
- can be tested by setting the project manager role to ad_groups in authSlice -> you can see the UI as if you'd only have the project manager role
