### PR TITLE
HKISD-147/Add Kalasatama-Pasila with extra rows on construction report

### DIFF
--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -740,7 +740,8 @@ export const convertToReportRows = (
         "8 09 Kaupunkiuudistus/Meri-Rastila",
         "8 10 Suuret liikennehankkeet/Kruunusillat",
         "8 10 Suuret liikennehankkeet/Sörnäistentunneli",
-        "8 10 Suuret liikennehankkeet/Länsi-Helsingin raitiotiet"
+        "8 10 Suuret liikennehankkeet/Länsi-Helsingin raitiotiet",
+        "8 10 Suuret liikennehankkeet/Kalasatama-Pasila"
       ]
       const projectsToBeShownMasterClass = (path: string | undefined | null) =>
         path && (path.startsWith('8 01') || path.startsWith('8 04') || path.startsWith('8 08'));


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKI-147

With this change, missing Kalasatama-Pasila rows "Muut alle 1 milj. euron investointihankkeet" and "Hankkeet yhteensä" rows will be added.