### PR TITLE
HKISD-147/Construction report empty summary rows

### DIFF
--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -802,6 +802,29 @@ export const convertToReportRows = (
           planningHierarchy.push(convertedClass);
 
           if (pathsWithExtraRows.includes(c.path)) {
+            if (convertedClass.type === 'class'){
+              // Check if one of class' childs has project.
+              // If any childs does not have projects, we don't show summary and empty rows.
+              const isNotEmptyClass = (inputClass: IConstructionProgramTableRow) => {
+                if (inputClass.projects.length) {
+                  return true;
+                }
+
+                if (inputClass.children.length){
+                  for (const child of inputClass.children) {
+                    if (isNotEmptyClass(child)) {
+                      return true;
+                    }
+                  }
+                }
+                return false;
+              }
+
+              if (!isNotEmptyClass(convertedClass)) {
+                continue;
+              }
+            }
+
             const summaryOfProjectsRow: IConstructionProgramTableRow = {
               id: `${c.id}-class-summary`,
               children: [],


### PR DESCRIPTION
The construction report shows empty extra summary rows, if classes does not have any printable projects.

This feature checks class' children and all projects. If the class, which will get summary rows, does not have printable projects, the feature skips and won't print summary rows.

![image](https://github.com/City-of-Helsinki/infraohjelmointi-ui/assets/14055798/1671a14f-cb9b-4164-842c-8a4b3c089631)