### PR TITLE
HKISD-152/toimintasuunnitelma report changes

### DIFF
--- a/src/components/Report/PdfReports/StrategyTableHeader.tsx
+++ b/src/components/Report/PdfReports/StrategyTableHeader.tsx
@@ -18,6 +18,7 @@ const styles = StyleSheet.create({
     fontSize: '8px',
     fontWeight: 500,
     color: 'white',
+    borderBottom: '1px solid #808080',
   },
   tableHeaderRow: {
     flexDirection: 'row',

--- a/src/components/Report/PdfReports/TableRow.tsx
+++ b/src/components/Report/PdfReports/TableRow.tsx
@@ -237,9 +237,30 @@ const strategyReportStyles = StyleSheet.create({
     ...tableRowStyles,
     backgroundColor: '#f2f2f2',
   },
+  masterClassRow: {
+    ...tableRowStyles,
+    backgroundColor: '#0000bf',
+    color: 'white',
+  },
   classRow: {
     ...tableRowStyles,
-    backgroundColor: '#f0f0ff'
+    backgroundColor: '#0000a3',
+    color: 'white',
+  },
+  subClassRow: {
+    ...tableRowStyles,
+    backgroundColor: '#00007a',
+    color: 'white',
+  },
+  subClassDistrictRow: {
+    ...tableRowStyles,
+    backgroundColor: '#00007a',
+    color: 'white',
+  },
+  districtPreviewRow: {
+    ...tableRowStyles,
+    backgroundColor: '#00005e',
+    color: 'white',
   },
   projectCell: {
     ...cellStyles,
@@ -318,18 +339,21 @@ const getMonthCellStyle = (monthCell: string | undefined) => {
   }
 }
 
-const getRowStyle = (rowType: string, depth: number) => {
+const getStrategyRowStyle = (rowType: string, depth: number) => {
   switch (rowType) {
-    case 'class':
-      return strategyReportStyles.classRow
-    case 'location':
-      return strategyReportStyles.oddRow
-    case 'project':
-      if (depth % 2) {
-        return strategyReportStyles.evenRow
-      } else {
-        return strategyReportStyles.oddRow
-      }
+      case 'masterClass':
+        return strategyReportStyles.masterClassRow;
+      case 'class':
+        return strategyReportStyles.classRow;
+      case 'subClass':
+        return strategyReportStyles.subClassRow;
+      case 'subClassDistrict':
+        return strategyReportStyles.subClassDistrictRow;
+      case 'districtPreview':
+        return strategyReportStyles.districtPreviewRow;
+    default:
+      if (depth % 2) return strategyReportStyles.evenRow;
+      return strategyReportStyles.oddRow;
   }
 }
 
@@ -366,31 +390,31 @@ const Row: FC<IRowProps> = memo(({ flattenedRow, index, reportType }) => {
         case Reports.Strategy: {
             if (flattenedRow) {
               tableRow =
-              <View wrap={false} style={getRowStyle(flattenedRow.type ?? '', index ?? 0)} key={flattenedRow.id}>
-                  <Text style={
-                    ['class', 'location'].includes(flattenedRow.type ?? '')
-                    ? strategyReportStyles.classNameCell
-                    : strategyReportStyles.projectCell}>
-                      {flattenedRow.name}
-                  </Text>
-                  <Text style={strategyReportStyles.projectManagerCell}>{flattenedRow.projectManager}</Text>
-                  <Text style={strategyReportStyles.projectPhaseCell}>{flattenedRow.projectPhase}</Text>
-                  <Text style={strategyReportStyles.budgetCell}>{flattenedRow.costPlan}</Text>
-                  <Text style={strategyReportStyles.budgetCell}>{flattenedRow.costForecast}</Text>
-                  <Text style={getMonthCellStyle(flattenedRow.januaryStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.februaryStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.marchStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.aprilStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.mayStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.juneStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.julyStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.augustStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.septemberStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.octoberStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.novemberStatus)}></Text>
-                  <Text style={getMonthCellStyle(flattenedRow.decemberStatus)}></Text>
-                  <Text style={strategyReportStyles.lastCell}></Text>
-              </View>
+                <View wrap={false} style={getStrategyRowStyle(flattenedRow.type ?? '', index ?? 0)} key={flattenedRow.id}>
+                    <Text style={
+                      ['masterClass', 'class', 'subClass', 'subClassDistrict', 'districtPreview'].includes(flattenedRow.type ?? '')
+                      ? strategyReportStyles.classNameCell
+                      : strategyReportStyles.projectCell}>
+                        {flattenedRow.name}
+                    </Text>
+                    <Text style={strategyReportStyles.projectManagerCell}>{flattenedRow.projectManager}</Text>
+                    <Text style={strategyReportStyles.projectPhaseCell}>{flattenedRow.projectPhase}</Text>
+                    <Text style={strategyReportStyles.budgetCell}>{flattenedRow.costPlan}</Text>
+                    <Text style={strategyReportStyles.budgetCell}>{flattenedRow.costForecast}</Text>
+                    <Text style={getMonthCellStyle(flattenedRow.januaryStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.februaryStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.marchStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.aprilStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.mayStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.juneStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.julyStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.augustStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.septemberStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.octoberStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.novemberStatus)}></Text>
+                    <Text style={getMonthCellStyle(flattenedRow.decemberStatus)}></Text>
+                    <Text style={strategyReportStyles.lastCell}></Text>
+                </View>
             } else {
               tableRow = <View></View>;
             }

--- a/src/components/Report/PdfReports/TableRow.tsx
+++ b/src/components/Report/PdfReports/TableRow.tsx
@@ -262,6 +262,10 @@ const strategyReportStyles = StyleSheet.create({
     backgroundColor: '#00005e',
     color: 'white',
   },
+  groupRow: {
+    ...tableRowStyles,
+    backgroundColor: '#e8f3fc',
+  },
   projectCell: {
     ...cellStyles,
     ...constructionProgramCommonStyles,
@@ -351,6 +355,8 @@ const getStrategyRowStyle = (rowType: string, depth: number) => {
         return strategyReportStyles.subClassDistrictRow;
       case 'districtPreview':
         return strategyReportStyles.districtPreviewRow;
+      case 'group':
+        return strategyReportStyles.groupRow;
     default:
       if (depth % 2) return strategyReportStyles.evenRow;
       return strategyReportStyles.oddRow;
@@ -392,7 +398,7 @@ const Row: FC<IRowProps> = memo(({ flattenedRow, index, reportType }) => {
               tableRow =
                 <View wrap={false} style={getStrategyRowStyle(flattenedRow.type ?? '', index ?? 0)} key={flattenedRow.id}>
                     <Text style={
-                      ['masterClass', 'class', 'subClass', 'subClassDistrict', 'districtPreview'].includes(flattenedRow.type ?? '')
+                      ['masterClass', 'class', 'subClass', 'subClassDistrict', 'districtPreview', 'group'].includes(flattenedRow.type ?? '')
                       ? strategyReportStyles.classNameCell
                       : strategyReportStyles.projectCell}>
                         {flattenedRow.name}

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -60,9 +60,21 @@ const getYear = (dateStr: string): number => {
   return parseInt(parts[2], 10);
 }
 
-const getMonth = (dateStr: string): number => {
-  const parts = dateStr.split('.');
-  return parseInt(parts[1], 10);
+const getMonth = (startDateStr: string, endDateStr?: string): number => {
+  const startParts = startDateStr.split('.');
+  const endParts = endDateStr ? endDateStr.split('.') : [];
+
+  if (endParts.length){
+    if (startParts[2] < endParts[2]){
+      // If end year is bigger, we return Dec.
+      // E.g. start 1.1.2024 and end 2.1.2026 should return 12.
+      return 12;
+    }
+
+    return parseInt(endParts[1], 10);
+  }
+
+  return parseInt(startParts[1], 10);
 }
 
 const mapOperationalEnvironmentAnalysisProperties = (finances: IPlanningCell[], type: 'frameBudget' | 'plannedBudget') => {
@@ -177,9 +189,9 @@ const getProjectPhasePerMonth = (project: IProject, month: number) => {
   const constructionEndYear = getYear(project.estConstructionEnd);
 
   const planningStartMonth = getMonth(project.estPlanningStart);
-  const planningEndMonth = getMonth(project.estPlanningEnd);
+  const planningEndMonth = getMonth(project.estPlanningStart, project.estPlanningEnd);
   const constructionStartMonth = getMonth(project.estConstructionStart);
-  const constructionEndMonth = getMonth(project.estConstructionEnd);
+  const constructionEndMonth = getMonth(project.estConstructionStart, project.estConstructionEnd);
 
   const isPlanning = (year >= planningStartYear && year <= planningEndYear) && (month >= planningStartMonth && month <= planningEndMonth);
   const isConstruction = (year >= constructionStartYear && year <= constructionEndYear) && (month >= constructionStartMonth && month <= constructionEndMonth);

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -906,7 +906,7 @@ const strategyCsvRows: IStrategyTableCsvRow[] = [];
 
 const processStrategyTableRows = (tableRows: IStrategyTableRow[]) => {
   tableRows.forEach((tableRow) => {
-    if (!strategyCsvRows.some(row => row.id === tableRow.id) && tableRow.type !== 'group') {
+    if (!strategyCsvRows.some(row => row.id === tableRow.id)) {
       strategyCsvRows.push({
         id: tableRow.id,
         name: tableRow.name,

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -425,13 +425,14 @@ const getBudgetBookSummaryProperties = (coordinatorRows: IPlanningRow[]) => {
   return properties;
 }
 
-const getRowType = (type: string) => {
-  if (['class', 'subClass', 'masterClass', 'otherClassification', 'collectiveSubLevel'].includes(type)) {
-    return 'class';
-  } else if (type === 'group') {
-    return 'group';
-  } else {
-    return 'location';
+const getStrategyRowType = (type: string) => {
+  switch (type) {
+    case 'class':
+    case 'otherClassification':
+    case 'collectiveSubLevel':
+      return 'class';
+    default:
+      return type;
   }
 }
 
@@ -617,7 +618,7 @@ export const convertToReportRows = (
           children: c.children.length ? convertToReportRows(c.children, reportType, categories, t) : [],
           projects: c.projectRows.length ? convertToReportProjects(c.projectRows) : [],
           costForecast: c.cells[0].plannedBudget,
-          type: getRowType(c.type) as ReportTableRowType
+          type: getStrategyRowType(c.type) as ReportTableRowType
         }
         forcedToFrameHierarchy.push(convertedClass);
       }


### PR DESCRIPTION
- fix colours when end month is different than December, and the end year is different than the current year
- add colours for rows based on row types (class, subClass, project, group, ...)
- show previously hidden groups on the report
- show TA "raamiluku" values

To-do
- Hide rows that does have "raami" 0
  - Hiding classes that has TA value 0 requires more investigation and will not be done on this PR.

Testing
- Open Reports
- Download strategy Toimintasuunnitelma PDF and CSV files
  - Should include the same TA and TS values
  - TA values are only visible for higher classes
  - TS values for each classes and projects
- PDF file
  - Stylized rows

Ticket and conversation: https://futurice.atlassian.net/browse/HKISD-152