### PR TITLE
HKISD-154: fix adding projects to groups

### DIFF
--- a/src/components/Planning/GroupDialog/GroupDialog.test.tsx
+++ b/src/components/Planning/GroupDialog/GroupDialog.test.tsx
@@ -164,7 +164,8 @@ describe('GroupDialog', () => {
       },
     };
 
-    mockedAxios.get.mockResolvedValueOnce(mockSuggestionsResponse);
+
+    mockedAxios.get.mockResolvedValue(mockSuggestionsResponse);
     mockedAxios.post.mockResolvedValueOnce(mockPostResponse);
 
     const { user, findAllByTestId, findByTestId, findByRole, findByText } = renderResult;
@@ -226,8 +227,8 @@ describe('GroupDialog', () => {
     const year = new Date().getFullYear();
 
     // Check that the correct url was called
-    expect(getRequest.calls[0][0]).toBe(
-      `localhost:4000/projects/?subClass=507e3e63-0c09-4c19-8d09-43549dcc65c8&district=koilinen-district-test&projectName=Vanha&inGroup=false&programmed=true&year=${year}&forcedToFrame=false&direct=false`,
+    expect(getRequest.lastCall[0]).toBe(
+      `localhost:4000/projects/?subClass=507e3e63-0c09-4c19-8d09-43549dcc65c8&inGroup=false&year=${year}&forcedToFrame=false&direct=false&programmed=true`,
     );
 
     expect(submitButton).toBeEnabled();

--- a/src/components/Planning/GroupDialog/GroupDialog.tsx
+++ b/src/components/Planning/GroupDialog/GroupDialog.tsx
@@ -189,7 +189,7 @@ const DialogContainer: FC<IDialogProps> = memo(
       (d: IOption, fieldName: string) =>
         Object.keys(d).includes('value') && d.value !== ''
           ? true
-          : t('validation.required', { value: fieldName }) || '',
+          : t('validation.required', { field: fieldName }) || '',
       [t],
     );
 
@@ -249,7 +249,7 @@ const DialogContainer: FC<IDialogProps> = memo(
                         <TextField
                           {...formProps('name')}
                           rules={{
-                            required: t('validation.required', { value: 'Ryhmän nimi' }) ?? '',
+                            required: t('validation.required', { field: 'Ryhmän nimi' }) ?? '',
                           }}
                         />
                         <SelectField
@@ -257,7 +257,7 @@ const DialogContainer: FC<IDialogProps> = memo(
                           disabled={editMode}
                           {...formProps('masterClass')}
                           rules={{
-                            required: t('validation.required', { value: 'Pääluokka' }) ?? '',
+                            required: t('validation.required', { field: 'Pääluokka' }) ?? '',
                             validate: {
                               isPopulated: (mc: IOption) => customValidation(mc, 'Pääluokka'),
                             },
@@ -269,7 +269,7 @@ const DialogContainer: FC<IDialogProps> = memo(
                           disabled={editMode}
                           {...formProps('class')}
                           rules={{
-                            required: t('validation.required', { value: 'Luokka' }) ?? '',
+                            required: t('validation.required', { field: 'Luokka' }) ?? '',
                             validate: {
                               isPopulated: (c: IOption) => customValidation(c, 'Luokka'),
                             },
@@ -282,7 +282,7 @@ const DialogContainer: FC<IDialogProps> = memo(
                           {...formProps('subClass')}
                           options={classOptions.subClasses}
                           rules={{
-                            required: classOptions.subClasses.length > 0 ? t('validation.required', { value: 'Alaluokka' }) ?? '' : '',
+                            required: classOptions.subClasses.length > 0 ? t('validation.required', { field: 'Alaluokka' }) ?? '' : '',
                             validate: {
                               isPopulated: (c: IOption) => classOptions.subClasses.length > 0 ? customValidation(c, 'Alaluokka') ?? '' : true,
                             },
@@ -295,7 +295,7 @@ const DialogContainer: FC<IDialogProps> = memo(
                           <SelectField
                             {...formProps('district')}
                             rules={{
-                              required: (["suurpiiri", "östersundom"].some(subClassSubstring => subClassField.label.includes(subClassSubstring))) ? t('validation.required', { value: 'Suurpiiri' }) ?? '' : '',
+                              required: (["suurpiiri", "östersundom"].some(subClassSubstring => subClassField.label.includes(subClassSubstring))) ? t('validation.required', { field: 'Suurpiiri' }) ?? '' : '',
                               validate: {
                                 isValidDistrict: (d: IOption) => districtValidation(d, subClassField.label),
                               },
@@ -332,9 +332,6 @@ const DialogContainer: FC<IDialogProps> = memo(
                   <GroupProjectSearch
                     getValues={getValues}
                     control={control}
-                    showAdvanceFields={showAdvanceFields}
-                    divisions={hierarchyDivisionsAsIoptions(districtField.label, subClassField.value, classField.value, hierarchyDistricts, hierarchyDivisions)}
-                    subClasses={classOptions.subClasses}
                   />
                 </div>
               </div>

--- a/src/components/Planning/GroupDialog/GroupProjectSearch.tsx
+++ b/src/components/Planning/GroupDialog/GroupProjectSearch.tsx
@@ -19,7 +19,7 @@ interface IProjectSearchProps {
 
 const getProjectsUnderClassOrSubClass = async (groupSubClass: string, groupClass: string, forcedToFrame: boolean, year: number) => {
   const res = await getProjectsWithParams({
-    params: (groupSubClass ? `subClass=${groupSubClass}`: `class=${groupClass}`) + "&inGroup=false",
+    params: (groupSubClass ? `subClass=${groupSubClass}`: groupClass ? `class=${groupClass}` : '') + "&inGroup=false",
     direct: false,
     programmed: true,
     forcedToFrame: forcedToFrame,
@@ -73,7 +73,6 @@ const GroupProjectSearch: FC<IProjectSearchProps> = ({
   
       const projectSearchResult = allProjectsUnderSelectedClass.filter((project) => {
         const projectNameMatches = project.name.toLowerCase().startsWith(lowerCaseSearchWord);
-        const noGroup = !project.projectGroup || project.projectGroup === '';
         const classMatches = (project.projectClass === groupSubClass || project.projectClass === groupClass);
         const districtMatches = 
           project.projectDistrict === groupDistrict ||
@@ -82,11 +81,11 @@ const GroupProjectSearch: FC<IProjectSearchProps> = ({
         const divisionMatches = project.projectDistrict === groupDivision || getLocationParent(projectSubDivisions, project.projectDistrict) === groupDivision;
         const subDivisionMatches = project.projectDistrict === groupSubDivision;
   
-        if (groupSubDivision) return subDivisionMatches && projectNameMatches && noGroup && classMatches;
-        else if (groupDivision) return divisionMatches && projectNameMatches && noGroup && classMatches;
-        else if (groupDistrict) return districtMatches && projectNameMatches && noGroup && classMatches;
+        if (groupSubDivision) return subDivisionMatches && projectNameMatches && classMatches;
+        else if (groupDivision) return divisionMatches && projectNameMatches && classMatches;
+        else if (groupDistrict) return districtMatches && projectNameMatches && classMatches;
         else if (groupSubClass || groupClass) {
-          return classMatches && projectNameMatches && noGroup;
+          return classMatches && projectNameMatches;
         }
         return false;
       });


### PR DESCRIPTION
- ticket: [https://futurice.atlassian.net/browse/HKISD-154](https://futurice.atlassian.net/browse/HKISD-154)
- Fixed issue with user not being able to add projects to groups, caused by the backend not using the new location lists, but the hierarchy locations.
- Also fixed the error messages on the groupDialog, cause in the UI they were just showing {{value}} instead of the actual value
- Fetching projects for the search now only fetches the projects again if the class or subClass of the group changes and other filtering is done in the frontend
- Allows projects under any lower level location to be selected for the group (basically as long as there's no mismatch in the location selection for the group and project, the project can be added there), so for example a group that doesn't have any location selected (lowest is subClass or class, in this case) projects under any location under that subClass or class can be added to the group