### PR TITLE
feat: IO-387/project card for viewers

### DIFF
--- a/src/components/AuthGuard/AuthGuard.tsx
+++ b/src/components/AuthGuard/AuthGuard.tsx
@@ -131,7 +131,7 @@ const AuthGuard: FC = () => {
       return navigate(-1);
     }
 
-    // Redirect to planning view if a viewer is trying to access anything but the planning view
+    // Redirect to planning view if a viewer is trying to access anything but the planning view or a project card
     if ((!pathname.includes(PAGES.PLANNING) && !pathname.includes(PAGES.PROJECT_BASICS)) && isUserOnlyViewer(user)) {
       return navigate(-1);
     }

--- a/src/components/AuthGuard/AuthGuard.tsx
+++ b/src/components/AuthGuard/AuthGuard.tsx
@@ -32,6 +32,7 @@ const AuthGuard: FC = () => {
     PROJECT_NEW: 'project/new',
     PROJECT_BASICS: 'basics',
     PROJECT_NOTES: 'notes',
+    SEARCH_RESULTS: 'search-results',
   }
 
   const MAINTENANCE_MODE: boolean = process.env.REACT_APP_MAINTENANCE_MODE === 'true';
@@ -131,8 +132,13 @@ const AuthGuard: FC = () => {
       return navigate(-1);
     }
 
-    // Redirect to planning view if a viewer is trying to access anything but the planning view or a project card
-    if ((!pathname.includes(PAGES.PLANNING) && !pathname.includes(PAGES.PROJECT_BASICS)) && isUserOnlyViewer(user)) {
+    // Redirect to planning view if a viewer is trying to access anything but the planning view, search results or a project card
+    if (
+      (!pathname.includes(PAGES.PLANNING) &&
+      !pathname.includes(PAGES.PROJECT_BASICS) &&
+      !pathname.includes(PAGES.SEARCH_RESULTS)) &&
+      isUserOnlyViewer(user)
+    ) {
       return navigate(-1);
     }
 

--- a/src/components/AuthGuard/AuthGuard.tsx
+++ b/src/components/AuthGuard/AuthGuard.tsx
@@ -132,8 +132,8 @@ const AuthGuard: FC = () => {
     }
 
     // Redirect to planning view if a viewer is trying to access anything but the planning view
-    if (!pathname.includes(PAGES.PLANNING) && isUserOnlyViewer(user)) {
-      return navigate(PAGES.PLANNING);
+    if ((!pathname.includes(PAGES.PLANNING) && !pathname.includes(PAGES.PROJECT_BASICS)) && isUserOnlyViewer(user)) {
+      return navigate(-1);
     }
 
     // Redirect project managers away from new project form

--- a/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/ProjectHead.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/ProjectHead.tsx
@@ -79,7 +79,7 @@ const ProjectHead: FC<IProjectHeadProps> = ({ project, sums }) => {
         <div className="project-name-container">
           <Link
             to={`/project/${project.id}/basics`}
-            className={`project-name-button ${isUserOnlyViewer(user) ? 'pointer-events-none' : ''}`}
+            className={`project-name-button`}
             data-testid={`navigate-${project.id}`}
           >
             {project.name}

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
@@ -30,12 +30,14 @@ interface IProjectFinancialSectionProps {
     subClasses: IOption[];
   };
   isInputDisabled: boolean;
+  isUserOnlyViewer: boolean
 }
 const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
   getFieldProps,
   control,
   classOptions,
   isInputDisabled,
+  isUserOnlyViewer
 }) => {
   const { t } = useTranslation();
 
@@ -58,6 +60,7 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
             size="full"
             shouldTranslate={false}
             disabled={isInputDisabled}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -68,6 +71,7 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
             options={classes}
             shouldTranslate={false}
             disabled={isInputDisabled}
+            readOnly={isUserOnlyViewer}
           />
         </div>
         <div className="form-col-md">
@@ -76,6 +80,7 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
             options={subClasses}
             shouldTranslate={false}
             disabled={isInputDisabled}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -86,16 +91,22 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
             tooltip="keur"
             hideLabel={true}
             rules={validateMaxLength(10, t)}
+            readOnly={isUserOnlyViewer}
           />
         </div>
         <div className="form-col-lg">
-          <SelectField {...getFieldProps('projectQualityLevel')} options={projectQualityLevels} />
+          <SelectField
+            {...getFieldProps('projectQualityLevel')}
+            options={projectQualityLevels}
+            readOnly={isUserOnlyViewer}
+          />
         </div>
         <div className="form-col-sm">
           <NumberField
             {...getFieldProps('projectWorkQuantity')}
             tooltip="m2"
             rules={validateMaxLength(10, t)}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -106,16 +117,22 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
             tooltip="keur"
             hideLabel={true}
             rules={validateMaxLength(10, t)}
+            readOnly={isUserOnlyViewer}
           />
         </div>
         <div className="form-col-lg">
-          <SelectField {...getFieldProps('planningPhase')} options={planningPhases} />
+          <SelectField
+            {...getFieldProps('planningPhase')}
+            options={planningPhases}
+            readOnly={isUserOnlyViewer}
+          />
         </div>
         <div className="form-col-sm">
           <NumberField
             {...getFieldProps('planningWorkQuantity')}
             tooltip="m2"
             rules={validateMaxLength(10, t)}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -126,22 +143,29 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
             tooltip="keur"
             hideLabel={true}
             rules={validateMaxLength(10, t)}
+            readOnly={isUserOnlyViewer}
           />
         </div>
         <div className="form-col-lg">
-          <SelectField {...getFieldProps('constructionPhase')} options={constructionPhases} />
+          <SelectField
+            {...getFieldProps('constructionPhase')}
+            options={constructionPhases}
+            readOnly={isUserOnlyViewer}
+          />
         </div>
         <div className="form-col-sm">
           <NumberField
             {...getFieldProps('constructionWorkQuantity')}
             tooltip="m2"
             rules={validateMaxLength(10, t)}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
       <ListField
         {...getFieldProps('realizedCostLabel')}
         disabled={isInputDisabled}
+        readOnly={isUserOnlyViewer}
         fields={[
           { ...getFieldProps('costForecast'), rules: validateMaxLength(15, t) },
           {
@@ -163,7 +187,7 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
         cancelEdit={isSaving}
       />
 
-      <OverrunRightField control={control} cancelEdit={isSaving} />
+      <OverrunRightField control={control} cancelEdit={isSaving} readOnly={isUserOnlyViewer}/>
       <ListField
         {...getFieldProps('preliminaryBudgetDivision')}
         readOnly={true}

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
@@ -49,117 +49,74 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
   const projectQualityLevels = useOptions('projectQualityLevels');
   const planningPhases = useOptions('planningPhases');
 
+  const renderSelectField = (name: string, options: IOption[], size: "full" | "lg" | undefined, shouldTranslate: boolean) => (
+    <SelectField
+      {...getFieldProps(name)}
+      options={options}
+      size={size}
+      shouldTranslate={shouldTranslate}
+      disabled={isInputDisabled}
+      readOnly={isUserOnlyViewer}
+    />
+  );
+
+  const renderNumberField = (name: string, tooltip: string, hideLabel: boolean) => (
+    <NumberField
+      {...getFieldProps(name)}
+      tooltip={tooltip}
+      hideLabel={hideLabel}
+      rules={validateMaxLength(10, t)}
+      readOnly={isUserOnlyViewer}
+    />
+  );
+
   return (
     <div className="w-full" id="basics-financials-section">
       <FormSectionTitle {...getFieldProps('financial')} />
       <div className="form-row">
         <div className="form-col-xxl">
-          <SelectField
-            {...getFieldProps('masterClass')}
-            options={masterClasses}
-            size="full"
-            shouldTranslate={false}
-            disabled={isInputDisabled}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderSelectField('masterClass', masterClasses, "full", false)}
         </div>
       </div>
       <div className="form-row">
         <div className="form-col-md">
-          <SelectField
-            {...getFieldProps('class')}
-            options={classes}
-            shouldTranslate={false}
-            disabled={isInputDisabled}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderSelectField('class', classes, undefined, false)}
         </div>
         <div className="form-col-md">
-          <SelectField
-            {...getFieldProps('subClass')}
-            options={subClasses}
-            shouldTranslate={false}
-            disabled={isInputDisabled}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderSelectField('subClass', subClasses, undefined, false)}
         </div>
       </div>
       <div className="form-row">
         <div className="form-col-sm">
-          <NumberField
-            {...getFieldProps('projectCostForecast')}
-            tooltip="keur"
-            hideLabel={true}
-            rules={validateMaxLength(10, t)}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderNumberField('projectCostForecast', "keur", true)}
         </div>
         <div className="form-col-lg">
-          <SelectField
-            {...getFieldProps('projectQualityLevel')}
-            options={projectQualityLevels}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderSelectField('projectQualityLevel', projectQualityLevels, undefined, true)}
         </div>
         <div className="form-col-sm">
-          <NumberField
-            {...getFieldProps('projectWorkQuantity')}
-            tooltip="m2"
-            rules={validateMaxLength(10, t)}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderNumberField('projectWorkQuantity', "m2", false)}
         </div>
       </div>
       <div className="form-row">
         <div className="form-col-sm">
-          <NumberField
-            {...getFieldProps('planningCostForecast')}
-            tooltip="keur"
-            hideLabel={true}
-            rules={validateMaxLength(10, t)}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderNumberField('planningCostForecast', "keur", true)}
         </div>
         <div className="form-col-lg">
-          <SelectField
-            {...getFieldProps('planningPhase')}
-            options={planningPhases}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderSelectField('planningPhase', planningPhases, undefined, true)}
         </div>
         <div className="form-col-sm">
-          <NumberField
-            {...getFieldProps('planningWorkQuantity')}
-            tooltip="m2"
-            rules={validateMaxLength(10, t)}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderNumberField('planningWorkQuantity', "m2", false)}
         </div>
       </div>
       <div className="form-row">
         <div className="form-col-sm">
-          <NumberField
-            {...getFieldProps('constructionCostForecast')}
-            tooltip="keur"
-            hideLabel={true}
-            rules={validateMaxLength(10, t)}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderNumberField('constructionCostForecast', "keur", true)}
         </div>
         <div className="form-col-lg">
-          <SelectField
-            {...getFieldProps('constructionPhase')}
-            options={constructionPhases}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderSelectField('constructionPhase', constructionPhases, undefined, true)}
         </div>
         <div className="form-col-sm">
-          <NumberField
-            {...getFieldProps('constructionWorkQuantity')}
-            tooltip="m2"
-            rules={validateMaxLength(10, t)}
-            readOnly={isUserOnlyViewer}
-          />
+          {renderNumberField('constructionWorkQuantity', "m2", false)}
         </div>
       </div>
       <ListField

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -402,9 +402,10 @@ const ProjectForm = () => {
         {...formProps}
         locationOptions={locationOptions}
         isInputDisabled={isInputDisabled}
+        isUserOnlyViewer={isOnlyViewer}
       />
       {/* SECTION 7 - PROJECT PROGRAM */}
-      <ProjectProgramSection {...formProps} />
+      <ProjectProgramSection {...formProps} isUserOnlyViewer={isOnlyViewer}/>
       {/* BANNER */}
       {!isOnlyViewer &&
         <ProjectFormBanner onSubmit={submitCallback} isDirty={isDirty} />

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -31,7 +31,7 @@ import usePromptConfirmOnNavigate from '@/hooks/usePromptConfirmOnNavigate';
 import { t } from 'i18next';
 import { notifyError } from '@/reducers/notificationSlice';
 import { clearLoading, setLoading } from '@/reducers/loaderSlice';
-import { isUserOnlyProjectManager } from '@/utils/userRoleHelpers';
+import { isUserOnlyProjectManager, isUserOnlyViewer } from '@/utils/userRoleHelpers';
 
 const ProjectForm = () => {
   const { formMethods, classOptions, locationOptions, selectedMasterClassName } = useProjectForm();
@@ -42,6 +42,8 @@ const ProjectForm = () => {
   const project = useAppSelector(selectProject);
   const projectMode = useAppSelector(selectProjectMode);
   const sapCosts = useAppSelector(getProjectSapCosts);
+
+  const isOnlyViewer = isUserOnlyViewer(user);
 
   const [newProjectId, setNewProjectId] = useState('');
 
@@ -393,7 +395,9 @@ const ProjectForm = () => {
       {/* SECTION 7 - PROJECT PROGRAM */}
       <ProjectProgramSection {...formProps} />
       {/* BANNER */}
-      <ProjectFormBanner onSubmit={submitCallback} isDirty={isDirty} />
+      {!isOnlyViewer &&
+        <ProjectFormBanner onSubmit={submitCallback} isDirty={isDirty} />
+      }
     </form>
   );
 };

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -373,9 +373,19 @@ const ProjectForm = () => {
       className="project-form"
     >
       {/* SECTION 1 - BASIC INFO */}
-      <ProjectInfoSection {...formProps} project={project} isInputDisabled={isInputDisabled} projectMode={projectMode} />
+      <ProjectInfoSection
+        {...formProps} project={project}
+        isInputDisabled={isInputDisabled}
+        projectMode={projectMode}
+        isUserOnlyViewer={isOnlyViewer}
+      />
       {/* SECTION 2 - STATUS */}
-      <ProjectStatusSection {...formProps} isInputDisabled={isInputDisabled} isUserOnlyProjectManager={isUserProjectManagerCheck} />
+      <ProjectStatusSection 
+        {...formProps}
+        isInputDisabled={isInputDisabled}
+        isUserOnlyProjectManager={isUserProjectManagerCheck}
+        isUserOnlyViewer={isOnlyViewer}
+      />
       {/* SECTION 3 - SCHEDULE */}
       <ProjectScheduleSection {...formProps} isUserOnlyProjectManager={isUserProjectManagerCheck} isUserOnlyViewer={isOnlyViewer}/>
       {/* SECTION 4 - FINANCIALS */}
@@ -383,6 +393,7 @@ const ProjectForm = () => {
         {...formProps}
         classOptions={classOptions}
         isInputDisabled={isInputDisabled}
+        isUserOnlyViewer={isOnlyViewer}
       />
       {/* SECTION 5 - RESPONSIBLE PERSONS */}
       <ProjectResponsiblePersonsSection {...formProps} isInputDisabled={isInputDisabled} />

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -377,7 +377,7 @@ const ProjectForm = () => {
       {/* SECTION 2 - STATUS */}
       <ProjectStatusSection {...formProps} isInputDisabled={isInputDisabled} isUserOnlyProjectManager={isUserProjectManagerCheck} />
       {/* SECTION 3 - SCHEDULE */}
-      <ProjectScheduleSection {...formProps} isUserOnlyProjectManager={isUserProjectManagerCheck} />
+      <ProjectScheduleSection {...formProps} isUserOnlyProjectManager={isUserProjectManagerCheck} isUserOnlyViewer={isOnlyViewer}/>
       {/* SECTION 4 - FINANCIALS */}
       <ProjectFinancialSection
         {...formProps}

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -396,7 +396,7 @@ const ProjectForm = () => {
         isUserOnlyViewer={isOnlyViewer}
       />
       {/* SECTION 5 - RESPONSIBLE PERSONS */}
-      <ProjectResponsiblePersonsSection {...formProps} isInputDisabled={isInputDisabled} />
+      <ProjectResponsiblePersonsSection {...formProps} isInputDisabled={isInputDisabled} isUserOnlyViewer={isOnlyViewer}/>
       {/* SECTION 6 - LOCATION */}
       <ProjectLocationSection
         {...formProps}

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/HashTagsContainer.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/HashTagsContainer.tsx
@@ -9,6 +9,7 @@ interface IHashTagsProps {
   onClick?: (tag: string) => void;
   onDelete?: (tag: string) => void;
   id?: string;
+  readOnly?: boolean;
 }
 
 const getAriaLabel = (
@@ -22,7 +23,7 @@ const getAriaLabel = (
   return translate(deleteTag ?? addTag ?? '');
 };
 
-const HashTagsContainer: FC<IHashTagsProps> = ({ tags, onClick, onDelete, id }) => {
+const HashTagsContainer: FC<IHashTagsProps> = ({ tags, onClick, onDelete, id, readOnly }) => {
   const { t } = useTranslation();
 
   const handleOnClick = useCallback(
@@ -44,7 +45,7 @@ const HashTagsContainer: FC<IHashTagsProps> = ({ tags, onClick, onDelete, id }) 
   );
 
   const handlers = {
-    onClick: handleOnClick,
+    onClick: readOnly ? undefined : handleOnClick,
     onDelete: onDelete ? handleOnDelete : undefined,
   };
 

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/ProjectHashTags.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/ProjectHashTags.tsx
@@ -255,6 +255,7 @@ interface IProjectHashTagsProps {
   control: HookFormControlType;
   project: IProject | null;
   projectMode: "edit" | "new";
+  readOnly?: boolean;
 }
 
 interface IProjectHashTagsState {
@@ -262,7 +263,7 @@ interface IProjectHashTagsState {
   projectHashTags: IListItem[];
 }
 
-const ProjectHashTags: FC<IProjectHashTagsProps> = ({ name, label, control, project, projectMode }) => {
+const ProjectHashTags: FC<IProjectHashTagsProps> = ({ name, label, control, project, projectMode, readOnly }) => {
   const { t } = useTranslation();
   const allHashTags = useAppSelector(selectHashTags);
   const [state, setState] = useState<IProjectHashTagsState>({
@@ -320,10 +321,11 @@ const ProjectHashTags: FC<IProjectHashTagsProps> = ({ name, label, control, proj
       <FormFieldLabel
         dataTestId="open-hash-tag-dialog-button"
         text={t(`projectForm.${name}`)}
-        onClick={toggleOpenDialog}
+        onClick={!readOnly ? toggleOpenDialog : undefined}
+        disabled={readOnly}
       />
       {/* Displayed on form (Project hashtags) */}
-      <HashTagsContainer tags={projectHashTags} />
+      <HashTagsContainer tags={projectHashTags} readOnly={readOnly}/>
     </div>
   );
 };

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
@@ -10,8 +10,6 @@ import { ProjectHashTags } from './ProjectHashTags';
 import { validateMaxLength, validateRequired } from '@/utils/validation';
 import { useAppSelector } from '@/hooks/common';
 import { selectIsProjectSaving, selectProjectMode } from '@/reducers/projectSlice';
-import { isUserOnlyViewer } from '@/utils/userRoleHelpers';
-import { selectUser } from '@/reducers/authSlice';
 
 interface IProjectInfoSectionProps {
   project: IProject | null;
@@ -24,6 +22,7 @@ interface IProjectInfoSectionProps {
   getValues: UseFormGetValues<IProjectForm>;
   isInputDisabled: boolean;
   projectMode: "edit" | "new";
+  isUserOnlyViewer: boolean;
 }
 
 const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
@@ -32,13 +31,12 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
   getValues,
   control,
   isInputDisabled,
+  isUserOnlyViewer
 }) => {
   const areas = useOptions('areas');
   const types = useOptions('types');
   const { t } = useTranslation();
   const projectMode = useAppSelector(selectProjectMode);
-  const user = useAppSelector(selectUser);
-  const isViewerOnly = isUserOnlyViewer(user);
 
   const isSaving = useAppSelector(selectIsProjectSaving);
 
@@ -58,7 +56,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
             options={types}
             disabled={isInputDisabled}
             rules={{ required: t('validation.required', { field: t('validation.phase') }) ?? '' }}
-            readOnly={isViewerOnly}
+            readOnly={isUserOnlyViewer}
           />
         </div>
         <div className="form-col-xl">
@@ -66,7 +64,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
             {...getFieldProps('hkrId')}
             rules={validateMaxLength(5, t)}
             disabled={isInputDisabled}
-            readOnly={isViewerOnly}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -76,7 +74,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
             {...getFieldProps('entityName')}
             rules={validateMaxLength(30, t)}
             disabled={isInputDisabled}
-            readOnly={isViewerOnly}
+            readOnly={isUserOnlyViewer}
           />
         </div>
         <div className="form-col-xl">
@@ -85,13 +83,13 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
             control={control}
             rules={validateMaxLength(15, t)}
             disabled={isInputDisabled}
-            readOnly={isViewerOnly}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
       <div className="form-row">
         <div className="form-col-xl">
-          <SelectField {...getFieldProps('area')} options={areas} readOnly={isViewerOnly} />
+          <SelectField {...getFieldProps('area')} options={areas} readOnly={isUserOnlyViewer} />
         </div>
         <div className="form-col-xl">
           <TextField
@@ -109,7 +107,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
             size="l"
             rules={{...validateMaxLength(1000,t), ...validateRequired('description', t)}}
             formSaved={isSaving}
-            readOnly={isViewerOnly}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -120,7 +118,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
           control={control}
           project={project}
           projectMode={projectMode}
-          readOnly={isViewerOnly}
+          readOnly={isUserOnlyViewer}
         />
       </div>
     </div>

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
@@ -1,4 +1,4 @@
-import { FormFieldLabel, FormSectionTitle, NumberField, SelectField, TextField } from '@/components/shared';
+import { FormSectionTitle, NumberField, SelectField, TextField } from '@/components/shared';
 import TextAreaField from '@/components/shared/TextAreaField';
 import { IProject } from '@/interfaces/projectInterfaces';
 import { FC, memo } from 'react';

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectInfoSection.tsx
@@ -1,15 +1,17 @@
-import { FormSectionTitle, NumberField, SelectField, TextField } from '@/components/shared';
+import { FormFieldLabel, FormSectionTitle, NumberField, SelectField, TextField } from '@/components/shared';
 import TextAreaField from '@/components/shared/TextAreaField';
 import { IProject } from '@/interfaces/projectInterfaces';
 import { FC, memo } from 'react';
 import { useOptions } from '@/hooks/useOptions';
-import { Control } from 'react-hook-form';
+import { Control, UseFormGetValues } from 'react-hook-form';
 import { IProjectForm } from '@/interfaces/formInterfaces';
 import { useTranslation } from 'react-i18next';
 import { ProjectHashTags } from './ProjectHashTags';
 import { validateMaxLength, validateRequired } from '@/utils/validation';
 import { useAppSelector } from '@/hooks/common';
 import { selectIsProjectSaving, selectProjectMode } from '@/reducers/projectSlice';
+import { isUserOnlyViewer } from '@/utils/userRoleHelpers';
+import { selectUser } from '@/reducers/authSlice';
 
 interface IProjectInfoSectionProps {
   project: IProject | null;
@@ -19,6 +21,7 @@ interface IProjectInfoSectionProps {
     label: string;
     control: Control<IProjectForm>;
   };
+  getValues: UseFormGetValues<IProjectForm>;
   isInputDisabled: boolean;
   projectMode: "edit" | "new";
 }
@@ -26,6 +29,7 @@ interface IProjectInfoSectionProps {
 const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
   project,
   getFieldProps,
+  getValues,
   control,
   isInputDisabled,
 }) => {
@@ -33,6 +37,8 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
   const types = useOptions('types');
   const { t } = useTranslation();
   const projectMode = useAppSelector(selectProjectMode);
+  const user = useAppSelector(selectUser);
+  const isViewerOnly = isUserOnlyViewer(user);
 
   const isSaving = useAppSelector(selectIsProjectSaving);
 
@@ -52,6 +58,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
             options={types}
             disabled={isInputDisabled}
             rules={{ required: t('validation.required', { field: t('validation.phase') }) ?? '' }}
+            readOnly={isViewerOnly}
           />
         </div>
         <div className="form-col-xl">
@@ -59,6 +66,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
             {...getFieldProps('hkrId')}
             rules={validateMaxLength(5, t)}
             disabled={isInputDisabled}
+            readOnly={isViewerOnly}
           />
         </div>
       </div>
@@ -68,6 +76,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
             {...getFieldProps('entityName')}
             rules={validateMaxLength(30, t)}
             disabled={isInputDisabled}
+            readOnly={isViewerOnly}
           />
         </div>
         <div className="form-col-xl">
@@ -76,12 +85,13 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
             control={control}
             rules={validateMaxLength(15, t)}
             disabled={isInputDisabled}
+            readOnly={isViewerOnly}
           />
         </div>
       </div>
       <div className="form-row">
         <div className="form-col-xl">
-          <SelectField {...getFieldProps('area')} options={areas} />
+          <SelectField {...getFieldProps('area')} options={areas} readOnly={isViewerOnly} />
         </div>
         <div className="form-col-xl">
           <TextField
@@ -99,6 +109,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
             size="l"
             rules={{...validateMaxLength(1000,t), ...validateRequired('description', t)}}
             formSaved={isSaving}
+            readOnly={isViewerOnly}
           />
         </div>
       </div>
@@ -109,6 +120,7 @@ const ProjectInfoSection: FC<IProjectInfoSectionProps> = ({
           control={control}
           project={project}
           projectMode={projectMode}
+          readOnly={isViewerOnly}
         />
       </div>
     </div>

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectLocationSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectLocationSection.tsx
@@ -17,11 +17,13 @@ interface IProjectLocationSectionProps {
     subDivisions: IOption[];
   };
   isInputDisabled: boolean;
+  isUserOnlyViewer: boolean;
 }
 const ProjectLocationSection: FC<IProjectLocationSectionProps> = ({
   getFieldProps,
   locationOptions,
   isInputDisabled,
+  isUserOnlyViewer
 }) => {
 
   const { districts, divisions, subDivisions } = locationOptions;
@@ -38,6 +40,7 @@ const ProjectLocationSection: FC<IProjectLocationSectionProps> = ({
             options={responsibleZones}
             size="full"
             disabled={isInputDisabled}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -50,6 +53,7 @@ const ProjectLocationSection: FC<IProjectLocationSectionProps> = ({
             size="full"
             shouldTranslate={false}
             disabled={isInputDisabled}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -61,6 +65,7 @@ const ProjectLocationSection: FC<IProjectLocationSectionProps> = ({
             options={divisions}
             shouldTranslate={false}
             disabled={isInputDisabled}
+            readOnly={isUserOnlyViewer}
           />
         </div>
         <div className="form-col-md">
@@ -70,20 +75,21 @@ const ProjectLocationSection: FC<IProjectLocationSectionProps> = ({
             options={subDivisions}
             shouldTranslate={false}
             disabled={isInputDisabled}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
       <div className="form-row">
         <div className="form-col-md">
-          <TextField {...getFieldProps('masterPlanAreaNumber')} />
+          <TextField {...getFieldProps('masterPlanAreaNumber')} readOnly={isUserOnlyViewer}/>
         </div>
         <div className="form-col-md">
-          <TextField {...getFieldProps('trafficPlanNumber')} />
+          <TextField {...getFieldProps('trafficPlanNumber')} readOnly={isUserOnlyViewer}/>
         </div>
       </div>
       <div className="form-row">
         <div className="form-col-md">
-          <TextField {...getFieldProps('bridgeNumber')} />
+          <TextField {...getFieldProps('bridgeNumber')} readOnly={isUserOnlyViewer}/>
         </div>
       </div>
     </div>

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectProgramSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectProgramSection.tsx
@@ -10,14 +10,15 @@ interface IProjectProgramSectionProps {
     label: string;
     control: Control<IProjectForm>;
   };
+  isUserOnlyViewer: boolean;
 }
-const ProjectProgramSection: FC<IProjectProgramSectionProps> = ({ getFieldProps }) => {
+const ProjectProgramSection: FC<IProjectProgramSectionProps> = ({ getFieldProps, isUserOnlyViewer }) => {
   return (
     <div className="w-full" id="basics-location-section">
       <FormSectionTitle {...getFieldProps('projectProgramTitle')} />
       <div className="form-row">
         <div className="form-col-xxl">
-          <TextAreaField {...getFieldProps('projectProgram')} />
+          <TextAreaField {...getFieldProps('projectProgram')} readOnly={isUserOnlyViewer}/>
         </div>
       </div>
     </div>

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectResponsiblePersonsSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectResponsiblePersonsSection.tsx
@@ -14,11 +14,13 @@ interface IProjectResponsiblePersonsSectionProps {
     control: Control<IProjectForm>;
   };
   isInputDisabled: boolean;
+  isUserOnlyViewer: boolean;
 }
 const ProjectResponsiblePersonsSection: FC<IProjectResponsiblePersonsSectionProps> = ({
   getFieldProps,
   getValues,
   isInputDisabled,
+  isUserOnlyViewer
 }) => {
   const { t } = useTranslation();
 
@@ -102,6 +104,7 @@ const ProjectResponsiblePersonsSection: FC<IProjectResponsiblePersonsSectionProp
             options={responsiblePersons}
             rules={validatePersonPlanning()}
             shouldTranslate={false}
+            readOnly={isUserOnlyViewer}
           />
         </div>
         <div className="form-col-md">
@@ -111,6 +114,7 @@ const ProjectResponsiblePersonsSection: FC<IProjectResponsiblePersonsSectionProp
             options={responsiblePersons}
             rules={validatePersonConstruction()}
             shouldTranslate={false}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -124,10 +128,11 @@ const ProjectResponsiblePersonsSection: FC<IProjectResponsiblePersonsSectionProp
             options={[]}
             shouldTranslate={false}
             disabled={isInputDisabled}
+            readOnly={isUserOnlyViewer}
           />
         </div>
         <div className="form-col-md">
-          <TextField {...getFieldProps('otherPersons')} />
+          <TextField {...getFieldProps('otherPersons')} readOnly={isUserOnlyViewer}/>
         </div>
       </div>
     </div>

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
@@ -18,13 +18,15 @@ interface IProjectScheduleSectionProps {
   };
   getFieldState: UseFormGetFieldState<IProjectForm>;
   isUserOnlyProjectManager: boolean;
+  isUserOnlyViewer: boolean;
 }
 
 const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
   getFieldProps,
   getValues,
   getFieldState,
-  isUserOnlyProjectManager
+  isUserOnlyProjectManager,
+  isUserOnlyViewer
 }) => {
   const { t } = useTranslation();
 
@@ -254,26 +256,26 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
       <Fieldset heading={t('projectForm.planning')} className="w-full" id="planning">
         <div className="form-row">
           <div className="form-col-md">
-            <DateField {...getFieldProps('estPlanningStart')} rules={validateEstPlanningStart()} />
+            <DateField {...getFieldProps('estPlanningStart')} rules={validateEstPlanningStart()} readOnly={isUserOnlyViewer}/>
           </div>
           <div className="form-col-md">
-            <DateField {...getFieldProps('estPlanningEnd')} rules={validateEstPlanningEnd()} />
-          </div>
-        </div>
-        <div className="form-row">
-          <div className="form-col-md">
-            <DateField {...getFieldProps('presenceStart')} rules={validatePresenceStart()} />
-          </div>
-          <div className="form-col-md">
-            <DateField {...getFieldProps('presenceEnd')} rules={validatePresenceEnd()} />
+            <DateField {...getFieldProps('estPlanningEnd')} rules={validateEstPlanningEnd()} readOnly={isUserOnlyViewer}/>
           </div>
         </div>
         <div className="form-row">
           <div className="form-col-md">
-            <DateField {...getFieldProps('visibilityStart')} rules={validateVisibilityStart()} />
+            <DateField {...getFieldProps('presenceStart')} rules={validatePresenceStart()} readOnly={isUserOnlyViewer}/>
           </div>
           <div className="form-col-md">
-            <DateField {...getFieldProps('visibilityEnd')} rules={validateVisibilityEnd()} />
+            <DateField {...getFieldProps('presenceEnd')} rules={validatePresenceEnd()} readOnly={isUserOnlyViewer}/>
+          </div>
+        </div>
+        <div className="form-row">
+          <div className="form-col-md">
+            <DateField {...getFieldProps('visibilityStart')} rules={validateVisibilityStart()} readOnly={isUserOnlyViewer}/>
+          </div>
+          <div className="form-col-md">
+            <DateField {...getFieldProps('visibilityEnd')} rules={validateVisibilityEnd()} readOnly={isUserOnlyViewer}/>
           </div>
         </div>
       </Fieldset>
@@ -282,12 +284,14 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
           <div className="form-col-md">
             <DateField
               {...getFieldProps('estConstructionStart')}
+              readOnly={isUserOnlyViewer}
               rules={validateEstConstructionStart()}
             />
           </div>
           <div className="form-col-md">
             <DateField
               {...getFieldProps('estConstructionEnd')}
+              readOnly={isUserOnlyViewer}
               rules={validateEstConstructionEnd()}
             />
           </div>

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -14,8 +14,6 @@ import { mapIconKey } from '@/utils/common';
 import { useAppSelector } from '@/hooks/common';
 import { selectProject } from '@/reducers/projectSlice';
 import { selectProjectPhases } from '@/reducers/listsSlice';
-import { selectUser } from '@/reducers/authSlice';
-import { isUserOnlyViewer } from '@/utils/userRoleHelpers';
 
 interface IProjectStatusSectionProps {
   getValues: UseFormGetValues<IProjectForm>;
@@ -26,6 +24,7 @@ interface IProjectStatusSectionProps {
   };
   isInputDisabled: boolean;
   isUserOnlyProjectManager: boolean;
+  isUserOnlyViewer: boolean;
 }
 
 const getPhaseIndexByPhaseId = (phaseId: string | undefined, phasesWithIndexes: IListItem[]) => {
@@ -37,7 +36,8 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
   getFieldProps,
   getValues,
   isInputDisabled,
-  isUserOnlyProjectManager
+  isUserOnlyProjectManager,
+  isUserOnlyViewer
 }) => {
   const phases = useOptions('phases');
   const phasesWithIndexes = useAppSelector(selectProjectPhases);
@@ -46,8 +46,6 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
   const constructionPhaseDetails = useOptions('constructionPhaseDetails');
   const currentPhase = getValues('phase').value;
   const { t } = useTranslation();
-  const user = useAppSelector(selectUser);
-  const isOnlyViewer = isUserOnlyViewer(user);
 
   const [phaseRequirements, setPhaseRequirements] = useState<Array<string>>([]);
 
@@ -330,7 +328,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             rules={validatePhase}
             iconKey={iconKey}
             shouldUpdateIcon={true}
-            readOnly={isOnlyViewer}
+            readOnly={isUserOnlyViewer}
           />
         </div>
         <div className="form-col-xl">
@@ -339,7 +337,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             options={constructionPhaseDetails}
             rules={validateConstructionPhaseDetails}
             disabled={isConstructionPhaseDetailsDisabled}
-            readOnly={isOnlyViewer}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -357,7 +355,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
           {...getFieldProps('programmed')}
           rules={validateProgrammed}
           disabled={isInputDisabled}
-          readOnly={isOnlyViewer}
+          readOnly={isUserOnlyViewer}
         />
       </div>
       <div className="form-row">
@@ -366,7 +364,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             {...getFieldProps('planningStartYear')}
             rules={validatePlanningStartYear}
             disabled={isInputDisabled}
-            readOnly={isOnlyViewer}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -376,15 +374,15 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             {...getFieldProps('constructionEndYear')}
             rules={validateConstructionEndYear}
             disabled={isInputDisabled}
-            readOnly={isOnlyViewer}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
       <div className="form-row">
-        <RadioCheckboxField {...getFieldProps('louhi')} readOnly={isOnlyViewer}/>
+        <RadioCheckboxField {...getFieldProps('louhi')} readOnly={isUserOnlyViewer}/>
       </div>
       <div className="form-row">
-        <RadioCheckboxField {...getFieldProps('gravel')} readOnly={isOnlyViewer}/>
+        <RadioCheckboxField {...getFieldProps('gravel')} readOnly={isUserOnlyViewer}/>
       </div>
       <div className="form-row">
         <div className="form-col-xl">
@@ -393,7 +391,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             options={categories}
             rules={validateCategory}
             disabled={isInputDisabled}
-            readOnly={isOnlyViewer}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>
@@ -401,7 +399,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
         <RadioCheckboxField 
           {...getFieldProps('effectHousing')}
           disabled={isInputDisabled}
-          readOnly={isOnlyViewer}
+          readOnly={isUserOnlyViewer}
         />
       </div>
       <div className="form-row">
@@ -410,7 +408,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             {...getFieldProps('riskAssessment')}
             options={riskAssessments}
             disabled={isInputDisabled}
-            readOnly={isOnlyViewer}
+            readOnly={isUserOnlyViewer}
           />
         </div>
       </div>

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -14,6 +14,8 @@ import { mapIconKey } from '@/utils/common';
 import { useAppSelector } from '@/hooks/common';
 import { selectProject } from '@/reducers/projectSlice';
 import { selectProjectPhases } from '@/reducers/listsSlice';
+import { selectUser } from '@/reducers/authSlice';
+import { isUserOnlyViewer } from '@/utils/userRoleHelpers';
 
 interface IProjectStatusSectionProps {
   getValues: UseFormGetValues<IProjectForm>;
@@ -44,6 +46,8 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
   const constructionPhaseDetails = useOptions('constructionPhaseDetails');
   const currentPhase = getValues('phase').value;
   const { t } = useTranslation();
+  const user = useAppSelector(selectUser);
+  const isOnlyViewer = isUserOnlyViewer(user);
 
   const [phaseRequirements, setPhaseRequirements] = useState<Array<string>>([]);
 
@@ -326,6 +330,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             rules={validatePhase}
             iconKey={iconKey}
             shouldUpdateIcon={true}
+            readOnly={isOnlyViewer}
           />
         </div>
         <div className="form-col-xl">
@@ -334,6 +339,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             options={constructionPhaseDetails}
             rules={validateConstructionPhaseDetails}
             disabled={isConstructionPhaseDetailsDisabled}
+            readOnly={isOnlyViewer}
           />
         </div>
       </div>
@@ -351,6 +357,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
           {...getFieldProps('programmed')}
           rules={validateProgrammed}
           disabled={isInputDisabled}
+          readOnly={isOnlyViewer}
         />
       </div>
       <div className="form-row">
@@ -359,6 +366,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             {...getFieldProps('planningStartYear')}
             rules={validatePlanningStartYear}
             disabled={isInputDisabled}
+            readOnly={isOnlyViewer}
           />
         </div>
       </div>
@@ -368,14 +376,15 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             {...getFieldProps('constructionEndYear')}
             rules={validateConstructionEndYear}
             disabled={isInputDisabled}
+            readOnly={isOnlyViewer}
           />
         </div>
       </div>
       <div className="form-row">
-        <RadioCheckboxField {...getFieldProps('louhi')} />
+        <RadioCheckboxField {...getFieldProps('louhi')} readOnly={isOnlyViewer}/>
       </div>
       <div className="form-row">
-        <RadioCheckboxField {...getFieldProps('gravel')} />
+        <RadioCheckboxField {...getFieldProps('gravel')} readOnly={isOnlyViewer}/>
       </div>
       <div className="form-row">
         <div className="form-col-xl">
@@ -384,11 +393,16 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             options={categories}
             rules={validateCategory}
             disabled={isInputDisabled}
+            readOnly={isOnlyViewer}
           />
         </div>
       </div>
       <div className="form-row">
-        <RadioCheckboxField {...getFieldProps('effectHousing')} disabled={isInputDisabled} />
+        <RadioCheckboxField 
+          {...getFieldProps('effectHousing')}
+          disabled={isInputDisabled}
+          readOnly={isOnlyViewer}
+        />
       </div>
       <div className="form-row">
         <div className="form-col-xl">
@@ -396,6 +410,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             {...getFieldProps('riskAssessment')}
             options={riskAssessments}
             disabled={isInputDisabled}
+            readOnly={isOnlyViewer}
           />
         </div>
       </div>

--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -16,6 +16,7 @@ import { patchProject } from '@/services/projectServices';
 import _ from 'lodash';
 import { selectPlanningGroups } from '@/reducers/groupSlice';
 import { notifyError } from '@/reducers/notificationSlice';
+import { isUserOnlyViewer } from '@/utils/userRoleHelpers';
 
 export interface IProjectHeaderFieldProps {
   control: HookFormControlType;
@@ -29,6 +30,7 @@ const ProjectHeader: FC = () => {
   const { t } = useTranslation();
   const projectMode = useAppSelector(selectProjectMode);
   const { formMethods } = useProjectHeaderForm();
+  const isOnlyViewer = isUserOnlyViewer(user);
 
   const projectGroupName = useMemo(() => {
     if (!project?.projectGroup) {
@@ -108,7 +110,7 @@ const ProjectHeader: FC = () => {
           >
             <ProjectNameFields control={control} />
             <SelectField
-              disabled={projectMode === 'new'}
+              disabled={projectMode === 'new' || isOnlyViewer}
               name="phase"
               control={control}
               options={phases}
@@ -120,9 +122,14 @@ const ProjectHeader: FC = () => {
         <div className="mr-3 flex-1" data-testid="project-header-right">
           <div className="flex h-full flex-col">
             <div className="mr-auto text-right">
-              <div className="mb-8" data-testid="project-favourite">
-                <ProjectFavouriteField control={control} />
-              </div>
+              {/*The viewers can't access any other views than planning view and the project card
+              so by default they also can't access the place where the favourite projects would
+              be. Also, the whole feature is not yet implemented.*/}
+              {!isOnlyViewer && 
+                <div className="mb-8" data-testid="project-favourite">
+                  <ProjectFavouriteField control={control} />
+                </div>
+              }
               <p className="text-white">{t('inGroup')}</p>
               <p className="text-l font-bold text-white">{projectGroupName}</p>
             </div>

--- a/src/components/Project/ProjectHeader/ProjectNameFields.tsx
+++ b/src/components/Project/ProjectHeader/ProjectNameFields.tsx
@@ -8,6 +8,8 @@ import './styles.css';
 import { useAppSelector } from '@/hooks/common';
 import { selectProjectMode } from '@/reducers/projectSlice';
 import { useTranslation } from 'react-i18next';
+import { selectUser } from '@/reducers/authSlice';
+import { isUserOnlyViewer } from '@/utils/userRoleHelpers';
 
 interface IProjectNameFormProps {
   control: HookFormControlType;
@@ -17,6 +19,8 @@ const ProjectNameForm: FC<IProjectNameFormProps> = ({ control }) => {
   const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
   const projectMode = useAppSelector(selectProjectMode);
+  const user = useAppSelector(selectUser);
+  const isOnlyViewer = isUserOnlyViewer(user);
   const handleSetEditing = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
@@ -71,13 +75,15 @@ const ProjectNameForm: FC<IProjectNameFormProps> = ({ control }) => {
           }
         />
       </div>
-      <IconButton
-        onClick={handleSetEditing}
-        icon={IconPenLine}
-        disabled={projectMode === 'new'}
-        color="white"
-        label="edit-project-name"
-      />
+      { !isOnlyViewer &&
+        <IconButton
+          onClick={handleSetEditing}
+          icon={IconPenLine}
+          disabled={projectMode === 'new'}
+          color="white"
+          label="edit-project-name"
+        />
+      }
     </div>
   );
 };

--- a/src/components/ProjectDetailsForm/projectDetailsForm.tsx
+++ b/src/components/ProjectDetailsForm/projectDetailsForm.tsx
@@ -3,6 +3,9 @@ import { t } from "i18next";
 import './style.css';
 import { ProjectNotes } from '../Project/ProjectNotes';
 import { ProjectBasics } from '../Project/ProjectBasics';
+import { useAppSelector } from '@/hooks/common';
+import { selectUser } from '@/reducers/authSlice';
+import { isUserOnlyViewer } from '@/utils/userRoleHelpers';
 
 interface IProjectDetailsProps {
   projectMode: 'edit' | 'new';
@@ -11,6 +14,8 @@ interface IProjectDetailsProps {
 const ProjectDetailsForm = ({ projectMode }: IProjectDetailsProps) => {
   const navigate = useNavigate();
   const location = useLocation().pathname;
+  const user = useAppSelector(selectUser);
+  const isOnlyViewer = isUserOnlyViewer(user);
  
   const onBasicsPage = location.includes("basics");
   const onNotesPage = location.includes('notes');
@@ -20,7 +25,7 @@ const ProjectDetailsForm = ({ projectMode }: IProjectDetailsProps) => {
     <div data-testid="tabs-list">
       <div className='button-container'>
         <button className={onNotesPage ? 'button' : 'buttonHighlighted'} onClick={() => navigate('basics')}>{t('basicInfo')}</button>
-        { projectMode !== 'new' &&
+        { projectMode !== 'new' && !isOnlyViewer &&
           <button className={onBasicsPage ? 'button' : 'buttonHighlighted'} onClick={() => navigate('notes')}>{t('notes')}</button>
         }
       </div>

--- a/src/components/shared/DateField.tsx
+++ b/src/components/shared/DateField.tsx
@@ -40,6 +40,7 @@ const DateField: FC<IDateFieldProps> = ({ name, label, control, rules, readOnly 
               invalid={error ? true : false}
               errorText={error?.message}
               maxDate={datePlus10Years}
+              disableDatePicker={readOnly}
             />
           </div>
         );

--- a/src/components/shared/FormFieldLabel.tsx
+++ b/src/components/shared/FormFieldLabel.tsx
@@ -2,6 +2,7 @@ import { Button } from 'hds-react';
 import { IconPenLine } from 'hds-react/icons';
 import { FC, MouseEventHandler } from 'react';
 import { useTranslation } from 'react-i18next';
+import Icon from './Icon';
 
 interface IFormFieldLabel {
   text: string;

--- a/src/components/shared/FormFieldLabel.tsx
+++ b/src/components/shared/FormFieldLabel.tsx
@@ -2,7 +2,6 @@ import { Button } from 'hds-react';
 import { IconPenLine } from 'hds-react/icons';
 import { FC, MouseEventHandler } from 'react';
 import { useTranslation } from 'react-i18next';
-import Icon from './Icon';
 
 interface IFormFieldLabel {
   text: string;

--- a/src/components/shared/OverrunRightField.tsx
+++ b/src/components/shared/OverrunRightField.tsx
@@ -35,7 +35,8 @@ const OverrunRightField: FC<IOverrunRightField> = ({ readOnly, control, cancelEd
             <div className="mb-3">
               <FormFieldLabel
                 text={t('overrunRightValue', { value: field.value })}
-                onClick={handleSetEditing}
+                onClick={!readOnly ? handleSetEditing : undefined}
+                disabled={readOnly}
               />
             </div>
             {editing && (

--- a/src/components/shared/RadioCheckboxField.tsx
+++ b/src/components/shared/RadioCheckboxField.tsx
@@ -4,6 +4,7 @@ import { RadioButton as HDSRadioButton } from 'hds-react/components/RadioButton'
 import { ChangeEvent, FC, memo, useCallback } from 'react';
 import { Control, Controller, FieldValues } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import TextField from './TextField';
 
 interface IRadioCheckboxFieldProps {
   name: string;
@@ -19,6 +20,7 @@ const RadioCheckboxField: FC<IRadioCheckboxFieldProps> = ({
   label,
   control,
   rules,
+  readOnly,
   disabled,
 }) => {
   const { t } = useTranslation();
@@ -41,27 +43,37 @@ const RadioCheckboxField: FC<IRadioCheckboxFieldProps> = ({
       control={control as Control<FieldValues>}
       render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
         <div className="input-wrapper" id={name} data-testid={name}>
-          <SelectionGroup
-            label={t(label) ?? ''}
-            direction="horizontal"
-            id="radio-checkbox"
-            errorText={error?.message}
-            required={true}
-            disabled={disabled}
-          >
-            {options?.map((o, i) => (
-              <HDSRadioButton
-                data-testid={`${name}-${i}`}
-                key={o.value}
-                id={`${name}-${i}`}
-                label={t(o.label)}
-                value={o.value}
-                onChange={(e) => onChange(optionToBoolean(e))}
-                onBlur={onBlur}
-                checked={valueToString(value) === o.value}
-              />
-            ))}
-          </SelectionGroup>
+          {readOnly ?
+            <TextField
+              name={''}
+              label={label ?? ""}
+              control={control}
+              readOnly={true}
+              readOnlyValue={options.find((o) => o.value == valueToString(value))?.label}
+            />
+          :
+            <SelectionGroup
+              label={t(label) ?? ''}
+              direction="horizontal"
+              id="radio-checkbox"
+              errorText={error?.message}
+              required={true}
+              disabled={disabled}
+            >
+              {options?.map((o, i) => (
+                <HDSRadioButton
+                  data-testid={`${name}-${i}`}
+                  key={o.value}
+                  id={`${name}-${i}`}
+                  label={t(o.label)}
+                  value={o.value}
+                  onChange={(e) => onChange(optionToBoolean(e))}
+                  onBlur={onBlur}
+                  checked={valueToString(value) === o.value}
+                />
+              ))}
+            </SelectionGroup>
+          }
         </div>
       )}
     />

--- a/src/components/shared/SelectField.tsx
+++ b/src/components/shared/SelectField.tsx
@@ -6,6 +6,7 @@ import { Select as HDSSelect } from 'hds-react/components/Select';
 import { IconCrossCircle } from 'hds-react/icons';
 import { useTranslation } from 'react-i18next';
 import optionIcon from '@/utils/optionIcon';
+import TextField from './TextField';
 
 interface ISelectFieldProps {
   name: string;
@@ -20,6 +21,7 @@ interface ISelectFieldProps {
   clearable?: boolean;
   size?: 'full' | 'lg';
   shouldTranslate?: boolean;
+  readOnly?: boolean;
 }
 
 const SelectField: FC<ISelectFieldProps> = ({
@@ -35,6 +37,7 @@ const SelectField: FC<ISelectFieldProps> = ({
   clearable,
   size,
   shouldTranslate,
+  readOnly
 }) => {
   const required = rules?.required ? true : false;
   const selectContainerRef = useRef<HTMLDivElement>(null);
@@ -128,23 +131,34 @@ const SelectField: FC<ISelectFieldProps> = ({
               }`}
               ref={selectContainerRef}
             >
-              <HDSSelect
-                id={`select-field-${name}`}
-                className={`custom-select ${iconKey ? 'icon' : ''}`}
-                value={translateValue(value)}
-                onChange={handleChange}
-                onBlur={onBlur}
-                label={!hideLabel && label && t(label)}
-                invalid={error ? true : false}
-                error={error?.message}
-                options={translatedOptions ?? []}
-                required={required}
-                disabled={disabled}
-                style={{ paddingTop: hideLabel ? '1.745rem' : '0' }}
-                placeholder={t('choose') ?? ''}
-                icon={icon}
-              />
-              {((clearable === undefined && value.value) || (clearable && value.value)) &&
+              {readOnly ?
+                <TextField
+                  name={''}
+                  label={label ?? ""}
+                  control={control}
+                  readOnly={true}
+                  readOnlyValue={translateValue(value).label}
+                />
+              :
+                <HDSSelect
+                  id={`select-field-${name}`}
+                  className={`custom-select ${iconKey ? 'icon' : ''}`}
+                  value={translateValue(value)}
+                  onChange={handleChange}
+                  onBlur={onBlur}
+                  label={!hideLabel && label && t(label)}
+                  invalid={error ? true : false}
+                  error={error?.message}
+                  options={translatedOptions ?? []}
+                  required={required}
+                  disabled={disabled}
+                  style={{ paddingTop: hideLabel ? '1.745rem' : '0' }}
+                  placeholder={t('choose') ?? ''}
+                  icon={icon}
+                />
+              }
+              {((clearable === undefined && value.value) || (clearable && value.value)) && 
+                !readOnly &&
                 !disabled &&
                 !required && (
                   <button

--- a/src/components/shared/TextField.tsx
+++ b/src/components/shared/TextField.tsx
@@ -13,6 +13,7 @@ interface ITextFieldProps {
   hideLabel?: boolean;
   tooltip?: string;
   disabled?: boolean;
+  readOnlyValue?: string;
 }
 
 const TextField: FC<ITextFieldProps> = ({
@@ -24,6 +25,7 @@ const TextField: FC<ITextFieldProps> = ({
   hideLabel,
   tooltip,
   disabled,
+  readOnlyValue,
 }) => {
   const required = rules?.required ? true : false;
   const { t } = useTranslation();
@@ -37,7 +39,7 @@ const TextField: FC<ITextFieldProps> = ({
         <div className="input-wrapper" id={name} data-testid={name}>
           <HDSTextInput
             className="input-l"
-            value={value}
+            value={readOnlyValue ?? value}
             onChange={onChange}
             label={t(label)}
             hideLabel={hideLabel}

--- a/src/utils/userRoleHelpers.ts
+++ b/src/utils/userRoleHelpers.ts
@@ -1,4 +1,4 @@
-import { IUser, UserRole } from '@/interfaces/userInterfaces';
+import { IAdGroup, IUser, UserRole } from '@/interfaces/userInterfaces';
 
 export const isUserAdmin = (user: IUser | null) => {
   if (!user) {
@@ -56,11 +56,16 @@ export const isUserProjectManager = (user: IUser | null) => {
   );
 };
 
+const adGroupIsViewer = (adGroup: IAdGroup) => adGroup.name === UserRole.VIEWER || adGroup.name === UserRole.VIEWER_OTHERS;
+
 export const isUserOnlyViewer = (user: IUser | null) => {
   if (!user) {
     return false;
   }
-  return user.ad_groups.length === 1 && user.ad_groups.some((ag) => ag.name === UserRole.VIEWER || ag.name === UserRole.VIEWER_OTHERS);
+  return (
+    (user.ad_groups.length === 1 && adGroupIsViewer(user.ad_groups[0])) ||
+    (user.ad_groups.length === 2 && (adGroupIsViewer(user.ad_groups[0]) && adGroupIsViewer(user.ad_groups[1])))
+  );
 };
 
 export const isUserOnlyProjectAreaPlanner = (user: IUser | null) => {


### PR DESCRIPTION
- ticket: [https://helsinkisolutionoffice.atlassian.net/browse/IO-387](https://helsinkisolutionoffice.atlassian.net/browse/IO-387)
- viewer role can now access project cards in a read only mode
- using search / seeing search results is also allowed for them

### How to test?
-UI and API need to be in the feature branches (API PR: [https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/162](https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/162)
- change your role to viewer only in both
-> for API, go to BaseViewSet.py file and remove all other role checks except for IsViewer from the list -> permission_classes should only have the IsAuthenticated and IsViewer
-> for UI, go to authSlice.ts and uncomment the viewer role/roles from ad_groups array, but leave all other roles commented out
- Open a project card and check that it's read only (no field is editable)
- Use the search and check that you can see search results and open project cards from there