### PR TITLE
HKISD-164/projects missing from construction report

### DIFF
--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -195,6 +195,7 @@ export interface IConstructionProgramTableRow extends ITableRowEssentials {
   projects: Array<IConstructionProgramTableRow>;
   type: ReportTableRowType;
 
+  path?: string;
   costForecast?: string;
   location?: string;
   startAndEnd?: string;

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -827,6 +827,7 @@ export const convertToReportRows = (
             id: c.id,
             name: c.name,
             parent: c.path,
+            path: c.path,
             children: c.children.length ? convertToReportRows(c.children, reportType, categories, t, divisions, subDivisions) : [],
             projects: c.projectRows.length ? convertToConstructionReportProjects(c.projectRows, divisions, subDivisions) : [],
             type: getConstructionRowType(c.type, c.name.toLowerCase()) as ReportTableRowType,
@@ -1061,11 +1062,11 @@ const isShownOnTheReport = (tableRow: IConstructionProgramTableRow): boolean => 
     tableRow.name === t('report.constructionProgram.underMillionSummary') ||
     tableRow.name === '' ||
     tableRow.children.some(isShownOnTheReport))
-    // temporary solution to remove Esirakentaminen from the report
+    // temporary solution to remove 8 0 Kiinteä omaisuus/Esirakentaminen from the report
     // will later possibly be removed from the database, but currently
-    //'Esirakentaminen' is old budget item that the tool stilll needs to show
+    //'8 0 Kiinteä omaisuus/Esirakentaminen' is old budget item that the tool stilll needs to show
     // but it should be hidden on the report.
-    && tableRow.name !== "Esirakentaminen"
+    && tableRow.path !== "8 0 Kiinteä omaisuus/Esirakentaminen"
   );
 };
 


### PR DESCRIPTION
- all classes, groups and projects named "Esirankentaminen" were missing from the construction report, though only 801/Esirankentaminen class was supposed to be missing
- fixed by comparing the path instead of the name when removing the row from the report
- ticket: [https://futurice.atlassian.net/browse/HKISD-164](https://futurice.atlassian.net/browse/HKISD-164)