### PR TITLE
Update/build dockerfile image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # ===============================================
-FROM alpine:3.20.0
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 # ===============================================
-WORKDIR /app
-# Copy all files
-COPY . .
 
 ENV YARN_VERSION 1.22.19
+
+# Use user 'root' to add missing microdnf and ym packages
+USER root
 
 # Changing ownership and user rights to support following use-cases:
 # 1) running container on OpenShift, whose default security model
@@ -18,19 +18,46 @@ ENV YARN_VERSION 1.22.19
 # UID=1001 && GID=0
 # UID=<any>&& GID=0
 # UID=1001 && GID=<any>
-RUN apk add --update nano nginx nodejs yarn bash && \
-  rm -rf /var/cache/apk/* && \
-  chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
-  chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run && \
-  yarn policies set-version $YARN_VERSION && \
-  # Install dependencies
-  yarn install && yarn build && \
-  cp -r /app/build /usr/share/nginx/html && \
-  # Copy nginx config
-  cp /app/nginx.conf /etc/nginx/nginx.conf
 
+# Import Yarn GPG key and add the repository
+RUN rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg && \
+    curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
+    microdnf install -y yum && \
+    microdnf module enable -y nodejs:18 && \
+    yum install -y nano nginx yarn && \
+    yum clean all && \
+    rm -rf /var/cache/yum && \
+    mkdir -p /.cache/yarn /.npm /.yarn
+
+# Change ownership and permissions
+RUN chown -R 1001:0 /.cache/yarn /.npm /run /usr/share/nginx/html /var/lib/nginx /var/log/nginx /.yarn && \
+    chmod -R ug+rwX /.cache/yarn /.npm /run /usr/share/nginx/html /var/lib/nginx /var/log/nginx /.yarn
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Use default user '1001' to install packages and copy files
+USER 1001
+
+WORKDIR /app
+
+COPY --chown=1001:0 package.json yarn.lock .
+
+RUN yarn install && \
+    npx update-browserslist-db@latest
+
+RUN yarn policies set-version $YARN_VERSION
+
+COPY --chown=1001:0 . .
+
+# Build application
+RUN yarn build && \
+    cp -r /app/build /usr/share/nginx/html
+
+# Change ownership and permissions
+RUN chown -R 1001:0 /run /usr/share/nginx/html /var/lib/nginx /var/log/nginx && \
+    chmod -R ug+rwX /run /usr/share/nginx/html /var/lib/nginx /var/log/nginx
 
 EXPOSE 4000
-# start nginx service
-USER 1001
+
+# Start nginx service
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,81 +1,44 @@
 # ===============================================
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 # ===============================================
-
-ENV YARN_VERSION 1.22.19
-
-# Use user 'root' to add missing microdnf and ym packages
-USER root
-
-# Changing ownership and user rights to support following use-cases:
-# 1) running container on OpenShift, whose default security model
-#    is to run the container under random UID, but GID=0
-# 2) for working root-less container with UID=1001, which does not have
-#    to have GID=0
-# 3) for default use-case, that is running container directly on operating system,
-#    with default UID and GID (1001:0)
-# Supported combinations of UID:GID are thus following:
-# UID=1001 && GID=0
-# UID=<any>&& GID=0
-# UID=1001 && GID=<any>
-
-# Import Yarn GPG key and add the repository
-RUN rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg && \
-    curl --proto "=https" --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
-    microdnf install -y yum && \
-    # microdnf module enable -y nodejs && \
-    yum install -y nano nginx nodejs yarn && \
-    yum clean all && \
-    rm -rf /var/cache/yum && \
-    mkdir -p /.cache/yarn /.npm /.yarn
-    
-# Change ownership and permissions
-RUN chown -R 1001:0 /.cache/yarn /.npm /run /usr/share/nginx/html /var/lib/nginx /var/log/nginx /.yarn && \
-    chmod -R ug+rwX /.cache/yarn /.npm /run /usr/share/nginx/html /var/lib/nginx /var/log/nginx /.yarn
-
-# Copy nginx file and change file owner and permissions
-COPY --chown=1001:0 nginx.conf /etc/nginx/nginx.conf
-RUN chown -R 1001:0 /etc/nginx/nginx.conf && \
-    chmod -R ug+rwX /etc/nginx/nginx.conf
-
-# Use default user '1001' to install packages and copy files
-USER 1001
-
 WORKDIR /app
 
-COPY --chown=1001:0 --chmod=755 yarn.lock .
-COPY --chown=1001:0 --chmod=755 package.json .
+# Set environment variables
+ENV YARN_VERSION=1.22.19
+ENV NODE_VERSION=18.x
 
-RUN yarn install --frozen-lockfile && \
-    npx update-browserslist-db@latest
+# Install necessary packages using curl-minimal
+RUN microdnf update -y && \
+  microdnf install -y \
+  tar \
+  gzip \
+  bash \
+  && curl -sL https://rpm.nodesource.com/setup_18.x | bash - && \
+  microdnf install -y \
+  nodejs \
+  nginx \
+  nano \
+  && microdnf clean all
 
-RUN yarn policies set-version $YARN_VERSION
+# Install Yarn manually
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION && \
+  ln -s /root/.yarn/bin/yarn /usr/local/bin/yarn
 
-COPY --chown=1001:0 --chmod=755 ./public ./public
-COPY --chown=1001:0 --chmod=755 ./src ./src
-COPY --chown=1001:0 --chmod=755 ./craco.config.js .
-COPY --chown=1001:0 --chmod=755 ./docker-entrypoint.sh .
-COPY --chown=1001:0 --chmod=755 ./sonar-project.properties .
-COPY --chown=1001:0 --chmod=755 ./tsconfig* .
-COPY --chown=1001:0 --chmod=755 ./.eslintrc.json .
-COPY --chown=1001:0 --chmod=755 ./.env.development .
-COPY --chown=1001:0 --chmod=755 ./.env.production .
+# Changing ownership and user rights to support following use-cases:
+RUN chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
+  chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run
 
-# Build application
-RUN yarn build
+# Install node dependencies and build the project
+COPY . .
+RUN yarn install && yarn build && \
+  cp -r /app/build/* /usr/share/nginx/html/ && \
+  cp /app/nginx.conf /etc/nginx/nginx.conf
 
-# Change ownership and permissions so the files can be replaced with app's files
-USER root
-RUN rm -rf /usr/share/nginx/html/* && \
-    chown -R 1001:0 /run /usr/share/nginx/html /var/lib/nginx /var/log/nginx && \
-    chmod -R ug+rwX /run /usr/share/nginx/html /var/lib/nginx /var/log/nginx 
-
-# We make sure we will entry with the user 1001
-USER 1001
-
-RUN cp -r /app/build/* /usr/share/nginx/html/
-
+# Expose port 4000
 EXPOSE 4000
+
+# Run the container as the non-root user
+USER 1001
 
 # Start nginx service
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: ./
       dockerfile: ./Dockerfile
     environment:
-      DEV_SERVER: true
+      DEV_SERVER: 'true'
     volumes:
       - .:/app:cached
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: ./
       dockerfile: ./Dockerfile
     environment:
-      DEV_SERVER: 'false'
+      DEV_SERVER: 'true'
     volumes:
       - .:/app:cached
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: ./
       dockerfile: ./Dockerfile
     environment:
-      DEV_SERVER: 'true'
+      DEV_SERVER: 'false'
     volumes:
       - .:/app:cached
     ports:


### PR DESCRIPTION
- Switch from Docker Hub image to Red Hat Ecosystem Catalog image to fix issues with blocked image fetches from Docker Hub.
- Rewrite dockerfile
- Change boolean value to string, because docker-compose does not allow boolean value type

How-to test:
- Run `docker-compose up --build --force-recreate`
  - This force-re-builds the image

If it fails, it might happen because image caches. Cleaning docker builder caches requires deleting all images 
- `docker-compose down` - Stop and remove all docker-compose containers (doesn't delete volumes)
- `docker rmi -f infraohjelmointi_ui` - Remove `..._ui` image only
  - `docker rmi -f $(docker images -aq)` - CAUTION: Remove all docker images (if the command is needed)
- `docker builder prune` - Remove only docker builder caches that is linked to removed images

This PR should be merged into DEV that is on the same level with the main branch, in case dev requires a rollback.