### PR TITLE
fix: HKISD-159 projects thrown out of group when location data matches

### DIFF
--- a/src/components/Planning/GroupDialog/GroupProjectSearch.tsx
+++ b/src/components/Planning/GroupDialog/GroupProjectSearch.tsx
@@ -1,4 +1,4 @@
-import { IListItem, IOption } from '@/interfaces/common';
+import { IOption } from '@/interfaces/common';
 import { getProjectsWithParams } from '@/services/projectServices';
 import { getLocationParent, listItemToOption } from '@/utils/common';
 import { Tag } from 'hds-react/components/Tag';

--- a/src/components/Planning/GroupDialog/GroupProjectSearch.tsx
+++ b/src/components/Planning/GroupDialog/GroupProjectSearch.tsx
@@ -1,6 +1,6 @@
 import { IListItem, IOption } from '@/interfaces/common';
 import { getProjectsWithParams } from '@/services/projectServices';
-import { listItemToOption } from '@/utils/common';
+import { getLocationParent, listItemToOption } from '@/utils/common';
 import { Tag } from 'hds-react/components/Tag';
 import { SearchInput } from 'hds-react/components/SearchInput';
 import { FC, memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -49,10 +49,6 @@ const GroupProjectSearch: FC<IProjectSearchProps> = ({
   const getSuggestions = useCallback(async() => {
     return searchedProjects;
   }, [searchedProjects]);
-
-  const getLocationParent = (locationList: IListItem[], locationId: string | undefined) => {
-    return locationList.find((location) => location.id === locationId)?.parent;
-  }
 
   useEffect( () => {
     const setProjectsForSearch = async () => {

--- a/src/forms/useGroupForm.ts
+++ b/src/forms/useGroupForm.ts
@@ -18,7 +18,6 @@ import { IListItem, IOption } from '@/interfaces/common';
 import { getLocationParent, listItemToOption } from '@/utils/common';
 import { selectProjectDistricts, selectProjectDivisions, selectProjectSubDivisions } from '@/reducers/listsSlice';
 import { selectProjects } from '@/reducers/planningSlice';
-import { IProject } from '@/interfaces/projectInterfaces';
 interface ISelectionState {
   selectedClass: string | undefined;
   selectedLocation: string | undefined;
@@ -90,8 +89,6 @@ const useGroupValues = (projects?: IOption[], id?: string | null) => {
       subDivision: listItemToOption(selectedSubDivision),
     };
   };
-
-  
 
   const formValues: IGroupForm = useMemo(
     () => ({

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -354,6 +354,10 @@ export const syncUpdatedClassFinancesWithStartYear = (financesFromState: IClassF
   return convertedFinances;
 }
 
+export const getLocationParent = (locationList: IListItem[], locationId: string | undefined) => {
+  return locationList.find((location) => location.id === locationId)?.parent;
+}
+
 export const enum IconKey {
   Proposal = 'proposal',
   Design = 'design',


### PR DESCRIPTION
- ticket: [https://futurice.atlassian.net/browse/HKISD-159](https://futurice.atlassian.net/browse/HKISD-159)
- Fixed the issue where projects are thrown out of group when the location data of the group is changed, even when the project should be allowed to stay inside the group (there's no location conflict after the change)