### PR TITLE
Add max size for http header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,19 +8,20 @@ events {
 }
 
 http {
-    include                 /etc/nginx/mime.types;
-    default_type            application/octet-stream;
-    log_format              main  '$remote_addr - $remote_user [$time_local] "$request" '
-                            '$status $body_bytes_sent "$http_referer" '
-                            '"$http_user_agent" "$http_x_forwarded_for"';
-    access_log              /var/log/nginx/access.log  main;
-    sendfile                on;
-    keepalive_timeout       65;
-    client_body_temp_path   /tmp/client_temp;
-    proxy_temp_path         /tmp/proxy_temp_path;
-    fastcgi_temp_path       /tmp/fastcgi_temp;
-    uwsgi_temp_path         /tmp/uwsgi_temp;
-    scgi_temp_path          /tmp/scgi_temp;
+    include                         /etc/nginx/mime.types;
+    default_type                    application/octet-stream;
+    log_format                      main  '$remote_addr - $remote_user [$time_local] "$request" '
+                                    '$status $body_bytes_sent "$http_referer" '
+                                    '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log                      /var/log/nginx/access.log  main;
+    sendfile                        on;
+    keepalive_timeout               65;
+    client_body_temp_path           /tmp/client_temp;
+    proxy_temp_path                 /tmp/proxy_temp_path;
+    fastcgi_temp_path               /tmp/fastcgi_temp;
+    uwsgi_temp_path                 /tmp/uwsgi_temp;
+    scgi_temp_path                  /tmp/scgi_temp;
+    large_client_header_buffers 4   32k;
 
     server {
         listen          4000;


### PR DESCRIPTION
Increase the size of http header 

Ticket: [HKI-184](https://futurice.atlassian.net/jira/servicedesk/projects/HKI/queues/custom/238/HKI-184 )

Helsinki-profiili made keyloak updates on 16.9.2024 and that increased the amount of groups in users AD_groups. That was causing login problems for many people. Users with too many ad_groups got "pääsy evätty" from infratool as the token was not valid. 

Helsinki-profiili advised to set http header size bigger, to allow more groups in user accounts. 

large_client_header_buffers 4   32k; is added as helsinki-profiili advises. 