### PR TITLE
HKISD-188 change strategy report to fetch coordination view data

### DIFF
--- a/src/components/Report/DownloadPdfButton.tsx
+++ b/src/components/Report/DownloadPdfButton.tsx
@@ -83,7 +83,7 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({ type, getForcedToFrame
         case Reports.Strategy:
         case Reports.BudgetBookSummary: {
           // For Strategy report, we will fetch next year data
-          const res = type === Reports.Strategy ? await getForcedToFrameData(year + 1, true) : await getForcedToFrameData(year, true);
+          const res = type === Reports.Strategy ? await getForcedToFrameData(year + 1, false) : await getForcedToFrameData(year, true);
           if (res && res.projects.length > 0) {
             const coordinatorRows = getCoordinationTableRows(res.classHierarchy, res.forcedToFrameDistricts.districts, res.initialSelections, res.projects, res.groupRes);
             document = getPdfDocument(type, coordinatorRows);

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -453,7 +453,7 @@
       "costForecastShortened": "Ennuste"
     },
     "strategy": {
-      "rowTitle": "Toimintasuunnitelma (sovitettu budjetti)",
+      "rowTitle": "Toimintasuunnitelma (Koordinointinäkymä)",
       "documentName": "toimintasuunnitelma",
       "title": "Helsingin kaupunki",
       "subtitle": "Yleisten alueiden ja tonttien rakentamiskelpoiseksi saattamisen investointiohjelma {{startYear}}",


### PR DESCRIPTION
- temporary changes strategy report to fetch data from coordination view instead of forced to frame view
- will be changed back ones the feature to update forced to frame view from planning/coordination view is implemented
- goes directly to main, because dev/test pipelines aren't currently working cause of issues in platta