### PR TITLE
HKSID-133 Fixed round cost estimate budget number to remove decimal

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
@@ -10,7 +10,7 @@ import { useOptions } from '@/hooks/useOptions';
 import { Control } from 'react-hook-form';
 import { IProjectForm } from '@/interfaces/formInterfaces';
 import { IOption } from '@/interfaces/common';
-import { validateMaxLength } from '@/utils/validation';
+import { validateInteger, validateMaxLength } from '@/utils/validation';
 import { useTranslation } from 'react-i18next';
 import { useAppSelector } from '@/hooks/common';
 import { selectIsProjectSaving } from '@/reducers/projectSlice';
@@ -30,14 +30,14 @@ interface IProjectFinancialSectionProps {
     subClasses: IOption[];
   };
   isInputDisabled: boolean;
-  isUserOnlyViewer: boolean
+  isUserOnlyViewer: boolean;
 }
 const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
   getFieldProps,
   control,
   classOptions,
   isInputDisabled,
-  isUserOnlyViewer
+  isUserOnlyViewer,
 }) => {
   const { t } = useTranslation();
 
@@ -49,7 +49,12 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
   const projectQualityLevels = useOptions('projectQualityLevels');
   const planningPhases = useOptions('planningPhases');
 
-  const renderSelectField = (name: string, options: IOption[], size: "full" | "lg" | undefined, shouldTranslate: boolean) => (
+  const renderSelectField = (
+    name: string,
+    options: IOption[],
+    size: 'full' | 'lg' | undefined,
+    shouldTranslate: boolean,
+  ) => (
     <SelectField
       {...getFieldProps(name)}
       options={options}
@@ -75,48 +80,38 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
       <FormSectionTitle {...getFieldProps('financial')} />
       <div className="form-row">
         <div className="form-col-xxl">
-          {renderSelectField('masterClass', masterClasses, "full", false)}
+          {renderSelectField('masterClass', masterClasses, 'full', false)}
         </div>
       </div>
       <div className="form-row">
-        <div className="form-col-md">
-          {renderSelectField('class', classes, undefined, false)}
-        </div>
+        <div className="form-col-md">{renderSelectField('class', classes, undefined, false)}</div>
         <div className="form-col-md">
           {renderSelectField('subClass', subClasses, undefined, false)}
         </div>
       </div>
       <div className="form-row">
-        <div className="form-col-sm">
-          {renderNumberField('projectCostForecast', "keur", true)}
-        </div>
+        <div className="form-col-sm">{renderNumberField('projectCostForecast', 'keur', true)}</div>
         <div className="form-col-lg">
           {renderSelectField('projectQualityLevel', projectQualityLevels, undefined, true)}
         </div>
-        <div className="form-col-sm">
-          {renderNumberField('projectWorkQuantity', "m2", false)}
-        </div>
+        <div className="form-col-sm">{renderNumberField('projectWorkQuantity', 'm2', false)}</div>
       </div>
       <div className="form-row">
-        <div className="form-col-sm">
-          {renderNumberField('planningCostForecast', "keur", true)}
-        </div>
+        <div className="form-col-sm">{renderNumberField('planningCostForecast', 'keur', true)}</div>
         <div className="form-col-lg">
           {renderSelectField('planningPhase', planningPhases, undefined, true)}
         </div>
-        <div className="form-col-sm">
-          {renderNumberField('planningWorkQuantity', "m2", false)}
-        </div>
+        <div className="form-col-sm">{renderNumberField('planningWorkQuantity', 'm2', false)}</div>
       </div>
       <div className="form-row">
         <div className="form-col-sm">
-          {renderNumberField('constructionCostForecast', "keur", true)}
+          {renderNumberField('constructionCostForecast', 'keur', true)}
         </div>
         <div className="form-col-lg">
           {renderSelectField('constructionPhase', constructionPhases, undefined, true)}
         </div>
         <div className="form-col-sm">
-          {renderNumberField('constructionWorkQuantity', "m2", false)}
+          {renderNumberField('constructionWorkQuantity', 'm2', false)}
         </div>
       </div>
       <ListField
@@ -124,7 +119,13 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
         disabled={isInputDisabled}
         readOnly={isUserOnlyViewer}
         fields={[
-          { ...getFieldProps('costForecast'), rules: validateMaxLength(15, t) },
+          {
+            ...getFieldProps('costForecast'),
+            rules: {
+              ...validateMaxLength(15, t),
+              ...validateInteger(t),
+            },
+          },
           {
             ...getFieldProps('realizedCost'),
             readOnly: true,
@@ -144,7 +145,7 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
         cancelEdit={isSaving}
       />
 
-      <OverrunRightField control={control} cancelEdit={isSaving} readOnly={isUserOnlyViewer}/>
+      <OverrunRightField control={control} cancelEdit={isSaving} readOnly={isUserOnlyViewer} />
       <ListField
         {...getFieldProps('preliminaryBudgetDivision')}
         readOnly={true}

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -107,6 +107,7 @@
     "isBefore": "Aika on oltava ennen kuin {{value}}",
     "isAfter": "Aika on oltava myöhemmin kuin {{value}}",
     "maxLength": "Maksimipituus on {{value}} merkkiä",
+    "wholeNumber": "Anna kokonaisluku",
     "minValue": "Arvon on oltava vähintään {{value}}",
     "maxValue": "Arvon on oltava enintään {{value}}",
     "requiredFor": "'{{requiredField}}' on pakollinen kun '{{field}}' on '{{value}}'",

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -7,9 +7,8 @@ import {
 } from '@/interfaces/planningInterfaces';
 import { IProject } from '@/interfaces/projectInterfaces';
 
-// Formats a number to include thousand sepparators and rounds it to a whole number
-export const formatNumber = (number: number | undefined) =>
-  Math.round(number ?? 0).toLocaleString('fi-FI');
+// Formats a number to include thousand sepparators
+export const formatNumber = (number: number | undefined) => number?.toLocaleString('fi-FI') ?? '0';
 
 // Turns a formatted number string to a number
 export const formattedNumberToNumber = (formattedNumber?: string) => {

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -7,8 +7,9 @@ import {
 } from '@/interfaces/planningInterfaces';
 import { IProject } from '@/interfaces/projectInterfaces';
 
-// Formats a number to include thousand sepparators
-export const formatNumber = (number: number | undefined) => number?.toLocaleString('fi-FI') ?? '0';
+// Formats a number to include thousand sepparators and rounds it to a whole number
+export const formatNumber = (number: number | undefined) =>
+  Math.round(number ?? 0).toLocaleString('fi-FI');
 
 // Turns a formatted number string to a number
 export const formattedNumberToNumber = (formattedNumber?: string) => {
@@ -16,7 +17,7 @@ export const formattedNumberToNumber = (formattedNumber?: string) => {
     return 0;
   }
   // The character U+2212 is compared intentional here, since the number is formatted with toLocaleString('fi-FI')
-  if (['−','-'].includes(formattedNumber.trim()[0])) {
+  if (['−', '-'].includes(formattedNumber.trim()[0])) {
     return -parseInt(formattedNumber.trim().replace(/\D/g, ''));
   } else {
     return parseInt(formattedNumber.trim().replace(/\D/g, ''));
@@ -182,7 +183,7 @@ export const calcPercentage = (value: number, total: number) => Math.round((valu
 export const keurToMillion = (value?: string | null | number) => {
   if (!value) return '0,0';
 
-  const valueAsNumber = typeof(value) !== "number" ? parseFloat(value.replace(/\s/g, '')) : value;
+  const valueAsNumber = typeof value !== 'number' ? parseFloat(value.replace(/\s/g, '')) : value;
   const millionValue = (valueAsNumber / 1000).toFixed(1);
 
   return millionValue.toString().replace('.', ',');
@@ -193,7 +194,8 @@ const roundUp = (number: number) => (number / 1000).toFixed(2);
 // Specifically for budgetBookSummaryReport
 export const convertToMillions = (value?: string | number): string => {
   if (!value) return '0.00';
-  const valueWithCorrectType: number = typeof value === 'string' ? Number(value.replace(/\s/g, '')): value;
+  const valueWithCorrectType: number =
+    typeof value === 'string' ? Number(value.replace(/\s/g, '')) : value;
   const rounded = roundUp(valueWithCorrectType);
   return String(rounded);
 };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -14,6 +14,12 @@ export const validateMaxLength = (
   maxLength: { value: value, message: t('validation.maxLength', { value: value }) },
 });
 
+export const validateInteger = (t: TFunction<'translation', undefined, 'translation'>) => ({
+  validate: {
+    isInteger: (value: string | number) =>
+      Number.isInteger(Number(value)) ? true : t('validation.wholeNumber'),
+  },
+});
 export const validateRequired = (
   field: string,
   t: TFunction<'translation', undefined, 'translation'>,


### PR DESCRIPTION
**Removed**: Fixed round cost estimate budget number to remove decimal. Original problem solved via backend.
**Added**: Validation for costForecast added, only whole numbers are now allowed
<img width="582" alt="image" src="https://github.com/user-attachments/assets/061f5854-2c81-459d-8846-071a729fd60b">
