### PR TITLE
HKISD-159: fix groupDialog project search and showing projects in hierarchy

### DIFF
--- a/src/components/Planning/GroupDialog/GroupProjectSearch.tsx
+++ b/src/components/Planning/GroupDialog/GroupProjectSearch.tsx
@@ -64,9 +64,13 @@ const GroupProjectSearch: FC<IProjectSearchProps> = ({
   useEffect(() => {
       const lowerCaseSearchWord = searchWord.toLowerCase();
       const groupSubDivision = getValues('subDivision.value');
-      const groupDivision = getValues('division.value');
       const groupDivisionName = getValues('division.label');
-      const groupDistrict = getValues('district.value');
+      // If selected groupDivision is Eri kaupunginosia (= Different divisions) it means that there is no specific division selected
+      // and the search should work as if there's no division selected
+      const groupDivision = groupDivisionName === "Eri kaupunginosia" ? undefined : getValues('division.value');
+      const groupDistrictName = getValues('district.label');
+      // If selected groupDistrict is Eri suurpiirejä (= Different districts) it's the same as if there was no groupDivision selected
+      const groupDistrict = groupDistrictName === "Eri suurpiirejä" ? undefined : getValues('district.value');
       const groupSubClass = getValues('subClass.value');
       const groupClass = getValues('class.value');
       const projectsForSubmitIds = getValues('projectsForSubmit').map(project => project.value);
@@ -80,8 +84,7 @@ const GroupProjectSearch: FC<IProjectSearchProps> = ({
           getLocationParent(projectDivisions, getLocationParent(projectSubDivisions, project.projectDistrict)) === groupDivision;
         const divisionMatches = 
           project.projectDistrict === groupDivision ||
-          getLocationParent(projectSubDivisions, project.projectDistrict) === groupDivision ||
-          (groupDivisionName === "Eri kaupunginosia" && districtMatches);
+          getLocationParent(projectSubDivisions, project.projectDistrict) === groupDivision;
         const subDivisionMatches = project.projectDistrict === groupSubDivision;
         const projectNotSelectedAlready = !projectsForSubmitIds.includes(project.id);
   

--- a/src/utils/planningRowUtils.ts
+++ b/src/utils/planningRowUtils.ts
@@ -203,7 +203,7 @@ export const fetchProjectsByRelation = async (
   year: number,
   isCoordinator?: boolean,
 ): Promise<Array<IProject>> => {
-  const direct = type === 'class' || type === 'subClass' || type === 'subClassDistrict';
+  const direct = type === 'class' || type === 'subClassDistrict';
   try {
     const allResults = await getProjectsWithParams(
       {


### PR DESCRIPTION
- changed the logic of GroupDialog's project search so that if "Eri suurpiirejä" is selected as the district it's the same as if no district was selected
- same for "Eri kaupunginosia" but with division
- changed the logic of fetching projects for the planning view so that projects don't have to be directly under subClass to be fetched to enable showing projects with location information under subClasses when they are inside a group without location information that is under a subClass.