### PR TITLE
fix: add a new and update existing hierarchy colours on strategy report

### DIFF
--- a/src/components/Report/PdfReports/TableRow.tsx
+++ b/src/components/Report/PdfReports/TableRow.tsx
@@ -257,6 +257,16 @@ const strategyReportStyles = StyleSheet.create({
     backgroundColor: '#00007a',
     color: 'white',
   },
+  subLevelDistrict: {
+    ...tableRowStyles,
+    backgroundColor: '#00005e',
+    color: 'white',
+  },
+  collectiveSubLevel: {
+    ...tableRowStyles,
+    backgroundColor: '#00005e',
+    color: 'white',
+  },
   districtPreviewRow: {
     ...tableRowStyles,
     backgroundColor: '#00005e',
@@ -359,18 +369,22 @@ const getMonthCellStyle = (monthCell: string | undefined, side: string) => {
 
 const getStrategyRowStyle = (rowType: string, depth: number) => {
   switch (rowType) {
-      case 'masterClass':
-        return strategyReportStyles.masterClassRow;
-      case 'class':
-        return strategyReportStyles.classRow;
-      case 'subClass':
-        return strategyReportStyles.subClassRow;
-      case 'subClassDistrict':
-        return strategyReportStyles.subClassDistrictRow;
-      case 'districtPreview':
-        return strategyReportStyles.districtPreviewRow;
-      case 'group':
-        return strategyReportStyles.groupRow;
+    case 'masterClass':
+      return strategyReportStyles.masterClassRow;
+    case 'class':
+      return strategyReportStyles.classRow;
+    case 'subClass':
+      return strategyReportStyles.subClassRow;
+    case 'subClassDistrict':
+      return strategyReportStyles.subClassDistrictRow;
+    case 'subLevelDistrict':
+      return strategyReportStyles.subLevelDistrict;
+    case 'collectiveSubLevel':
+      return strategyReportStyles.collectiveSubLevel;
+    case 'districtPreview':
+      return strategyReportStyles.districtPreviewRow;
+    case 'group':
+      return strategyReportStyles.groupRow;
     default:
       if (depth % 2) return strategyReportStyles.evenRow;
       return strategyReportStyles.oddRow;
@@ -408,11 +422,12 @@ const Row: FC<IRowProps> = memo(({ flattenedRow, index, reportType }) => {
     let tableRow;
     switch (reportType) {
         case Reports.Strategy: {
-            if (flattenedRow) {
+          const classNameTypes = ['masterClass', 'class', 'subClass', 'subClassDistrict', 'subLevelDistrict', 'collectiveSubLevel', 'districtPreview', 'group']
+          if (flattenedRow) {
               tableRow =
                 <View wrap={false} style={getStrategyRowStyle(flattenedRow.type ?? '', index ?? 0)} key={flattenedRow.id}>
                     <Text style={
-                      ['masterClass', 'class', 'subClass', 'subClassDistrict', 'districtPreview', 'group'].includes(flattenedRow.type ?? '')
+                      classNameTypes.includes(flattenedRow.type ?? '')
                       ? strategyReportStyles.classNameCell
                       : strategyReportStyles.projectCell}>
                         {flattenedRow.name}

--- a/src/components/Report/PdfReports/TableRow.tsx
+++ b/src/components/Report/PdfReports/TableRow.tsx
@@ -267,6 +267,11 @@ const strategyReportStyles = StyleSheet.create({
     backgroundColor: '#00005e',
     color: 'white',
   },
+  otherClassification: {
+    ...tableRowStyles,
+    backgroundColor: '#00005e',
+    color: 'white',
+  },
   districtPreviewRow: {
     ...tableRowStyles,
     backgroundColor: '#00005e',
@@ -381,6 +386,8 @@ const getStrategyRowStyle = (rowType: string, depth: number) => {
       return strategyReportStyles.subLevelDistrict;
     case 'collectiveSubLevel':
       return strategyReportStyles.collectiveSubLevel;
+    case 'otherClassification':
+      return strategyReportStyles.otherClassification;
     case 'districtPreview':
       return strategyReportStyles.districtPreviewRow;
     case 'group':
@@ -422,7 +429,18 @@ const Row: FC<IRowProps> = memo(({ flattenedRow, index, reportType }) => {
     let tableRow;
     switch (reportType) {
         case Reports.Strategy: {
-          const classNameTypes = ['masterClass', 'class', 'subClass', 'subClassDistrict', 'subLevelDistrict', 'collectiveSubLevel', 'districtPreview', 'group']
+          const classNameTypes = [
+            'masterClass',
+            'class',
+            'subClass',
+            'subClassDistrict',
+            'subLevelDistrict',
+            'collectiveSubLevel',
+            'otherClassification',
+            'districtPreview',
+            'group'
+          ]
+
           if (flattenedRow) {
               tableRow =
                 <View wrap={false} style={getStrategyRowStyle(flattenedRow.type ?? '', index ?? 0)} key={flattenedRow.id}>

--- a/src/components/Report/PdfReports/TableRow.tsx
+++ b/src/components/Report/PdfReports/TableRow.tsx
@@ -403,6 +403,8 @@ const getConstructionRowStyle = (rowType: string, depth: number) => {
     case 'masterClass':
       return styles.masterClassRow;
     case 'class':
+    case 'otherClassification':
+    case 'collectiveSubLevel':
       return styles.classRow;
     case 'subClass':
       return styles.subClassRow;
@@ -526,13 +528,24 @@ const Row: FC<IRowProps> = memo(({ flattenedRow, index, reportType }) => {
           // Programming view (hierarchy) colours for class rows
           // We also hide all rows that names are empty, such as old budget item '8 01 Kiinteä omaisuus/Esirakentaminen'
         if (flattenedRow && (flattenedRow.name !== '' || flattenedRow.type === 'empty')) {
+          const classNameTypes = [
+            'masterClass',
+            'class',
+            'subClass',
+            'subClassDistrict',
+            'collectiveSubLevel',
+            'otherClassification',
+            'districtPreview',
+            'info'
+          ]
+
           tableRow =
             <View
               wrap={false}
               style={ getConstructionRowStyle(flattenedRow.type ?? '', index ?? 0 )}
               key={flattenedRow.id}
             >
-              <Text style={['masterClass', 'class', 'subClass', 'subClassDistrict', 'districtPreview', 'info'].includes(flattenedRow.type)
+              <Text style={classNameTypes.includes(flattenedRow.type)
                 ? styles.classNameCell
                 : styles.nameCell}
               >{flattenedRow.name}</Text>
@@ -556,7 +569,7 @@ const Row: FC<IRowProps> = memo(({ flattenedRow, index, reportType }) => {
 
               let defaultStyle;
 
-              if (flattenedRow.type === 'class' || flattenedRow.type === 'investmentpart') {
+              if (['class', 'otherClassification', 'collectiveSubLevel'].includes(flattenedRow.type) || flattenedRow.type === 'investmentpart') {
                   defaultStyle = styles.classNameTargetCell;
               } else {
                   defaultStyle = styles.nameTargetCell;

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -96,6 +96,7 @@ export type ReportTableRowType =
   | 'districtPreview'
   | 'subLevelDistrict'
   | 'collectiveSubLevel'
+  | 'otherClassification'
   | 'changePressure'
   | 'taeFrame'
   | 'division'

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -94,6 +94,8 @@ export type ReportTableRowType =
   | 'group'
   | 'groupWithValues'
   | 'districtPreview'
+  | 'subLevelDistrict'
+  | 'collectiveSubLevel'
   | 'changePressure'
   | 'taeFrame'
   | 'division'

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -470,16 +470,6 @@ const getBudgetBookSummaryProperties = (coordinatorRows: IPlanningRow[]) => {
   return properties;
 }
 
-const getStrategyRowType = (type: string) => {
-  switch (type) {
-    case 'class':
-    case 'otherClassification':
-      return 'class';
-    default:
-      return type;
-  }
-}
-
 const getConstructionRowType = (type: string, name: string) => {
   switch (type) {
     case 'masterClass':
@@ -678,7 +668,7 @@ export const convertToReportRows = (
             projects: c.projectRows.length ? convertToReportProjects(c.projectRows) : [],
             costForecast: c.cells[0].plannedBudget,
             costPlan: frameBudget,
-            type: getStrategyRowType(c.type) as ReportTableRowType
+            type: c.type as ReportTableRowType
           }
           if (convertedClass.type !== 'group' || convertedClass.projects.length) {
             forcedToFrameHierarchy.push(convertedClass);

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -474,7 +474,6 @@ const getStrategyRowType = (type: string) => {
   switch (type) {
     case 'class':
     case 'otherClassification':
-    case 'collectiveSubLevel':
       return 'class';
     default:
       return type;


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-207

The strategy report has style issues. The hierarchy level "sublevel district" had an incorrect color, and the "collective sublevel" color was missing. This PR fixes the colors to be the same as on the hierarchy view.