### PR TITLE
HKISD-208: feat add waiting for name in strategy report if project manager is not named

### DIFF
--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -463,7 +463,8 @@
       "projectManagerTitle": "projektipäällikkö",
       "footerInfoText": "s = suunnittelu, r = rakentaminen",
       "planning": "Suunnittelu",
-      "constructing": "Rakentaminen"
+      "constructing": "Rakentaminen",
+      "projectManagerMissing": "Odottaa nimeämistä"
     },
     "constructionProgram": {
       "rowTitle": "Rakentamisohjelma (yli 1 milj hankkeet)",

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -273,7 +273,7 @@ const convertToReportProjects = (projects: IProject[]): IStrategyTableRow[] => {
       children: [],
       costPlan: "",                                                                   // TA value "raamiluku". Will not be shown for projects.
       costForecast: split(p.finances.budgetProposalCurrentYearPlus0, ".")[0] ?? "",   // TS value
-      projectManager: p.personPlanning?.lastName ?? "",
+      projectManager: p.personPlanning?.lastName ?? "Odottaa nimeämistä",
       projectPhase: getProjectPhase(p),
       januaryStatus: getProjectPhasePerMonth(p, 1),
       februaryStatus: getProjectPhasePerMonth(p,2),

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -273,7 +273,7 @@ const convertToReportProjects = (projects: IProject[]): IStrategyTableRow[] => {
       children: [],
       costPlan: "",                                                                   // TA value "raamiluku". Will not be shown for projects.
       costForecast: split(p.finances.budgetProposalCurrentYearPlus0, ".")[0] ?? "",   // TS value
-      projectManager: p.personPlanning?.lastName ?? "Odottaa nimeämistä",
+      projectManager: p.personPlanning?.lastName ?? (t('report.strategy.projectManagerMissing') as string),
       projectPhase: getProjectPhase(p),
       januaryStatus: getProjectPhasePerMonth(p, 1),
       februaryStatus: getProjectPhasePerMonth(p,2),


### PR DESCRIPTION
- If project has not named planning person ("vastuuhenkilö"), in strategy report (toimintasuunnitelma) there will be text "Odottaa nimeämistä" (waiting for naming) in project manager column in strategy report. Previously those were empty if responsible person was not named. 