### PR TITLE
fix: HKISD-213 add districtPreview and collectiveSubLevel to frameBud…

### DIFF
--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -630,13 +630,15 @@ const getUnderMillionSummary = (rows: IConstructionProgramTableRow[]) => {
  * Shows current year cost estimated budget (TA, "raamiluku") on
  * Strategy report for high level classes only.
  */
-const frameBudgetHandler = (type: string, budgets: IPlanningCell[]) => {
-  if (['masterClass', 'class', 'subClass', 'subClassDistrict'].includes(type)) {
-    const budget = budgets.find(obj => obj.year === new Date().getFullYear() + 1);
-    return budget ? budget.displayFrameBudget : "";
-  }
+const frameBudgetHandler = (type: string, budgets: IPlanningCell[], path: string) => {
+  const allowedTypes = ['masterClass', 'class', 'subClass', 'subClassDistrict', 'districtPreview', 'collectiveSubLevel']
 
-  return "";
+  if (!allowedTypes.includes(type)) return ""
+  
+  if (type === 'collectiveSubLevel' && !path.startsWith('803')) return ""
+
+  const budget = budgets.find(obj => obj.year === new Date().getFullYear() + 1);
+  return budget ? budget.displayFrameBudget : "";
 }
 
 export const convertToReportRows = (
@@ -658,7 +660,7 @@ export const convertToReportRows = (
     case Reports.Strategy: {
       const forcedToFrameHierarchy: IStrategyTableRow[] = [];
       for (const c of rows) {
-        const frameBudget = frameBudgetHandler(c.type, c.cells);
+        const frameBudget = frameBudgetHandler(c.type, c.cells, c.path);
         if ((c.cells[0].displayFrameBudget != '0' || c.cells[0].isFrameBudgetOverlap) || c.cells[0].plannedBudget != '0') {
           const convertedClass = {
             id: c.id,


### PR DESCRIPTION
### About
This PR adds new types to frameBudgetHandler. 

Problem was that certain rows in report with these types had no frameBudget numbers in strategy report (toimintasuunnitelma). Adding types of those to frameBudgetHandler helps.

For the type "collectiveSubLevel" there needs to be check for path to start with 803, because outside that path, it's wanted that collectiveSubLevel types are not showing frameBudgetNumbers in strategy report. 

### Testing
1. Upload strategy report (toimintasuunnitelma). Find path 8 03 01 01 and under that "A Eteläinen suurpiiri". Previously it did not have frame budget numbers. Now there's number in column TA 2025. This was type of "previewDistrict".

2. From strategy report find path 8 04 01 02 and under that “Uudet liikuntapuistot” and “Uudet liikuntapaikat ja kentät”. Type of these is "collectiveSubLevel" but frameBudget should not be shown for these, because path does not start with 803. 

To check that this applies (copied from ticket): 
Uudisrakentamisen alta A-H (8 03 01 01), Perusparantaminen ja liikennejärjestelyt alta A-F (8 03 01 02), Muut investoinnit alta A-D (8 03 01 03) kohdista raamiluvut tulee löytyä. 