### PR TITLE
IO-403 & IO-353/forced to frame admin view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import AccessDeniedView from './views/AccessDeniedView';
 import { isUserOnlyViewer } from './utils/userRoleHelpers';
 import MaintenanceView from './views/Maintenance';
 import { AppDispatch } from './store';
+import AdminForcedToFrame from './components/Admin/AdminForcedToFrame/AdminForcedToFrame';
 
 const LOADING_APP_ID = 'loading-app-data';
 
@@ -158,6 +159,7 @@ const App: FC = () => {
               <Route path="/admin" element={<AdminView />}>
                 <Route path="functions" element={<AdminFunctions />} />
                 <Route path="hashtags" element={<AdminHashtags />} />
+                <Route path="forcedtoframestate" element={<AdminForcedToFrame />} />
               </Route>
               <Route path="/access-denied" element={<AccessDeniedView />} />
               <Route path="/auth/helsinki/return" element={<></>}></Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import { isUserOnlyViewer } from './utils/userRoleHelpers';
 import MaintenanceView from './views/Maintenance';
 import { AppDispatch } from './store';
 import AdminForcedToFrame from './components/Admin/AdminForcedToFrame/AdminForcedToFrame';
+import { getAppStateValuesThunk } from './reducers/appStateValueSlice';
 
 const LOADING_APP_ID = 'loading-app-data';
 
@@ -104,7 +105,8 @@ const App: FC = () => {
     try {
       await dispatch(getListsThunk());
       await dispatch(getHashTagsThunk());
-      await dispatch(getCoordinatorNotesThunk())
+      await dispatch(getCoordinatorNotesThunk());
+      await dispatch(getAppStateValuesThunk());
     } catch (e) {
       console.log('Error getting app data: ', e);
       dispatch(notifyError({ message: 'appDataError', type: 'notification', title: '500' }));

--- a/src/components/Admin/AdminForcedToFrame/AdminForcedToFrame.tsx
+++ b/src/components/Admin/AdminForcedToFrame/AdminForcedToFrame.tsx
@@ -1,9 +1,50 @@
+import { useAppDispatch, useAppSelector } from "@/hooks/common";
+import { IForcedToFrameState, selectForcedToFrameState, setForcedToFrameState } from "@/reducers/appStateValueSlice";
+import { postOrPatchAppStateValue } from "@/services/appStateValueServices";
+import { Button, Fieldset, ToggleButton } from "hds-react";
 import { memo } from "react";
+import { useTranslation } from "react-i18next";
 
 const AdminForcedToFrame = () => {
+    const { t } = useTranslation();
+    const dispatch = useAppDispatch();
+    const forcedToFrameState = useAppSelector(selectForcedToFrameState);
+    
     return (
         <div data-testid="admin-forcedtoframe">
-
+            <Fieldset border heading={t(`adminFunctions.forcedtoframestate.viewState`) ?? ''} style={{ display: "flex", flexDirection: "row", gap: "60px"}}>
+                <div>
+                    <p style={{fontWeight: "bold"}}>Tila</p>
+                    <p>Lukittu</p>
+                </div>
+                <div>
+                    <p style={{fontWeight: "bold"}}>Tilaa viimeksi muokattu</p>
+                    <p>18.10.2024 klo. 11:01</p>
+                </div>
+                <div>
+                    <p style={{fontWeight: "bold"}}>Avaa sovitettu budjetti -näkymä</p>
+                    <ToggleButton id={""} label={undefined} checked={forcedToFrameState.isOpen} onChange={function (isOn: boolean): void {
+                        const request = {
+                            name: "forcedToFrameStatus",
+                            value: !forcedToFrameState.isOpen,
+                            id: forcedToFrameState.id !== "" ? forcedToFrameState.id : undefined
+                        }
+                        postOrPatchAppStateValue(request);
+                        const newValues: IForcedToFrameState = {
+                            ...forcedToFrameState,
+                            isOpen: !forcedToFrameState.isOpen
+                        };
+                        dispatch(setForcedToFrameState(newValues))
+                    }}></ToggleButton>
+                </div>
+            </Fieldset>
+            <Fieldset border heading={t(`adminFunctions.forcedtoframestate.moveData`) ?? ''} style={{ display: "flex", flexDirection: "row", gap: "60px", marginTop: "30px"}}>
+                <div>
+                    <p style={{fontWeight: "bold"}}>Tiedot viimeksi siirretty</p>
+                    <p>18.10.2024 klo. 11:01</p>
+                </div>
+                <Button style={{height: "50%", marginTop: "14px"}}>Siirrä tiedot</Button>
+            </Fieldset>
         </div>
     );
 }

--- a/src/components/Admin/AdminForcedToFrame/AdminForcedToFrame.tsx
+++ b/src/components/Admin/AdminForcedToFrame/AdminForcedToFrame.tsx
@@ -1,0 +1,11 @@
+import { memo } from "react";
+
+const AdminForcedToFrame = () => {
+    return (
+        <div data-testid="admin-forcedtoframe">
+
+        </div>
+    );
+}
+
+export default memo(AdminForcedToFrame);

--- a/src/components/Admin/AdminForcedToFrame/AdminForcedToFrame.tsx
+++ b/src/components/Admin/AdminForcedToFrame/AdminForcedToFrame.tsx
@@ -1,7 +1,9 @@
 import { useAppDispatch, useAppSelector } from "@/hooks/common";
 import { IForcedToFrameState, selectForcedToFrameState, setForcedToFrameState } from "@/reducers/appStateValueSlice";
+import { setIsSaving } from "@/reducers/projectSlice";
 import { postOrPatchAppStateValue } from "@/services/appStateValueServices";
 import { Button, Fieldset, ToggleButton } from "hds-react";
+import moment from "moment";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -9,41 +11,48 @@ const AdminForcedToFrame = () => {
     const { t } = useTranslation();
     const dispatch = useAppDispatch();
     const forcedToFrameState = useAppSelector(selectForcedToFrameState);
+    const forcedToFrameUpdatedDate = moment(new Date(forcedToFrameState.lastModified)).format('D.M.YYYY HH:mm:ss');
+
+    const handleForcedToFrameStatusChange = async () => {
+        setIsSaving(true);
+        const request = {
+            name: "forcedToFrameStatus",
+            value: !forcedToFrameState.isOpen,
+            id: forcedToFrameState.id !== "" ? forcedToFrameState.id : undefined
+        }
+        const response = await postOrPatchAppStateValue(request);
+        const newValues: IForcedToFrameState = {
+            ...forcedToFrameState,
+            id: response.id,
+            isOpen: response.value,
+            lastModified: response.updatedDate
+        };
+        dispatch(setForcedToFrameState(newValues));
+        setIsSaving(false);
+    }
     
     return (
         <div data-testid="admin-forcedtoframe">
             <Fieldset border heading={t(`adminFunctions.forcedtoframestate.viewState`) ?? ''} style={{ display: "flex", flexDirection: "row", gap: "60px"}}>
                 <div>
-                    <p style={{fontWeight: "bold"}}>Tila</p>
-                    <p>Lukittu</p>
+                    <p style={{fontWeight: "bold"}}>{t(`status`)}</p>
+                    <p>{forcedToFrameState.isOpen ? t(`adminFunctions.forcedtoframestate.open`): t(`adminFunctions.forcedtoframestate.locked`)}</p>
                 </div>
                 <div>
-                    <p style={{fontWeight: "bold"}}>Tilaa viimeksi muokattu</p>
-                    <p>18.10.2024 klo. 11:01</p>
+                    <p style={{fontWeight: "bold"}}>{t(`adminFunctions.forcedtoframestate.lastModified`)}</p>
+                    <p>{forcedToFrameUpdatedDate}</p>
                 </div>
                 <div>
-                    <p style={{fontWeight: "bold"}}>Avaa sovitettu budjetti -näkymä</p>
-                    <ToggleButton id={""} label={undefined} checked={forcedToFrameState.isOpen} onChange={function (isOn: boolean): void {
-                        const request = {
-                            name: "forcedToFrameStatus",
-                            value: !forcedToFrameState.isOpen,
-                            id: forcedToFrameState.id !== "" ? forcedToFrameState.id : undefined
-                        }
-                        postOrPatchAppStateValue(request);
-                        const newValues: IForcedToFrameState = {
-                            ...forcedToFrameState,
-                            isOpen: !forcedToFrameState.isOpen
-                        };
-                        dispatch(setForcedToFrameState(newValues))
-                    }}></ToggleButton>
+                    <p style={{fontWeight: "bold"}}>{t(`adminFunctions.forcedtoframestate.changeStatus`)}</p>
+                    <ToggleButton id={""} label={undefined} checked={forcedToFrameState.isOpen} onChange={handleForcedToFrameStatusChange}></ToggleButton>
                 </div>
             </Fieldset>
             <Fieldset border heading={t(`adminFunctions.forcedtoframestate.moveData`) ?? ''} style={{ display: "flex", flexDirection: "row", gap: "60px", marginTop: "30px"}}>
                 <div>
-                    <p style={{fontWeight: "bold"}}>Tiedot viimeksi siirretty</p>
+                    <p style={{fontWeight: "bold"}}>{t(`adminFunctions.forcedtoframestate.dataLastUpdated`)}</p>
                     <p>18.10.2024 klo. 11:01</p>
                 </div>
-                <Button style={{height: "50%", marginTop: "14px"}}>Siirrä tiedot</Button>
+                <Button style={{height: "50%", marginTop: "14px"}}>{t(`adminFunctions.forcedtoframestate.updateData`)}</Button>
             </Fieldset>
         </div>
     );

--- a/src/components/Admin/AdminForcedToFrame/AdminForcedToFrame.tsx
+++ b/src/components/Admin/AdminForcedToFrame/AdminForcedToFrame.tsx
@@ -66,14 +66,7 @@ const AdminForcedToFrame = () => {
                 }),
             );
         } catch (e) {
-            dispatch(
-                notifyError({
-                    message: 'forcedToFrameDataUpdateError',
-                    title: 'patchError',
-                    type: 'toast',
-                    duration: 5000,
-                }),
-            );
+            dispatch(notifyError({ message: 'forcedToFrameDataUpdateError', type: 'notification', title: 'patchError' }));
         }
         dispatch(clearLoading("update-forced-to-frame-data"));
     }

--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningCell.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningCell.tsx
@@ -112,6 +112,7 @@ const PlanningCell: FC<IPlanningCellProps> = ({ type, id, cell, name }) => {
             frameBudget: valueToPatch,
           },
         },
+        forcedToFrame: forcedToFrame
       },
     };
 

--- a/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/PlanningForecastSums.tsx
@@ -87,6 +87,7 @@ const PlanningForecastSums: FC<IPlanningForecastSums> = ({ type, id, cell, sapCo
             budgetChange: parsedValue,
           },
         },
+        forcedToFrame: forcedToFrame
       },
     };
     patchCoordinationClass(request);

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -516,7 +516,9 @@
     "forcedtoframestate": {
       "name": "Sovitettu budjetti -näkymän hallinta",
       "description": "Sulje tai avaa sovitettu budjetti. Lataa tiedot koordinointinäkymästä sovitettu budjetti -näkymään.",
-      "button": "Hallitse sovitettu budjetti -näkymää"
+      "button": "Hallitse sovitettu budjetti -näkymää",
+      "viewState": "Sovitettu budjetti -näkymän tila",
+      "moveData": "Tietojen siirto sovitettu budjetti -näkymään"
     }
   },
   "projectCount": "Projektien määrä",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -512,6 +512,11 @@
       "name": "Tilinpäätös",
       "description": "Päätä edellinen vuosi ja lukitse tilinpäätös.",
       "button": "Lukitse tilinpäätös tästä"
+    },
+    "forcedtoframestate": {
+      "name": "Sovitettu budjetti -näkymän hallinta",
+      "description": "Sulje tai avaa sovitettu budjetti. Lataa tiedot koordinointinäkymästä sovitettu budjetti -näkymään.",
+      "button": "Hallitse sovitettu budjetti -näkymää"
     }
   },
   "projectCount": "Projektien määrä",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -274,7 +274,8 @@
       "undefined": "Virhe",
       "noteAddSuccess": "Muistiinpano lisätty",
       "noteAddError": "Muistiinpanon lisääminen epäonnistui",
-      "update": "Päivitys"
+      "update": "Päivitys",
+      "updateSuccessful": "Tietojen siirto onnistui"
     },
     "message": {
       "projectUpdated": "Hankkeen tietoja päivitettiin",
@@ -300,7 +301,10 @@
       "financeChangeError": "Haluamasi muutos budjettiin vaatii lisää tietoja hankekorttiin. Tee muutos hankekortilla.",
       "frameBudgetError": "Raamibudjetti ei voi olla negatiivinen.",
       "Network Error": "Verkkovirhe",
-      "accessError": "Käyttäjälläsi ei ole oikeutta suorittaa toimintoa."
+      "accessError": "Käyttäjälläsi ei ole oikeutta suorittaa toimintoa.",
+      "forcedToFrameUpdated": "Koordinointinäkymän tiedot siirrettiin onnistuneesti Sovitettu budjetti -näkymään.",
+      "forcedToFrameDataUpdateError": "Tietojen päivityksessä Sovitettu budjetti -näkymään tapahtui virhe.",
+      "forcedToFrameStatusUpdateError": "Sovitettu budjetti -näkymän tilan vaihtamisessa tapahtui virhe."
     }
   },
   "searchOrder": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -518,7 +518,13 @@
       "description": "Sulje tai avaa sovitettu budjetti. Lataa tiedot koordinointinäkymästä sovitettu budjetti -näkymään.",
       "button": "Hallitse sovitettu budjetti -näkymää",
       "viewState": "Sovitettu budjetti -näkymän tila",
-      "moveData": "Tietojen siirto sovitettu budjetti -näkymään"
+      "moveData": "Tietojen siirto sovitettu budjetti -näkymään",
+      "lastModified": "Tilaa viimeksi muokattu",
+      "changeStatus": "Vaihda tilan status",
+      "dataLastUpdated": "Tiedot viimeksi siirretty",
+      "updateData": "Siirrä tiedot",
+      "open": "Auki",
+      "locked": "Lukittu"
     }
   },
   "projectCount": "Projektien määrä",

--- a/src/interfaces/adminInterfaces.ts
+++ b/src/interfaces/adminInterfaces.ts
@@ -1,3 +1,3 @@
-export const adminFunctions = ['hashtags', 'menus', 'auditlog', 'financialstatements'] as const;
+export const adminFunctions = ['hashtags', 'menus', 'auditlog', 'financialstatements', 'forcedtoframestate'] as const;
 
 export type AdminFunctionType = (typeof adminFunctions)[number];

--- a/src/interfaces/classInterfaces.ts
+++ b/src/interfaces/classInterfaces.ts
@@ -49,5 +49,6 @@ export interface IClassPatchRequest {
       year9?: IClassBudgets;
       year10?: IClassBudgets;
     };
+    forcedToFrame: boolean;
   };
 }

--- a/src/reducers/appStateValueSlice.ts
+++ b/src/reducers/appStateValueSlice.ts
@@ -8,14 +8,16 @@ export interface IForcedToFrameState {
     isOpen: boolean,
     lastModified: string
 }
+
+export interface IForcedToFrameDataUpdated {
+    id: string,
+    hasBeenMoved: boolean,
+    lastModified: string
+}
  
 export interface IAppStateValues {
     forcedToFrameState: IForcedToFrameState
-    coordinationDataMoved: {
-        id: string,
-        hasBeenMoved: boolean,
-        lastModified: string
-    }
+    forcedToFrameDataUpdated: IForcedToFrameDataUpdated
 }
 
 const initialState: IAppStateValues = {
@@ -24,7 +26,7 @@ const initialState: IAppStateValues = {
         isOpen: false,
         lastModified: "",
     },
-    coordinationDataMoved: {
+    forcedToFrameDataUpdated: {
         id: "",
         hasBeenMoved: false,
         lastModified: ""
@@ -44,12 +46,25 @@ const getForcedToFrameState = (appStateValues: Array<any>): IForcedToFrameState 
     return initialState.forcedToFrameState;
 }
 
+const getForcedToFrameDataUpdated = (appStateValues: Array<any>): IForcedToFrameDataUpdated => {
+    for (const value of appStateValues) {
+        if (value.name === "forcedToFrameDataUpdated") {
+            return {
+                id: value.id,
+                hasBeenMoved: value.value,
+                lastModified: value.updatedDate
+            }
+        }
+    }
+    return initialState.forcedToFrameDataUpdated;
+}
+
 export const getAppStateValuesThunk = createAsyncThunk("appStateValues/get", async (_, thunkAPI) => {
     try {
         const appStateValues = await getAllAppStateValues();
         return {
             forcedToFrameState: getForcedToFrameState(appStateValues),
-            coordinationDataMoved: appStateValues
+            forcedToFrameDataUpdated: getForcedToFrameDataUpdated(appStateValues),
         }
     } catch (err) {
         return thunkAPI.rejectWithValue(err);
@@ -63,6 +78,9 @@ export const appStateValueSlice = createSlice({
         setForcedToFrameState(state, action: PayloadAction<IForcedToFrameState>) {
             return { ...state, forcedToFrameState: action.payload };
           },
+        setForcedToFrameValuesUpdated(state, action: PayloadAction<IForcedToFrameDataUpdated>) {
+            return { ...state, forcedToFrameDataUpdated: action.payload};
+        },
     },
     extraReducers: (builder) => {
         // GET all app state values
@@ -79,10 +97,11 @@ export const appStateValueSlice = createSlice({
 });
 
 export const selectForcedToFrameState = (state: RootState) => state.appStateValues.forcedToFrameState;
-export const selectCoordinationDataMoved = (state: RootState) => state.appStateValues.coordinationDataMoved;
+export const selectForcedToFrameDataUpdtaed = (state: RootState) => state.appStateValues.forcedToFrameDataUpdated;
 
 export const {
     setForcedToFrameState,
+    setForcedToFrameValuesUpdated,
 } = appStateValueSlice.actions;
 
 export default appStateValueSlice.reducer;

--- a/src/reducers/appStateValueSlice.ts
+++ b/src/reducers/appStateValueSlice.ts
@@ -47,7 +47,6 @@ const getForcedToFrameState = (appStateValues: Array<any>): IForcedToFrameState 
 export const getAppStateValuesThunk = createAsyncThunk("appStateValues/get", async (_, thunkAPI) => {
     try {
         const appStateValues = await getAllAppStateValues();
-        console.log(appStateValues)
         return {
             forcedToFrameState: getForcedToFrameState(appStateValues),
             coordinationDataMoved: appStateValues

--- a/src/reducers/appStateValueSlice.ts
+++ b/src/reducers/appStateValueSlice.ts
@@ -1,0 +1,89 @@
+import { IError } from "@/interfaces/common"
+import { getAllAppStateValues } from "@/services/appStateValueServices"
+import { RootState } from "@/store"
+import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit"
+
+export interface IForcedToFrameState {
+    id: string,
+    isOpen: boolean,
+    lastModified: string
+}
+ 
+export interface IAppStateValues {
+    forcedToFrameState: IForcedToFrameState
+    coordinationDataMoved: {
+        id: string,
+        hasBeenMoved: boolean,
+        lastModified: string
+    }
+}
+
+const initialState: IAppStateValues = {
+    forcedToFrameState: {
+        id: "",
+        isOpen: false,
+        lastModified: "",
+    },
+    coordinationDataMoved: {
+        id: "",
+        hasBeenMoved: false,
+        lastModified: ""
+    }
+}
+
+const getForcedToFrameState = (appStateValues: Array<any>): IForcedToFrameState => {
+    for (const value of appStateValues) {
+        if (value.name === "forcedToFrameStatus") {
+            return {
+                id: value.id,
+                isOpen: value.value,
+                lastModified: value.updatedDate
+            }
+        }
+    }
+    return initialState.forcedToFrameState;
+}
+
+export const getAppStateValuesThunk = createAsyncThunk("appStateValues/get", async (_, thunkAPI) => {
+    try {
+        const appStateValues = await getAllAppStateValues();
+        console.log(appStateValues)
+        return {
+            forcedToFrameState: getForcedToFrameState(appStateValues),
+            coordinationDataMoved: appStateValues
+        }
+    } catch (err) {
+        return thunkAPI.rejectWithValue(err);
+    }
+});
+
+export const appStateValueSlice = createSlice({
+    name: 'appStateValues',
+    initialState,
+    reducers: {
+        setForcedToFrameState(state, action: PayloadAction<IForcedToFrameState>) {
+            return { ...state, forcedToFrameState: action.payload };
+          },
+    },
+    extraReducers: (builder) => {
+        // GET all app state values
+        builder.addCase(
+          getAppStateValuesThunk.fulfilled,
+          (state, action: PayloadAction<Omit<IAppStateValues, 'error'>>) => {
+            return { ...state, ...action.payload };
+          },
+        );
+        builder.addCase(getAppStateValuesThunk.rejected, (state, action: PayloadAction<IError | unknown>) => {
+          return { ...state, error: action.payload };
+        });
+      },
+});
+
+export const selectForcedToFrameState = (state: RootState) => state.appStateValues.forcedToFrameState;
+export const selectCoordinationDataMoved = (state: RootState) => state.appStateValues.coordinationDataMoved;
+
+export const {
+    setForcedToFrameState,
+} = appStateValueSlice.actions;
+
+export default appStateValueSlice.reducer;

--- a/src/services/appStateValueServices.ts
+++ b/src/services/appStateValueServices.ts
@@ -15,7 +15,7 @@ export const postOrPatchAppStateValue = async (request: {name: string, value: bo
     try {
         // if value already exists we modify the existing one
         if (request.id) {
-            const res = await axios.patch(`${REACT_APP_API_URL}/app-state-value/`, request);
+            const res = await axios.patch(`${REACT_APP_API_URL}/app-state-value/${request.id}/`, request);
             return res.data;
         // post a new value if there's no existing value
         } else {

--- a/src/services/appStateValueServices.ts
+++ b/src/services/appStateValueServices.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+
+const { REACT_APP_API_URL } = process.env;
+
+export const getAllAppStateValues = async (): Promise<any> => {
+    try {
+        const res = await axios.get(`${REACT_APP_API_URL}/app-state-value/`);
+        return res.data;
+    } catch (e) {
+        return Promise.reject(e);
+    }
+}
+
+export const postOrPatchAppStateValue = async (request: {name: string, value: boolean, id?: string}): Promise<any> => {
+    try {
+        // if value already exists we modify the existing one
+        if (request.id) {
+            const res = await axios.patch(`${REACT_APP_API_URL}/app-state-value/`, request);
+            return res.data;
+        // post a new value if there's no existing value
+        } else {
+            const res = await axios.post(`${REACT_APP_API_URL}/app-state-value/`, request);
+            return res.data;
+        }
+      } catch (e) {
+        return Promise.reject(e);
+      }
+}

--- a/src/services/projectServices.ts
+++ b/src/services/projectServices.ts
@@ -76,6 +76,15 @@ export const patchProjects = async (
   }
 };
 
+export const patchForcedToFrameProjects = async (): Promise<any> => {
+  try {
+    const res = await axios.patch(`${REACT_APP_API_URL}/projects/bulk-update/forced-to-frame/`);
+    return res.data;
+  } catch (e) {
+    return Promise.reject(e);
+  }
+}
+
 export const getProjectsWithParams = async (
   req: IProjectSearchRequest,
   isCoordinator?: boolean,

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,6 +13,7 @@ import groupReducer from './reducers/groupSlice';
 import eventsReducer from './reducers/eventsSlice';
 import planningReducer from './reducers/planningSlice';
 import sapCostReducer from './reducers/sapCostSlice';
+import appStateValuesReducer from './reducers/appStateValueSlice';
 
 // Add slices (reducers) here, this is imported into the test-utils for providing the redux state into tests
 export const storeItems = {
@@ -30,6 +31,7 @@ export const storeItems = {
   events: eventsReducer,
   planning: planningReducer,
   sapCosts: sapCostReducer,
+  appStateValues: appStateValuesReducer,
 };
 
 const rootReducer = combineReducers(storeItems);

--- a/src/views/AdminView/AdminView.test.tsx
+++ b/src/views/AdminView/AdminView.test.tsx
@@ -65,7 +65,7 @@ describe('AdminView', () => {
 
     adminFunctions.forEach((af) => {
       expect(getByTestId(`admin-card-${af}`)).toBeInTheDocument();
-      if (af === 'hashtags') {
+      if (af === 'hashtags' || af === 'forcedtoframestate') {
         expect(getByTestId(`admin-card-button-${af}`)).not.toBeDisabled();
       } else {
         expect(getByTestId(`admin-card-button-${af}`)).toBeDisabled();


### PR DESCRIPTION
- added forced to frame -view's status control section to admin view
- added functionality to update forced to frame budgets and schedules for projects, classes and locations (bulk update and update per project/class/location whenever connection between views is set to open and some budget or schedule data is modified in coordinator view)
- ticket: [https://helsinkisolutionoffice.atlassian.net/browse/IO-403](https://helsinkisolutionoffice.atlassian.net/browse/IO-403)
- API PR: https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/197