### PR TITLE
HKISD-217: remove spaces from csv numbers

### DIFF
--- a/src/components/Report/DownloadCsvButton.tsx
+++ b/src/components/Report/DownloadCsvButton.tsx
@@ -35,8 +35,12 @@ const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({
     return data.map((row) => {
       return Object.keys(row).reduce((acc, key) => {
         const typedKey = key as keyof (IConstructionProgramCsvRow | IBudgetBookSummaryCsvRow);
-
-        acc[typedKey] = row[typedKey] ?? '';
+        if (key === "\nTS 2025" || key === "\nTA 2025") {
+          const value = (row[typedKey] ?? '') as string;
+          acc[typedKey] = value ? value.replace(/\s/g, '') : '';
+        } else {
+          acc[typedKey] = row[typedKey] ?? '';
+        }
         return acc;
       }, {} as IConstructionProgramCsvRow | IBudgetBookSummaryCsvRow);
     });


### PR DESCRIPTION
- strategy report had an issue where sometimes the TA and TS numbers on the report had thousand separator that caused Excel to not understand that the column has numbers
- ticket: [https://futurice.atlassian.net/browse/HKISD-217](https://futurice.atlassian.net/browse/HKISD-217)