### PR TITLE
IO-401/strategy report from sovitettu budjetti data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import ErrorView from './views/ErrorView';
 import AuthGuard from './components/AuthGuard';
 import SearchResultsView from './views/SearchResultsView';
 import { CustomContextMenu } from './components/CustomContextMenu';
-import { getCoordinationGroupsThunk, getPlanningGroupsThunk } from './reducers/groupSlice';
+import { getCoordinationGroupsThunk, getForcedToFrameGroupsThunk, getPlanningGroupsThunk } from './reducers/groupSlice';
 import { getHashTagsThunk } from './reducers/hashTagsSlice';
 import { clearLoading, setLoading } from './reducers/loaderSlice';
 import { getSapCostsThunk } from './reducers/sapCostSlice';
@@ -70,6 +70,7 @@ export const loadCoordinationData = async (dispatch: AppDispatch, year: number) 
     await dispatch(getCoordinationGroupsThunk(year));
     await dispatch(getCoordinationClassesThunk(year));
     await dispatch(getCoordinationLocationsThunk(year));
+    await dispatch(getForcedToFrameGroupsThunk(year));
     await dispatch(getForcedToFrameClassesThunk(year));
     await dispatch(getForcedToFrameLocationsThunk(year));
   } catch (e) {

--- a/src/components/Report/DownloadCsvButton.tsx
+++ b/src/components/Report/DownloadCsvButton.tsx
@@ -53,7 +53,10 @@ const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({
       if (data && data.length > 0) {
         data = cleanData(data);
         const documentName = t(`report.${type}.documentName`);
-        downloadCSV(data, `${documentName}_${type === 'strategy' ? year + 1 : year}.csv`);
+        downloadCSV(
+          data, `${documentName} ${['strategy','strategyAgreedBudget'].includes(type) ?
+          year + 1 : year}.csv`
+        );
       } else {
         console.warn('No data available for CSV download.');
       }

--- a/src/components/Report/PdfReports/ReportContainer.tsx
+++ b/src/components/Report/PdfReports/ReportContainer.tsx
@@ -30,6 +30,7 @@ const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data, proje
   const getDocumentTitle = () => {
     switch (reportType) {
       case Reports.Strategy:
+      case Reports.StrategyAgreedBudget:
         return t('report.strategy.title');
       case Reports.ConstructionProgram:
         return t('report.constructionProgram.title');
@@ -48,6 +49,7 @@ const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data, proje
   const getDocumentSubtitleOne = () => {
     switch (reportType) {
       case Reports.Strategy:
+      case Reports.StrategyAgreedBudget:
         return t('report.strategy.subtitle', {
           startYear: new Date().getFullYear() + 1
         });
@@ -92,7 +94,7 @@ const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data, proje
             date={reportType === Reports.OperationalEnvironmentAnalysis ? currentDate : ''}
           />
           <ReportTable reportType={reportType} data={data} projectsInWarrantyPhase={projectsInWarrantyPhase} />
-          {reportType === Reports.Strategy ?
+          {reportType === Reports.Strategy || reportType === Reports.StrategyAgreedBudget ?
             <StrategyReportFooter
               infoText={t('report.strategy.footerInfoText')}
               colorInfoTextOne={t('report.strategy.planning')}

--- a/src/components/Report/PdfReports/ReportTable.tsx
+++ b/src/components/Report/PdfReports/ReportTable.tsx
@@ -67,18 +67,20 @@ const ReportTable: FC<IReportTableProps> = ({
         , reportType
   ) : [];
 
-  const strategyReportRows = reportType === Reports.Strategy ? flattenStrategyTableRows(reportRows) : [];
+  const strategyReportRows = reportType === Reports.Strategy || reportType === Reports.StrategyAgreedBudget ?
+    flattenStrategyTableRows(reportRows) : [];
 
   const getTableHeader = () => {
     switch (reportType) {
+      case Reports.OperationalEnvironmentAnalysis:
+        return <OperationalEnvironmentAnalysisTableHeader />
       case Reports.Strategy:
+      case Reports.StrategyAgreedBudget:
         return <StrategyTableHeader />;
       case Reports.ConstructionProgram:
         return <ConstructionProgramTableHeader />;
       case Reports.BudgetBookSummary:
         return <BudgetBookSummaryTableHeader />;
-      case Reports.OperationalEnvironmentAnalysis:
-        return <OperationalEnvironmentAnalysisTableHeader />
     }
   }
 
@@ -87,7 +89,10 @@ const ReportTable: FC<IReportTableProps> = ({
     <View>
       <View style={styles.table}>
         <View fixed>{tableHeader}</View>
-        <TableRow flattenedRows={reportType === Reports.Strategy ? strategyReportRows : flattenedRows} reportType={reportType}/>
+        <TableRow reportType={reportType} flattenedRows={
+          reportType === Reports.Strategy || reportType === Reports.StrategyAgreedBudget ?
+            strategyReportRows : flattenedRows
+        }/>
       </View>
     </View>
   );

--- a/src/components/Report/PdfReports/TableRow.tsx
+++ b/src/components/Report/PdfReports/TableRow.tsx
@@ -430,7 +430,8 @@ const getConstructionRowStyle = (rowType: string, depth: number) => {
 const Row: FC<IRowProps> = memo(({ flattenedRow, index, reportType }) => {
     let tableRow;
     switch (reportType) {
-        case Reports.Strategy: {
+        case Reports.Strategy:
+        case Reports.StrategyAgreedBudget: {
           const classNameTypes = [
             'masterClass',
             'class',

--- a/src/components/Report/ReportRow.tsx
+++ b/src/components/Report/ReportRow.tsx
@@ -53,7 +53,7 @@ const ReportRow: FC<IReportRowProps> = ({ type }) => {
     const forcedToFrameDistricts = separateLocationsIntoHierarchy(locationRes, true);
 
     // groups
-    const groupRes = await getCoordinatorGroups(year);
+    const groupRes = await getCoordinatorGroups(year, forcedToFrame);
 
     // selections
     const initialSelections: IPlanningRowSelections = {

--- a/src/hooks/useCoordinationRows.ts
+++ b/src/hooks/useCoordinationRows.ts
@@ -15,7 +15,7 @@ import {
   IPlanningRowSelections,
   PlanningRowType,
 } from '@/interfaces/planningInterfaces';
-import { selectCoordinationGroups } from '@/reducers/groupSlice';
+import { selectCoordinationGroups, selectForcedToFrameGroups } from '@/reducers/groupSlice';
 import { IProject } from '@/interfaces/projectInterfaces';
 import {
   selectForcedToFrame,
@@ -320,7 +320,8 @@ export const getCoordinationTableRows = (
  */
 const useCoordinationRows = () => {
   const dispatch = useAppDispatch();
-  const groups = useAppSelector(selectCoordinationGroups);
+  const coordinationGroups = useAppSelector(selectCoordinationGroups);
+  const forcedToFrameGroups = useAppSelector(selectForcedToFrameGroups);
   const rows = useAppSelector(selectPlanningRows);
   const projects = useAppSelector(selectProjects);
   const startYear = useAppSelector(selectStartYear);
@@ -361,7 +362,7 @@ const useCoordinationRows = () => {
     if (type && id) {
       getAndSetProjectsForSelections(type as PlanningRowType, id);
     }
-  }, [selections, groups, mode, forcedToFrame, startYear, dispatch]);
+  }, [selections, coordinationGroups, mode, forcedToFrame, startYear, dispatch]);
 
   /**
    * We use coordinator or forced to frame values (classes and locations).
@@ -378,13 +379,15 @@ const useCoordinationRows = () => {
       ? batchedForcedToFrameLocations.districts
       : batchedCoordinationLocations.districts;
 
+    const groups = forcedToFrame ? forcedToFrameGroups : coordinationGroups;
+
     const nextRows = getCoordinationTableRows(allClasses, districts, selections, projects, groups);
 
     // Re-build planning rows if the existing rows are not equal
     if (!_.isEqual(nextRows, rows)) {
       dispatch(setPlanningRows(nextRows));
     }
-  }, [startYear, batchedCoordinationClasses, batchedCoordinationLocations, groups, projects, selections, mode, forcedToFrame, batchedForcedToFrameClasses, batchedForcedToFrameLocations.districts, rows, dispatch]);
+  }, [startYear, batchedCoordinationClasses, batchedCoordinationLocations, coordinationGroups, projects, selections, mode, forcedToFrame, batchedForcedToFrameClasses, batchedForcedToFrameLocations.districts, rows, dispatch]);
 };
 
 export default useCoordinationRows;

--- a/src/hooks/useCsvData.ts
+++ b/src/hooks/useCsvData.ts
@@ -9,10 +9,18 @@ import {
   IDownloadCsvButtonProps,
   IConstructionProgramCsvRow,
   IBudgetBookSummaryCsvRow,
+  ReportType,
 } from '@/interfaces/reportInterfaces';
 import { getCoordinationTableRows } from './useCoordinationRows';
 import { getDistricts } from '@/services/listServices';
 import { getProjectDistricts } from '@/reducers/listsSlice';
+
+const getData = async (getForcedToFrameData: IDownloadCsvButtonProps["getForcedToFrameData"], type: ReportType, year: number) => {
+  // Function is used on Reports Strategy, StrategyAgreedBudget, and BudgetBookSummary
+  if (type === Reports.Strategy) return await getForcedToFrameData(year + 1, false);
+  if (type === Reports.StrategyAgreedBudget) return await getForcedToFrameData(year + 1, true);
+  else return await getForcedToFrameData(year, true);
+}
 
 export const useCsvData = ({
   type,
@@ -36,9 +44,10 @@ export const useCsvData = ({
 
       switch (type) {
         case Reports.BudgetBookSummary:
-        case Reports.Strategy: {
+        case Reports.Strategy:
+        case Reports.StrategyAgreedBudget: {
           // For Strategy report, we will fetch next year data
-          const res = type === Reports.Strategy ? await getForcedToFrameData(year + 1, false) : await getForcedToFrameData(year, true);
+          const res = await getData(getForcedToFrameData, type, year)
           if (res && res.projects.length > 0) {
             const coordinatorRows = getCoordinationTableRows(
               res.classHierarchy,

--- a/src/hooks/useUpdateEvents.ts
+++ b/src/hooks/useUpdateEvents.ts
@@ -11,7 +11,7 @@ import {
   ICoordinatorClassHierarchy,
   selectBatchedForcedToFrameClasses,
 } from '@/reducers/classSlice';
-import { selectCoordinationGroups, selectPlanningGroups, updateGroup } from '@/reducers/groupSlice';
+import { selectCoordinationGroups, selectForcedToFrameGroups, selectPlanningGroups, updateGroup } from '@/reducers/groupSlice';
 import { ILocationHierarchy, selectBatchedCoordinationLocations, selectBatchedForcedToFrameLocations, selectBatchedPlanningLocations, updateDistrict } from '@/reducers/locationSlice';
 import {
   addFinanceUpdateEventListener,
@@ -164,6 +164,7 @@ const useUpdateEvents = () => {
   const forcedToFrameLocationDataFromState = useAppSelector(selectBatchedForcedToFrameLocations);
   const plannigGroupsDataFromState = useAppSelector(selectPlanningGroups);
   const coordinationGroupDataFromState = useAppSelector(selectCoordinationGroups);
+  const forcedToFrameGroupDataFromState = useAppSelector(selectForcedToFrameGroups);
 
   const startYear = useAppSelector(selectStartYear);
 
@@ -229,7 +230,7 @@ const useUpdateEvents = () => {
       if (forcedToFrame) {
         forcedToFrame = {...forcedToFrame, ...syncClassFinances(forcedToFrameClassDataFromState, forcedToFrame, startYear)};
         forcedToFrame = {...forcedToFrame, ...syncLocationFinances(forcedToFrameLocationDataFromState, forcedToFrame, startYear)};
-        forcedToFrame = {...forcedToFrame, ...syncGroupFinances(coordinationGroupDataFromState, forcedToFrame, startYear)};
+        forcedToFrame = {...forcedToFrame, ...syncGroupFinances(forcedToFrameGroupDataFromState, forcedToFrame, startYear)};
         forcedToFrame = syncCoordinationFinances(forcedToFrameClassDataFromState, forcedToFrame, startYear);
         const type = 'forcedToFrame';
         Promise.all([

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -459,7 +459,20 @@
     },
     "strategy": {
       "rowTitle": "Toimintasuunnitelma (Koordinointinäkymä)",
-      "documentName": "toimintasuunnitelma",
+      "documentName": "toimintasuunnitelma - koordinointinäkymä",
+      "title": "Helsingin kaupunki",
+      "subtitle": "Yleisten alueiden ja tonttien rakentamiskelpoiseksi saattamisen investointiohjelma {{startYear}}",
+      "projectNameTitle": "Hanke",
+      "projectsTitle": "Kohteen",
+      "projectManagerTitle": "projektipäällikkö",
+      "footerInfoText": "s = suunnittelu, r = rakentaminen",
+      "planning": "Suunnittelu",
+      "constructing": "Rakentaminen",
+      "projectManagerMissing": "Odottaa nimeämistä"
+    },
+    "strategyAgreedBudget": {
+      "rowTitle": "Toimintasuunnitelma (Sovitettu budjetti)",
+      "documentName": "toimintasuunnitelma - sovitettu budjetti",
       "title": "Helsingin kaupunki",
       "subtitle": "Yleisten alueiden ja tonttien rakentamiskelpoiseksi saattamisen investointiohjelma {{startYear}}",
       "projectNameTitle": "Hanke",

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -52,6 +52,7 @@ export type IPlanningData = {
 export const reports = [
   'operationalEnvironmentAnalysis',
   'strategy',
+  'strategyAgreedBudget',
   'constructionProgram',
   'budgetBookSummary',
   'financialStatement',
@@ -76,6 +77,7 @@ export interface IOperationalEnvironmentAnalysisCsvRow {
 export enum Reports {
   OperationalEnvironmentAnalysis = 'operationalEnvironmentAnalysis',
   Strategy = 'strategy',
+  StrategyAgreedBudget = 'strategyAgreedBudget',
   ConstructionProgram = 'constructionProgram',
   BudgetBookSummary = 'budgetBookSummary',
   FinancialStatement = 'financialStatement',

--- a/src/services/groupServices.ts
+++ b/src/services/groupServices.ts
@@ -21,9 +21,9 @@ export const getPlanningGroups = async (year: number): Promise<Array<IGroup>> =>
   }
 };
 
-export const getCoordinatorGroups = async (year: number) => {
+export const getCoordinatorGroups = async (year: number, forcedToFrame: boolean): Promise<Array<IGroup>> => {
   try {
-    const res = await axios.get(`${REACT_APP_API_URL}/project-groups/coordinator/?year=${year}`);
+    const res = await axios.get(`${REACT_APP_API_URL}/project-groups/coordinator/?year=${year}&forcedToFrame=${forcedToFrame}`);
     return res.data;
   } catch (e) {
     return Promise.reject(e);

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -154,12 +154,24 @@ const getProjectPhase = (project: IProject) => {
   }
 }
 
-const getProjectPhasePerMonth = (project: IProject, month: number) => {
+const getStrategyReportProjectPhasePerMonth = (type: ReportType, project: IProject, month: number) => {
   const monthStartDate = new Date(new Date().getFullYear() + 1, month - 1, 1);
   const monthEndDate = new Date(new Date().getFullYear() + 1, month, 0);
   const dateFormat = "DD.MM.YYYY";
-  const isPlanning = projectIsInPlanningPhase(project.estPlanningStart, monthStartDate, project.estPlanningEnd, monthEndDate, project.planningStartYear, dateFormat);
-  const isConstruction = projectIsInConstructionPhase(project.estConstructionStart, monthStartDate, project.estConstructionEnd, monthEndDate, project.estPlanningStart, project.planningStartYear, dateFormat);
+
+  const planningStartYear = () => {
+    if (type === Reports.Strategy) return project.planningStartYear;
+
+    return project.frameEstPlanningStart ? getYear(project.frameEstPlanningStart) : project.planningStartYear;
+  }
+
+  const isPlanning = type === Reports.Strategy ?
+    projectIsInPlanningPhase(project.estPlanningStart, monthStartDate, project.estPlanningEnd, monthEndDate, planningStartYear(), dateFormat) :
+    projectIsInPlanningPhase(project.frameEstPlanningStart, monthStartDate, project.frameEstPlanningEnd, monthEndDate, planningStartYear(), dateFormat);
+
+  const isConstruction = type === Reports.Strategy ?
+    projectIsInConstructionPhase(project.estConstructionStart, monthStartDate, project.estConstructionEnd, monthEndDate, project.estPlanningStart, planningStartYear(), dateFormat) :
+    projectIsInConstructionPhase(project.frameEstConstructionStart, monthStartDate, project.frameEstConstructionEnd, monthEndDate, project.frameEstPlanningStart, planningStartYear(), dateFormat);
 
   if (isPlanning && isConstruction) {
     return "planningAndConstruction";
@@ -288,28 +300,28 @@ const convertToStrategyReportProjects = (type: ReportType, projects: IProject[])
   }
 
   return filteredProjects().map((p) => ({
-      name: p.name,
-      id: p.id,
-      parent: p.projectClass ?? null,
-      projects: [],
-      children: [],
-      costPlan: "",                                                                   // TA value "raamiluku". Will not be shown for projects.
-      costForecast: split(p.finances.budgetProposalCurrentYearPlus0, ".")[0] ?? "",   // TS value
-      projectManager: p.personPlanning?.lastName ?? (t('report.strategy.projectManagerMissing') as string),
-      projectPhase: getProjectPhase(p),
-      januaryStatus: getProjectPhasePerMonth(p, 1),
-      februaryStatus: getProjectPhasePerMonth(p,2),
-      marchStatus: getProjectPhasePerMonth(p,3),
-      aprilStatus: getProjectPhasePerMonth(p,4),
-      mayStatus: getProjectPhasePerMonth(p,5),
-      juneStatus: getProjectPhasePerMonth(p,6),
-      julyStatus: getProjectPhasePerMonth(p,7),
-      augustStatus: getProjectPhasePerMonth(p,8),
-      septemberStatus: getProjectPhasePerMonth(p,9),
-      octoberStatus: getProjectPhasePerMonth(p,10),
-      novemberStatus: getProjectPhasePerMonth(p,11),
-      decemberStatus: getProjectPhasePerMonth(p,12),
-      type: 'project',
+    name: p.name,
+    id: p.id,
+    parent: p.projectClass ?? null,
+    projects: [],
+    children: [],
+    costPlan: "",                                                                   // TA value "raamiluku". Will not be shown for projects.
+    costForecast: split(p.finances.budgetProposalCurrentYearPlus0, ".")[0] ?? "",   // TS value
+    projectManager: p.personPlanning?.lastName ?? (t('report.strategy.projectManagerMissing') as string),
+    projectPhase: getProjectPhase(p),
+    januaryStatus: getStrategyReportProjectPhasePerMonth(type, p, 1),
+    februaryStatus: getStrategyReportProjectPhasePerMonth(type, p, 2),
+    marchStatus: getStrategyReportProjectPhasePerMonth(type, p, 3),
+    aprilStatus: getStrategyReportProjectPhasePerMonth(type, p, 4),
+    mayStatus: getStrategyReportProjectPhasePerMonth(type, p, 5),
+    juneStatus: getStrategyReportProjectPhasePerMonth(type, p, 6),
+    julyStatus: getStrategyReportProjectPhasePerMonth(type, p, 7),
+    augustStatus: getStrategyReportProjectPhasePerMonth(type, p, 8),
+    septemberStatus: getStrategyReportProjectPhasePerMonth(type, p, 9),
+    octoberStatus: getStrategyReportProjectPhasePerMonth(type, p, 10),
+    novemberStatus: getStrategyReportProjectPhasePerMonth(type, p, 11),
+    decemberStatus: getStrategyReportProjectPhasePerMonth(type, p ,12),
+    type: 'project',
     }));
 }
 


### PR DESCRIPTION
Create new report that uses Strategy report but uses "Sovittu budjetti" data.

To-Do:
- [x] Tests

Bugs:
- [ ] If both Strategy reports (e.g. PDF version) are downloaded without refresh, the second PDF uses same data as the PDF that was downloaded first.