### PR TITLE
HKISD-199: fix emptying project's group id 

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -288,7 +288,7 @@ const ProjectForm = () => {
           if (data?.projectClass && project.projectGroup) {
 
               const projectGroup = groups.find(({id}) => id === project.projectGroup);
-              if (project.projectClass !== projectGroup?.classRelation) {
+              if (data.projectClass !== projectGroup?.classRelation) {
                 data = {...data, "projectGroup": null} 
               }
           }


### PR DESCRIPTION
### Description
Changing the data from where project's class info is taken. Previously if-loop was never reached because class info was taken from updated project info (=new class info) instead of previous class info. 

### Testing
You have a group that has for example location 8 03 Kadut ja liikenneväylät - Uudisrakentaminen - Eteläinen suurpiiri. And in that group you have projects that has same classes chosen. Project has projectGroup_id in database. 

Then go to project card and change classes for this project to be different from what group has. For example change classes to be 8 04 Puistot ja liikunta-alueet - Uudet puistot - Läntinen suurpiiri. 

Before problem was that projectGroup_id was not emptied after projects classes changed to be different than group's. This caused a situation, that project could not be seen anywhere in hierarchy. 

Now this is fixed, and projectGroup_id is emptied when project's and group's classes are different and project is visible in the new location. 
