### PR TITLE
fix: HKISD-196 set projects if the planning mode is the same as the view

### DIFF
--- a/src/hooks/useCoordinationRows.ts
+++ b/src/hooks/useCoordinationRows.ts
@@ -353,7 +353,7 @@ const useCoordinationRows = () => {
           year,
           true,
         );
-        dispatch(setProjects(projects));
+        dispatch(setProjects({mode, projects}));
       } catch (e) {
         console.log('Error fetching projects for coordination selections: ', e);
       }

--- a/src/hooks/usePlanningRows.ts
+++ b/src/hooks/usePlanningRows.ts
@@ -281,7 +281,7 @@ const usePlanningRows = () => {
       try {
         const year = startYear ?? new Date().getFullYear();
         const projects = await fetchProjectsByRelation(type as PlanningRowType, id, false, year);
-        dispatch(setProjects(projects));
+        dispatch(setProjects({mode, projects}));
       } catch (e) {
         console.log('Error fetching projects for planning selections: ', e);
       }

--- a/src/hooks/useUpdateEvents.ts
+++ b/src/hooks/useUpdateEvents.ts
@@ -257,7 +257,7 @@ const useUpdateEvents = () => {
         return p.id === projectUpdate.id ? projectUpdate : p
       });
       Promise.all([
-        dispatch(setProjects(updatedProjects))
+        dispatch(setProjects({projects: updatedProjects}))
       ]).catch((e) => console.log('Error updating project data: ', e));
     }
   }, [financeUpdate, projectUpdateEventData]);

--- a/src/reducers/planningSlice.ts
+++ b/src/reducers/planningSlice.ts
@@ -123,8 +123,14 @@ export const planningSlice = createSlice({
     setPlanningRows(state, action: PayloadAction<Array<IPlanningRow>>) {
       return { ...state, rows: action.payload };
     },
-    setProjects(state, action: PayloadAction<Array<IProject>>) {
-      return { ...state, projects: action.payload };
+    setProjects(state, action: PayloadAction<{mode?: string, projects: Array<IProject>}>) {
+      // In case the mode is switched while fetching projects, we don't want to set
+      // different view projects on another view (['planning' | 'coordination']).
+      if (!action.payload.mode || action.payload.mode === state.mode){
+        return { ...state, projects: action.payload.projects };
+      }
+
+      return state;
     },
     setGroupsExpanded(state, action: PayloadAction<boolean>) {
       return { ...state, groupsExpanded: action.payload };


### PR DESCRIPTION
Ticket: https://futurice.atlassian.net/browse/HKISD-196

Issue: 
When user selects a project on Seach view, hierarchy loads correctly with projects but suddenly all projects disappears.

What happens:
When the user opens Search view on Coordinator view, the state `planning.mode` stays as `coordinator`. When the project is selected from the list, the Programming view is opened, but there is a change it start to fetch coordinator related projects. When the Programming view project fetch ends, projects appears on the hierarchy, but then if the project fetch for coordinator view ends, it replaces projects list with empty list. This causes the project list disappearing.

How is it fixed:
When the setProjects is called, we check if the payload `mode` is the same as the current view on Redux State.

How to test with/without the fix:
- Before testing, search a random project on Programming view that is 3+ level deep. We use project's name for testing
- Open Coordinator view
- Navigate into deeper levels
- Click search tool and search the project (step 1 project's name)
- Click the project on search result
- Programming view opens showing the search project
- Wait to see if all projects disappears or stays on the hierarchy