### PR TITLE
feat: IO-419 redirect to planning view as a default

### DIFF
--- a/src/components/AuthGuard/AuthGuard.tsx
+++ b/src/components/AuthGuard/AuthGuard.tsx
@@ -221,6 +221,8 @@ const AuthGuard: FC = () => {
       handleUserRoles(pathname, user, navigate, initialPath);
       // Other redirects
       handlePageRedirects(pathname);
+
+      return navigate(PAGES.PLANNING);
     }
   }, [location, navigate, user, isAuthenticated, authError]);
 


### PR DESCRIPTION
https://helsinkisolutionoffice.atlassian.net/browse/IO-419

Currently when an user opens the app, after different checks it finally redirects them to the root domain. 

This change redirects an user to `/planning` view if they authenticated successfully, they have correct access rights, and they didn't use an URL that redirects to different page.

### How to test?
When opening the local environment `http://localhost:4000`, it should redirect to `localhost:4000/planning` view.