### PR TITLE
HKISD-254: Fix search remove selected words

### DIFF
--- a/src/components/Search/FreeSearchForm.tsx
+++ b/src/components/Search/FreeSearchForm.tsx
@@ -146,7 +146,7 @@ const FreeSearchForm = ({
       const formValue = getValues('freeSearchParams') as FreeSearchFormObject;
 
       const {
-        [(e.currentTarget as HTMLElement)?.parentElement?.innerText as string]: _,
+        [e.currentTarget?.innerText]: _,
         ...nextChange
       } = formValue;
 


### PR DESCRIPTION
On Search view that opens from "Haku", you can remove a search word under "Mitä haet?" if there is only one on the list. The issue appears if the list has more than one search word.

The reason why this happened is the currect selector sees all search words as one text, and tries to find this from the `formValue` object. This fix selects correct element's text and uses it to remove the property from the object.

How to test before and after: Open Haku search view and add multiple search words. Try to remove one element by clicking the element.

![image](https://github.com/user-attachments/assets/b03af728-9e2d-4d3b-bafa-44d065671564)
