### PR TITLE
Add thousand separator to sap values in project card

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
@@ -2,7 +2,7 @@ import mockI18next from '@/mocks/mockI18next';
 import axios from 'axios';
 import mockProject from '@/mocks/mockProject';
 import { renderWithProviders, sendProjectUpdateEvent } from '@/utils/testUtils';
-import { arrayHasValue, matchExact } from '@/utils/common';
+import { arrayHasValue, formatNumberToContainSpaces, matchExact } from '@/utils/common';
 import { IProject } from '@/interfaces/projectInterfaces';
 import {
   mockConstructionPhaseDetails,
@@ -164,25 +164,26 @@ describe('projectForm', () => {
     expectRadioBoolean('gravel-0', false);
     expectRadioBoolean('effectHousing-0', false);
 
-    expect(await findByText(`${Number(project?.costForecast).toFixed(0)}`)).toBeInTheDocument();
+    const costForecastValue = Number(project?.costForecast).toFixed(0);
+    expect(await findByText(`${formatNumberToContainSpaces(Number(costForecastValue))}`)).toBeInTheDocument();
 
     const sapCurrentYearprojectTaskCosts = Number(sapCostCurrentYear[project.id]?.project_task_costs).toFixed(0);
     const sapCurrentYearProductionTaskCosts = Number(sapCostCurrentYear[project.id]?.production_task_costs).toFixed(0);
-    const SapCostsCurrentYearValue = Number(sapCurrentYearprojectTaskCosts) + Number(sapCurrentYearProductionTaskCosts);
-    expect(await findByText(`${SapCostsCurrentYearValue}`)).toBeInTheDocument();
+    const sapCostsCurrentYearValue = Number(sapCurrentYearprojectTaskCosts) + Number(sapCurrentYearProductionTaskCosts);
+    expect(await findByText(`${formatNumberToContainSpaces(sapCostsCurrentYearValue)}`)).toBeInTheDocument();
 
     const sapAllProjectTaskCosts = Number(sapCostAll[project.id]?.project_task_costs).toFixed(0);
     const sapAllProductionTaskCosts = Number(sapCostAll[project.id]?.production_task_costs).toFixed(0);
-    const SapCostsAllValue = Number(sapAllProjectTaskCosts) + Number(sapAllProductionTaskCosts);
-    expect(await findByText(`${SapCostsAllValue}`)).toBeInTheDocument();
+    const sapCostsAllValue = Number(sapAllProjectTaskCosts) + Number(sapAllProductionTaskCosts);
+    expect(await findByText(`${formatNumberToContainSpaces(sapCostsAllValue)}`)).toBeInTheDocument();
 
     const sapAllProjectTaskCommitments = Number(sapCostAll[project.id]?.project_task_commitments).toFixed(0);
     const sapAllProductionTaskCommitments = Number(sapCostAll[project.id]?.production_task_commitments).toFixed(0);
-    const SapCommitmentsAllValue = Number(sapAllProjectTaskCommitments) + Number(sapAllProductionTaskCommitments);
-    expect(await findByText(`${SapCommitmentsAllValue}`)).toBeInTheDocument();
+    const sapCommitmentsAllValue = Number(sapAllProjectTaskCommitments) + Number(sapAllProductionTaskCommitments);
+    expect(await findByText(`${formatNumberToContainSpaces(sapCommitmentsAllValue)}`)).toBeInTheDocument();
 
-    const SapAllSpentValue = SapCostsAllValue + SapCommitmentsAllValue;
-    expect(await findByText(`${SapAllSpentValue}`)).toBeInTheDocument();
+    const SapAllSpentValue = sapCostsAllValue + sapCommitmentsAllValue;
+    expect(await findByText(`${formatNumberToContainSpaces(SapAllSpentValue)}`)).toBeInTheDocument();
 
     expect(await findByText('overrunRightValue' || '')).toBeInTheDocument();
     expect(await findByText(`${project?.budgetOverrunAmount} keur` || '')).toBeInTheDocument();

--- a/src/components/shared/ListField.tsx
+++ b/src/components/shared/ListField.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import FormFieldLabel from './FormFieldLabel';
 import { Tooltip } from 'hds-react';
 import { IProjectSapCost } from '@/interfaces/sapCostsInterfaces';
+import { formatNumber } from '@/utils/calculations';
 
 interface IListFieldProps {
   name: string;
@@ -31,7 +32,7 @@ const ListField: FC<IListFieldProps> = ({
     return costs ? (Number(costs[costType1 as keyof IProjectSapCost]) || 0) + (Number(costs[costType2 as keyof IProjectSapCost]) || 0) : 0;
   }
 
-  function getSapCostValue(field: IForm):string {
+  function getSapCostValue(field: IForm):number {
     let sapValue = 0;
 
     switch (field.name) {
@@ -54,7 +55,7 @@ const ListField: FC<IListFieldProps> = ({
       default:
         break;
     }
-    return Number(sapValue).toFixed(0);
+    return sapValue;
   };
 
   const showTooltip = (field: IForm) => {
@@ -107,7 +108,7 @@ const ListField: FC<IListFieldProps> = ({
                 
                 {!editing || f.readOnly ? (
                   <div className="list-field-values">
-                    <span>{f.isSapProject ? `${getSapCostValue(f)}` : `${Number(field.value).toFixed(0)}`}</span>
+                    <span>{f.isSapProject ? `${formatNumber(getSapCostValue(f))}` : `${formatNumber(field.value)}`}</span>
                     <span>{f.isSapProject ? '€' : 'keur'}</span>
                   </div>
                 ) : (

--- a/src/components/shared/ListField.tsx
+++ b/src/components/shared/ListField.tsx
@@ -86,6 +86,10 @@ const ListField: FC<IListFieldProps> = ({
     }
   }, [cancelEdit]);
 
+  const formatFieldValue = (fieldValue: string) => {
+    return formatNumberToContainSpaces(Number(Number(fieldValue).toFixed(0)))
+  }
+
   return (
     <div className="input-wrapper" id={name} data-testid={name}>
       <div className="flex flex-col">
@@ -108,7 +112,7 @@ const ListField: FC<IListFieldProps> = ({
                 
                 {!editing || f.readOnly ? (
                   <div className="list-field-values">
-                    <span>{f.isSapProject ? `${getSapCostValue(f)}` : `${formatNumberToContainSpaces(Number((field.value).toFixed(0)))}`}</span>
+                    <span>{f.isSapProject ? `${getSapCostValue(f)}` : `${formatFieldValue(field.value)}`}</span>
                     <span>{f.isSapProject ? '€' : 'keur'}</span>
                   </div>
                 ) : (

--- a/src/components/shared/ListField.tsx
+++ b/src/components/shared/ListField.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import FormFieldLabel from './FormFieldLabel';
 import { Tooltip } from 'hds-react';
 import { IProjectSapCost } from '@/interfaces/sapCostsInterfaces';
-import { formatNumber } from '@/utils/calculations';
+import { formatNumberToContainSpaces } from '@/utils/common';
 
 interface IListFieldProps {
   name: string;
@@ -32,7 +32,7 @@ const ListField: FC<IListFieldProps> = ({
     return costs ? (Number(costs[costType1 as keyof IProjectSapCost]) || 0) + (Number(costs[costType2 as keyof IProjectSapCost]) || 0) : 0;
   }
 
-  function getSapCostValue(field: IForm):number {
+  function getSapCostValue(field: IForm): string {
     let sapValue = 0;
 
     switch (field.name) {
@@ -55,7 +55,7 @@ const ListField: FC<IListFieldProps> = ({
       default:
         break;
     }
-    return sapValue;
+    return formatNumberToContainSpaces(Number((sapValue).toFixed(0)));
   };
 
   const showTooltip = (field: IForm) => {
@@ -108,7 +108,7 @@ const ListField: FC<IListFieldProps> = ({
                 
                 {!editing || f.readOnly ? (
                   <div className="list-field-values">
-                    <span>{f.isSapProject ? `${formatNumber(getSapCostValue(f))}` : `${formatNumber(field.value)}`}</span>
+                    <span>{f.isSapProject ? `${getSapCostValue(f)}` : `${formatNumberToContainSpaces(Number((field.value).toFixed(0)))}`}</span>
                     <span>{f.isSapProject ? '€' : 'keur'}</span>
                   </div>
                 ) : (

--- a/src/utils/mockGetResponseProvider.ts
+++ b/src/utils/mockGetResponseProvider.ts
@@ -106,6 +106,8 @@ export const mockGetResponseProvider = () =>
         return Promise.resolve(mockSapCosts);
       case url.toLocaleLowerCase().includes(`/coordinator-notes/`):
         return Promise.resolve(mockCoordinatorNotes);
+      case url.toLocaleLowerCase().includes(`/sap-current-year-costs/${year}/`):
+        return Promise.resolve(mockSapCosts);
       default:
         console.log('not found!: ', url);
 


### PR DESCRIPTION
Adding spaces as thousand separators to sap values and budget value in project card. 

Using function formatNumberToContainSpaces from common.ts. Fixing also tests to use thousand separated values and found one missing case in mockGetResponseProvider.ts.
