### PR TITLE
fix: HKISD-196 fetch projects only if the view is correct

### DIFF
--- a/src/hooks/usePlanningRows.ts
+++ b/src/hooks/usePlanningRows.ts
@@ -65,10 +65,7 @@ export const buildPlanningTableRows = (
   subDivisions?: Array<ILocation>
 ) => {
   const { masterClasses, classes, subClasses, districts, divisions, otherClassifications, groups } = list;
-
   const { selectedMasterClass, selectedClass, selectedSubClass, selectedDistrict } = selections;
-
-
 
   const districtType = selectedDistrict ? 'district' : 'districtPreview';
 

--- a/src/hooks/usePlanningRows.ts
+++ b/src/hooks/usePlanningRows.ts
@@ -2,6 +2,7 @@ import { selectBatchedPlanningClasses } from '@/reducers/classSlice';
 import { useAppDispatch, useAppSelector } from './common';
 import { selectBatchedPlanningLocations, selectPlanningSubDivisions } from '@/reducers/locationSlice';
 import { useEffect } from 'react';
+import { useLocation } from 'react-router';
 import { ILocation } from '@/interfaces/locationInterfaces';
 import {
   IPlanningRow,
@@ -265,6 +266,7 @@ const usePlanningRows = () => {
   const batchedPlanningClasses = useAppSelector(selectBatchedPlanningClasses);
   const batchedPlanningLocations = useAppSelector(selectBatchedPlanningLocations);
   const subDivisions = useAppSelector(selectPlanningSubDivisions);
+  const location = useLocation();
 
   const mode = useAppSelector(selectPlanningMode);
 
@@ -287,10 +289,14 @@ const usePlanningRows = () => {
       }
     };
 
-    if (type && id) {
+    // Prevent fetching projects if selected class/district is different what is shown on the page
+    const queryParams = new URLSearchParams(location.search);
+    const openedViewId = queryParams.get(type as string);
+
+    if (type && id && openedViewId === id) {
       getAndSetProjectsForSelections(type as PlanningRowType, id);
     }
-  }, [selections, groups, mode, forcedToFrame, startYear, dispatch]);
+  }, [selections, groups, mode, forcedToFrame, startYear, dispatch, location.search]);
 
   // Build planning table rows when locations, classes, groups, project, mode or selections change
   useEffect(() => {


### PR DESCRIPTION
When an user returns from the Search results view back to hierarchy view, it might create two separate projects-fetches to backend. Depending on which one of requests finishes last, it could cause the hierarchy view to populate projects and then remove all projects. Why this happens is because the last fetch loads projects that are for different hierarchy view.

To prevent unnesessary fetches, the logic checks the page with lowest class/district/group ID is the same as selected lowest class/district/group ID set in state.

How to test before and after:
- Open Search view and search two or more different projects. Projects need to be under different hierarchy classes/districts
- From Search results view, select one of the results. It is 50/50 chance will projects appear and then quickly disappear.