### PR TITLE
HKISD-259: fix remove hashtags on the project view

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/ProjectHashTags.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/ProjectHashTags.tsx
@@ -111,7 +111,8 @@ const ProjectHashTagsDialog: FC<IProjectHashTagsDialogProps> = forwardRef(
 
     const onHashTagDelete = useCallback((value: string) => {
       setFormState((current) => {
-        const hashTagsForSubmit = current.hashTagsForSubmit.filter((hv) => hv.value !== value);
+        const hashTagsForSubmit = current.hashTagsForSubmit.filter((hv) => hv.id !== value);
+
         if (projectMode === 'new') {
           setHashTagsState((current) => ({
             ...current,


### PR DESCRIPTION
Fixes an issue where a hashtag (tunniste) can't be removed on the project card view.