### PR TITLE
HKISD-224: search groups and projects with same name

### DIFF
--- a/src/components/Search/FreeSearchForm.tsx
+++ b/src/components/Search/FreeSearchForm.tsx
@@ -162,8 +162,6 @@ const FreeSearchForm = ({
   const handleSetSearchWord = useCallback(
     (value: string) =>
       setSearchState((current) => {
-        // TODO: here user must be notified if selected value is duplicate
-        // TODO: searchWordDuplicates contains duplicates
         return { ...current, searchWord: value };
       }),
     [],

--- a/src/utils/buildSearchParams.ts
+++ b/src/utils/buildSearchParams.ts
@@ -1,8 +1,13 @@
-import { FreeSearchFormObject, IOption } from '@/interfaces/common';
+import { FreeSearchFormItem, FreeSearchFormObject, IOption } from '@/interfaces/common';
 import { ISearchForm } from '@/interfaces/formInterfaces';
 
 // Build a search parameter with all the choices from the search form
 const buildSearchParams = (form: ISearchForm) => {
+  const typeToParam: {[key in FreeSearchFormItem['type']]?: string} = {
+    projects: 'projectName',
+    groups: 'group',
+    hashtags: 'hashtag'
+  };
   const searchParams = [];
   for (const [key, value] of Object.entries(form)) {
     switch (key) {
@@ -29,8 +34,9 @@ const buildSearchParams = (form: ISearchForm) => {
         break;
       case 'freeSearchParams':
         for (const [_, v] of Object.entries(value as FreeSearchFormObject)) {
-          const paramType = v.type.substring(0, v.type.length - 1);
-          searchParams.push(`${paramType}=${v.value}`);
+          const paramType = typeToParam[v.type];
+          const paramValue = v.type === 'hashtags' ? v.value : v.label;
+          searchParams.push(`${paramType}=${paramValue}`);
         }
         break;
       default:

--- a/src/utils/buildSearchParams.ts
+++ b/src/utils/buildSearchParams.ts
@@ -36,7 +36,12 @@ const buildSearchParams = (form: ISearchForm) => {
         for (const [_, v] of Object.entries(value as FreeSearchFormObject)) {
           const paramType = typeToParam[v.type];
           const paramValue = v.type === 'hashtags' ? v.value : v.label;
-          searchParams.push(`${paramType}=${paramValue}`);
+          if (paramType === "hashtag") {
+            searchParams.push(`${paramType}=${paramValue}`);
+          } else {
+            searchParams.push(`projectName=${paramValue}`);
+            searchParams.push(`group=${paramValue}`);
+          }
         }
         break;
       default:


### PR DESCRIPTION
- ticket: https://futurice.atlassian.net/browse/HKISD-224
- previously search only returned one project or group with same name even when there actually was more (no projects or groups with duplicate names where returned)
- you can test by creating multiple projects and groups with same name and see that search results has all of them when you search with the name
- you also need the API PR for testing: [https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/235](https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/235)