### PR TITLE
HKISD-119: fix filtering classes based on users selections

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -13,10 +13,10 @@ import CheckboxField from '../shared/CheckboxField';
 import { Fieldset } from 'hds-react/components/Fieldset';
 import { useOptions } from '@/hooks/useOptions';
 import {
+  clearSearchState,
   getSearchResultsThunk,
   selectOpen,
   setLastSearchParams,
-  setSearchForm,
   setSubmittedSearchForm,
   toggleSearch,
 } from '@/reducers/searchSlice';
@@ -62,8 +62,8 @@ const Search = () => {
 
   const handleClose = useCallback(() => {
     dispatch(toggleSearch());
-    dispatch(setSearchForm(getValues()));
-  }, [dispatch, getValues]);
+    dispatch(clearSearchState());
+  }, [dispatch]);
 
   const formProps = useCallback(
     (name: string) => {

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -13,10 +13,10 @@ import CheckboxField from '../shared/CheckboxField';
 import { Fieldset } from 'hds-react/components/Fieldset';
 import { useOptions } from '@/hooks/useOptions';
 import {
-  clearSearchState,
   getSearchResultsThunk,
   selectOpen,
   setLastSearchParams,
+  setSearchForm,
   setSubmittedSearchForm,
   toggleSearch,
 } from '@/reducers/searchSlice';
@@ -62,8 +62,8 @@ const Search = () => {
 
   const handleClose = useCallback(() => {
     dispatch(toggleSearch());
-    dispatch(clearSearchState());
-  }, [dispatch]);
+    dispatch(setSearchForm(getValues()));
+  }, [dispatch, getValues]);
 
   const formProps = useCallback(
     (name: string) => {

--- a/src/forms/useSearchForm.ts
+++ b/src/forms/useSearchForm.ts
@@ -1,14 +1,15 @@
 import { ISearchForm } from '@/interfaces/formInterfaces';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useAppSelector } from '../hooks/common';
-import { initialSearchForm, selectSearchForm } from '@/reducers/searchSlice';
+import { useAppDispatch, useAppSelector } from '../hooks/common';
+import { initialSearchForm, selectSearchForm, setSearchForm } from '@/reducers/searchSlice';
 import useMultiClassOptions from '@/hooks/useMultiClassOptions';
 import useMultiLocationOptions from '@/hooks/useMultiLocationOptions';
 import _ from 'lodash';
 import { IOption } from '@/interfaces/common';
 
 const useSearchForm = () => {
+  const dispatch = useAppDispatch();
   const storeFormValues = useAppSelector(selectSearchForm);
   const [submitDisabled, setSubmitDisabled] = useState(true);
   const formMethods = useForm<ISearchForm>({
@@ -42,7 +43,7 @@ const useSearchForm = () => {
   const {
     reset,
     watch,
-    formState: { isDirty },
+    getValues,
   } = formMethods;
 
   const setMultiListOption = useCallback((key: string, value: IOption) => {
@@ -71,6 +72,14 @@ const useSearchForm = () => {
     });
     return () => subscription.unsubscribe();
   }, [watch]);
+
+  // Set form values to the store when the user chnages any values on the form
+  useEffect(() => {
+    const subscription = watch(() => {
+      dispatch(setSearchForm(getValues()))
+    });
+    return () => subscription.unsubscribe();
+  }, [dispatch, getValues, watch])
 
   // Set the form and the multi-selections to match the values in redux storeFormValues
   useEffect(() => {


### PR DESCRIPTION
- ticket: [https://futurice.atlassian.net/browse/HKISD-119](https://futurice.atlassian.net/browse/HKISD-119)
- fixed the issue partly by fixing the filtering of class selection in the search form
- class options are now filtered based on the higher levels. For example if you select a master class, class options only has classes under that master class