### PR TITLE
HKISD-269: fix project card being cleared

### DIFF
--- a/src/forms/useProjectForm.ts
+++ b/src/forms/useProjectForm.ts
@@ -294,7 +294,7 @@ const useProjectForm = () => {
   }, [project, projectUpdate]);
 
   useEffect(() => {
-    if (!isLoading) {
+    if (!isLoading && projectMode === "edit") {
       reset(formValues);
     }
   }, [formValues, isLoading, reset]);

--- a/src/forms/useProjectForm.ts
+++ b/src/forms/useProjectForm.ts
@@ -19,7 +19,7 @@ import { selectProjectDistricts, selectProjectDivisions, selectProjectSubDivisio
 import _ from 'lodash';
 import { selectProjectUpdate } from '@/reducers/eventsSlice';
 import { notifyInfo } from '@/reducers/notificationSlice';
-import { selectIsLoading } from '@/reducers/loaderSlice';
+import { selectIsProjectCardLoading } from '@/reducers/loaderSlice';
 
 /**
  * Creates the memoized initial values for react-hook-form useForm()-hook. It also returns the
@@ -184,7 +184,7 @@ const useProjectForm = () => {
     defaultValues: useMemo(() => formValues, [formValues]),
     mode: 'onBlur',
   });
-  const isLoading = useAppSelector(selectIsLoading);
+  const isProjectCardLoading = useAppSelector(selectIsProjectCardLoading);
 
   const [selections, setSelections] = useState({ selectedClass: project?.projectClass, selectedLocation: project?.projectDistrict });
 
@@ -294,10 +294,10 @@ const useProjectForm = () => {
   }, [project, projectUpdate]);
 
   useEffect(() => {
-    if (!isLoading && projectMode === "edit") {
+    if (!isProjectCardLoading) {
       reset(formValues);
     }
-  }, [formValues, isLoading, reset]);
+  }, [isProjectCardLoading]);
 
   return { formMethods, classOptions, locationOptions, selectedMasterClassName };
 };

--- a/src/reducers/loaderSlice.ts
+++ b/src/reducers/loaderSlice.ts
@@ -8,11 +8,13 @@ interface ILoaderItem {
 
 interface ILoadingState {
   isLoading: boolean;
+  isProjectCardLoading: boolean;
   loaders: Array<ILoaderItem>;
 }
 
 const initialState: ILoadingState = {
   isLoading: false,
+  isProjectCardLoading: false,
   loaders: [],
 };
 
@@ -30,6 +32,12 @@ export const loaderSlice = createSlice({
       currentLoaders.push(action.payload);
       return { ...state, loaders: currentLoaders, isLoading: currentLoaders.length > 0 };
     },
+    setIsProjectCardLoading(state) {
+      return { ...state, isLoading: true };
+    },
+    clearIsProjectCardLoading(state) {
+      return { ...state, isLoading: false };
+    },
     clearLoading(state, action: PayloadAction<string>) {
       const nextLoaders = state.loaders.filter((s) => s.id !== action.payload);
       return { ...state, loaders: nextLoaders, isLoading: nextLoaders.length > 0 };
@@ -38,6 +46,7 @@ export const loaderSlice = createSlice({
 });
 
 export const selectIsLoading = (state: RootState) => state.loader.isLoading;
+export const selectIsProjectCardLoading = (state: RootState) => state.loader.isProjectCardLoading
 
-export const { setLoading, clearLoading } = loaderSlice.actions;
+export const { setLoading, clearLoading, setIsProjectCardLoading, clearIsProjectCardLoading } = loaderSlice.actions;
 export default loaderSlice.reducer;

--- a/src/views/ProjectView/ProjectView.tsx
+++ b/src/views/ProjectView/ProjectView.tsx
@@ -13,7 +13,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { ProjectToolbar } from '@/components/Project/ProjectToolbar';
 import { ProjectHeader } from '@/components/Project/ProjectHeader';
 import { selectProjectUpdate } from '@/reducers/eventsSlice';
-import { clearLoading, setLoading } from '@/reducers/loaderSlice';
+import { clearIsProjectCardLoading, clearLoading, setIsProjectCardLoading, setLoading } from '@/reducers/loaderSlice';
 import { selectUser } from '@/reducers/authSlice';
 import _ from 'lodash';
 
@@ -50,6 +50,7 @@ const ProjectView = () => {
   useEffect(() => {
     const getProjectById = async (id: string) => {
       dispatch(setLoading({ text: 'Loading project', id: LOADING_PROJECT }));
+      dispatch(setIsProjectCardLoading());
 
       try {
         const res = await dispatch(getProjectThunk(id));
@@ -61,6 +62,7 @@ const ProjectView = () => {
         console.log('Error getting project by id: ', e);
       } finally {
         dispatch(clearLoading(LOADING_PROJECT));
+        dispatch(clearIsProjectCardLoading());
       }
     };
 


### PR DESCRIPTION
- ticket: [https://futurice.atlassian.net/browse/HKISD-269](https://futurice.atlassian.net/browse/HKISD-269)
- if a user was creating a new project or editing an existing one and someone else made a finance update, the project card was cleared
- can be tested by opening the infratool in two windows and editing or creating a new project but not saving and in the other window editing some budgets from the timeline