### PR TITLE
HKSID-270: fix project managers permissions

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
@@ -55,7 +55,7 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
     options: IOption[],
     size: 'full' | 'lg' | undefined,
     shouldTranslate: boolean,
-    shouldNotBeDisabled?: boolean,
+    userIsProjectManager?: boolean,
   ) => (
 
     <SelectField
@@ -63,7 +63,7 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
       options={options}
       size={size}
       shouldTranslate={shouldTranslate}
-      disabled={shouldNotBeDisabled ? false : isInputDisabled}
+      disabled={userIsProjectManager ? false : isInputDisabled}
       readOnly={isUserOnlyViewer}
     />
   );

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
@@ -55,13 +55,15 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
     options: IOption[],
     size: 'full' | 'lg' | undefined,
     shouldTranslate: boolean,
+    shouldNotBeDisabled?: boolean,
   ) => (
+
     <SelectField
       {...getFieldProps(name)}
       options={options}
       size={size}
       shouldTranslate={shouldTranslate}
-      disabled={isInputDisabled}
+      disabled={shouldNotBeDisabled ? false : isInputDisabled}
       readOnly={isUserOnlyViewer}
     />
   );
@@ -93,14 +95,14 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
       <div className="form-row">
         <div className="form-col-sm">{renderNumberField('projectCostForecast', 'keur', true)}</div>
         <div className="form-col-lg">
-          {renderSelectField('projectQualityLevel', projectQualityLevels, undefined, true)}
+          {renderSelectField('projectQualityLevel', projectQualityLevels, undefined, true, true)}
         </div>
         <div className="form-col-sm">{renderNumberField('projectWorkQuantity', 'm2', false)}</div>
       </div>
       <div className="form-row">
         <div className="form-col-sm">{renderNumberField('planningCostForecast', 'keur', true)}</div>
         <div className="form-col-lg">
-          {renderSelectField('planningPhase', planningPhases, undefined, true)}
+          {renderSelectField('planningPhase', planningPhases, undefined, true, true)}
         </div>
         <div className="form-col-sm">{renderNumberField('planningWorkQuantity', 'm2', false)}</div>
       </div>
@@ -109,7 +111,7 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
           {renderNumberField('constructionCostForecast', 'keur', true)}
         </div>
         <div className="form-col-lg">
-          {renderSelectField('constructionPhase', constructionPhases, undefined, true)}
+          {renderSelectField('constructionPhase', constructionPhases, undefined, true, true)}
         </div>
         <div className="form-col-sm">
           {renderNumberField('constructionWorkQuantity', 'm2', false)}
@@ -151,7 +153,7 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
         cancelEdit={isSaving}
       />
 
-      <OverrunRightField control={control} cancelEdit={isSaving} readOnly={isUserOnlyViewer} />
+      <OverrunRightField control={control} cancelEdit={isSaving} readOnly={isUserOnlyViewer} isInputDisabled={isInputDisabled}/>
       <ListField
         {...getFieldProps('preliminaryBudgetDivision')}
         readOnly={true}

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -66,7 +66,7 @@ const ProjectForm = () => {
     }
     return null;
   }, [project?.currentYearsSapValues]);
- 
+
   const isOnlyViewer = isUserOnlyViewer(user);
 
   const [newProjectId, setNewProjectId] = useState('');
@@ -305,10 +305,10 @@ const ProjectForm = () => {
 
           if (data?.projectClass && project.projectGroup) {
 
-              const projectGroup = groups.find(({id}) => id === project.projectGroup);
-              if (data.projectClass !== projectGroup?.classRelation) {
-                data = {...data, "projectGroup": null} 
-              }
+            const projectGroup = groups.find(({ id }) => id === project.projectGroup);
+            if (data.projectClass !== projectGroup?.classRelation) {
+              data = { ...data, "projectGroup": null }
+            }
           }
 
           /* If project is under a district and user changes the class, the district has to be removed or the
@@ -520,7 +520,11 @@ const ProjectForm = () => {
       {/* SECTION 7 - PROJECT PROGRAM */}
       <ProjectProgramSection {...formProps} isUserOnlyViewer={isOnlyViewer} />
       {/* BANNER */}
-      {!isOnlyViewer && <ProjectFormBanner onSubmit={submitCallback} isDirty={isDirty} />}
+      {!isOnlyViewer &&
+        <ProjectFormBanner
+          onSubmit={submitCallback}
+          isDirty={isDirty}
+          isInputDisabled={isInputDisabled} />}
     </form>
   );
 };

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectFormBanner.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectFormBanner.tsx
@@ -13,9 +13,10 @@ interface IProjectFormbannerProps {
     | ((e?: BaseSyntheticEvent<object, unknown, unknown> | undefined) => Promise<void>)
     | undefined;
   isDirty: boolean;
+  isInputDisabled: boolean;
 }
 
-const ProjectFormBanner: FC<IProjectFormbannerProps> = ({ onSubmit, isDirty }) => {
+const ProjectFormBanner: FC<IProjectFormbannerProps> = ({ onSubmit, isDirty, isInputDisabled }) => {
   const dispatch = useAppDispatch();
   const startYear = useAppSelector(selectStartYear);
   const { t } = useTranslation();
@@ -61,7 +62,7 @@ const ProjectFormBanner: FC<IProjectFormbannerProps> = ({ onSubmit, isDirty }) =
             {/** Add logic for disabling button later based on user type */}
             <Button
               data-testid={'open-delete-project-dialog-button'}
-              disabled={false}
+              disabled={isInputDisabled}
               iconStart={<IconTrash />}
               variant={ButtonVariant.Supplementary}
               onClick={handleProjectDelete}

--- a/src/components/shared/OverrunRightField.tsx
+++ b/src/components/shared/OverrunRightField.tsx
@@ -10,8 +10,9 @@ interface IOverrunRightField {
   control: HookFormControlType;
   readOnly?: boolean;
   cancelEdit?: boolean;
+  isInputDisabled: boolean;
 }
-const OverrunRightField: FC<IOverrunRightField> = ({ readOnly, control, cancelEdit }) => {
+const OverrunRightField: FC<IOverrunRightField> = ({ readOnly, control, cancelEdit, isInputDisabled }) => {
   const [editing, setEditing] = useState(false);
   const { t } = useTranslation();
 
@@ -36,7 +37,7 @@ const OverrunRightField: FC<IOverrunRightField> = ({ readOnly, control, cancelEd
               <FormFieldLabel
                 text={t('overrunRightValue', { value: field.value })}
                 onClick={!readOnly ? handleSetEditing : undefined}
-                disabled={readOnly}
+                disabled={isInputDisabled}
               />
             </div>
             {editing && (


### PR DESCRIPTION
### Description

Project manager is not allowed to delete projects. 
Also fixed permission to fields budgetOverRun (forbidden), projectQualityLevel (allowed), planningPhase (allowed) and constructionPhase (allowed).

Ticket: https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-270
Related PR in backend: https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/245

### Testing
Set the roles in backend: in file BaseViewSet.py modify the permission_classes so that it includes only the projectManager role. In frontend: in file AuthSlice.ts uncomment from the ad_groups the projectManager group. This will simulate the case when user has only projectManager role. 