### PR TITLE
HKISD-119: change location filter to use project card location lists

### DIFF
--- a/src/forms/useSearchForm.ts
+++ b/src/forms/useSearchForm.ts
@@ -37,7 +37,6 @@ const useSearchForm = () => {
     multiListsState.masterClass,
     multiListsState.class,
     multiListsState.subClass,
-    multiListsState.otherClassification,
   );
 
   const {

--- a/src/hooks/useMultiClassOptions.ts
+++ b/src/hooks/useMultiClassOptions.ts
@@ -2,7 +2,6 @@ import { IOption } from '@/interfaces/common';
 import {
   selectPlanningClasses,
   selectPlanningMasterClasses,
-  selectPlanningOtherClassifications,
   selectPlanningSubClasses,
 } from '@/reducers/classSlice';
 import { useCallback, useMemo } from 'react';
@@ -17,18 +16,15 @@ import { classesToOptions } from '@/utils/common';
  * @param masterClasses selected masterClass options
  * @param classes selected class options
  * @param subClasses selected subClass options
- * @param otherClassifications selected OtherClassification options
  */
 const useMultiClassOptions = (
   masterClasses: Array<IOption>,
   classes: Array<IOption>,
   subClasses: Array<IOption>,
-  otherClassifications: Array<IOption>,
 ) => {
   const allMasterClasses = useAppSelector(selectPlanningMasterClasses);
   const allClasses = useAppSelector(selectPlanningClasses);
   const allSubClasses = useAppSelector(selectPlanningSubClasses);
-  const allOtherClassifications = useAppSelector(selectPlanningOtherClassifications);
 
   const selectedClassParents = useMemo(
     () =>
@@ -47,11 +43,7 @@ const useMultiClassOptions = (
   );
 
   const getNextClasses = useCallback(() => {
-    if (!_.isEmpty(otherClassifications)) {
-      return allOtherClassifications.filter(
-        (c) => selectedSubClassParents.findIndex((sc) => sc === c.id) !== -1,
-      );
-    } else if (!_.isEmpty(subClasses)) {
+    if (!_.isEmpty(subClasses)) {
       return allClasses.filter(
         (c) => selectedSubClassParents.findIndex((sc) => sc === c.id) !== -1,
       );
@@ -62,15 +54,7 @@ const useMultiClassOptions = (
     } else {
       return allClasses;
     }
-  }, [allClasses, masterClasses, selectedSubClassParents, allOtherClassifications, subClasses]);
-
-  const getNextOtherClassifications = useCallback(() => {
-    if (!_.isEmpty(classes)) {
-      return allOtherClassifications.filter((aoc) => classes.findIndex((fc) => aoc.parent === fc.value) !== -1);
-    } else {
-      return allOtherClassifications;
-    }
-  }, [allOtherClassifications, classes]);
+  }, [allClasses, masterClasses, selectedSubClassParents, subClasses]);
 
   const getNextSubClasses = useCallback(() => {
     if (!_.isEmpty(classes)) {
@@ -102,7 +86,6 @@ const useMultiClassOptions = (
     masterClasses: classesToOptions(getNextMasterClasses()),
     classes: classesToOptions(getNextClasses()),
     subClasses: classesToOptions(getNextSubClasses()),
-    otherClassifications: classesToOptions(getNextOtherClassifications())
   };
 };
 

--- a/src/hooks/useMultiLocationOptions.ts
+++ b/src/hooks/useMultiLocationOptions.ts
@@ -7,7 +7,8 @@ import {
 import { useCallback, useMemo } from 'react';
 import { useAppSelector } from './common';
 import _ from 'lodash';
-import { classesToOptions } from '@/utils/common';
+import { classesToOptions, listItemsToOption } from '@/utils/common';
+import { selectProjectDistricts, selectProjectDivisions, selectProjectSubDivisions } from '@/reducers/listsSlice';
 
 /**
  * Populates the district, division and subDivision lists. Filters the available options of the lists
@@ -22,9 +23,9 @@ const useMultiLocationOptions = (
   divisions: Array<IOption>,
   subDivisions: Array<IOption>,
 ) => {
-  const allDistricts = useAppSelector(selectPlanningDistricts);
-  const allDivisions = useAppSelector(selectPlanningDivisions);
-  const allSubDivisions = useAppSelector(selectPlanningSubDivisions);
+  const allDistricts = useAppSelector(selectProjectDistricts);
+  const allDivisions = useAppSelector(selectProjectDivisions);
+  const allSubDivisions = useAppSelector(selectProjectSubDivisions);
 
   const selectedDivisionParent = useMemo(
     () =>
@@ -83,9 +84,9 @@ const useMultiLocationOptions = (
   }, [allDistricts, divisions, getNextDivisions, selectedDivisionParent, subDivisions]);
 
   return {
-    districts: classesToOptions(getNextDistricts()),
-    divisions: classesToOptions(getNextDivisions()),
-    subDivisions: classesToOptions(getNextSubDivisions()),
+    districts: listItemsToOption(getNextDistricts()),
+    divisions: listItemsToOption(getNextDivisions()),
+    subDivisions: listItemsToOption(getNextSubDivisions()),
   };
 };
 

--- a/src/hooks/useMultiLocationOptions.ts
+++ b/src/hooks/useMultiLocationOptions.ts
@@ -1,13 +1,8 @@
 import { IOption } from '@/interfaces/common';
-import {
-  selectPlanningDistricts,
-  selectPlanningDivisions,
-  selectPlanningSubDivisions,
-} from '@/reducers/locationSlice';
 import { useCallback, useMemo } from 'react';
 import { useAppSelector } from './common';
 import _ from 'lodash';
-import { classesToOptions, listItemsToOption } from '@/utils/common';
+import { listItemsToOption } from '@/utils/common';
 import { selectProjectDistricts, selectProjectDivisions, selectProjectSubDivisions } from '@/reducers/listsSlice';
 
 /**

--- a/src/utils/buildSearchParams.ts
+++ b/src/utils/buildSearchParams.ts
@@ -9,10 +9,12 @@ const buildSearchParams = (form: ISearchForm) => {
       case 'masterClass':
       case 'class':
       case 'subClass':
+        value.forEach((v: IOption) => searchParams.push(`${key}=${v.value}`));
+        break;
       case 'district':
       case 'division':
       case 'subDivision':
-        value.forEach((v: IOption) => searchParams.push(`${key}=${v.value}`));
+        value.forEach((v: IOption) => searchParams.push(`project${key}=${v.value}`));
         break;
       case 'programmedYes':
         value && searchParams.push('programmed=true');


### PR DESCRIPTION
- location filters in search used the locations from the hierarchy, which caused the lists to have multiple duplicates and missing options
- changed to use the same location options as the project card has
- API PR: https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/246