### PR TITLE
HKISD-119: fix dublicate classes search issue

### DIFF
--- a/src/hooks/useMultiClassOptions.ts
+++ b/src/hooks/useMultiClassOptions.ts
@@ -93,7 +93,7 @@ const useMultiClassOptions = (
       const isDuplicate = classNameCounts[c.name] > 1;
       if (isDuplicate) {
         const parentClass = allParentClasses.find((parentClass) => parentClass.id === c.parent);
-        const newName = `${c.name} (${parentClass?.name || ''})`;
+        const newName = `${c.name} (${parentClass?.name ?? ''})`;
         return { ...c, name: newName };
       }
       return c;

--- a/src/hooks/useMultiClassOptions.ts
+++ b/src/hooks/useMultiClassOptions.ts
@@ -8,6 +8,7 @@ import { useCallback, useMemo } from 'react';
 import { useAppSelector } from './common';
 import _ from 'lodash';
 import { classesToOptions } from '@/utils/common';
+import { IClass } from '@/interfaces/classInterfaces';
 
 /**
  * Populates the masterClass, class and subClass lists. Filters the available options of the lists
@@ -82,10 +83,28 @@ const useMultiClassOptions = (
     }
   }, [allMasterClasses, classes, getNextClasses, selectedClassParents, subClasses]);
 
+  const renameDublicateClassNames = (classes: IClass[], allParentClasses: IClass[]) => {
+    const classNameCounts = classes.reduce((acc: {[key: string]: number}, c) => {
+      acc[c.name] = (acc[c.name] || 0) + 1;
+      return acc;
+    }, {});
+  
+    const renamedClasses = classes.map((c) => {
+      const isDuplicate = classNameCounts[c.name] > 1;
+      if (isDuplicate) {
+        const parentClass = allParentClasses.find((parentClass) => parentClass.id === c.parent);
+        const newName = `${c.name} (${parentClass?.name || ''})`;
+        return { ...c, name: newName };
+      }
+      return c;
+    });
+    return renamedClasses;
+  }
+
   return {
     masterClasses: classesToOptions(getNextMasterClasses()),
-    classes: classesToOptions(getNextClasses()),
-    subClasses: classesToOptions(getNextSubClasses()),
+    classes: classesToOptions(renameDublicateClassNames(getNextClasses(), allMasterClasses)),
+    subClasses: classesToOptions(renameDublicateClassNames(getNextSubClasses(), allClasses)),
   };
 };
 

--- a/src/hooks/useMultiLocationOptions.ts
+++ b/src/hooks/useMultiLocationOptions.ts
@@ -1,4 +1,4 @@
-import { IOption } from '@/interfaces/common';
+import { IListItem, IOption } from '@/interfaces/common';
 import { useCallback, useMemo } from 'react';
 import { useAppSelector } from './common';
 import _ from 'lodash';
@@ -78,11 +78,36 @@ const useMultiLocationOptions = (
     }
   }, [allDistricts, divisions, getNextDivisions, selectedDivisionParent, subDivisions]);
 
-  return {
-    districts: listItemsToOption(getNextDistricts()),
-    divisions: listItemsToOption(getNextDivisions()),
-    subDivisions: listItemsToOption(getNextSubDivisions()),
+  const renameDublicateLocationNames = (locations: IListItem[], allParentLocations: IListItem[]) => {
+    const locationNameCounts = locations.reduce((acc: {[key: string]: number}, location) => {
+      acc[location.value] = (acc[location.value] || 0) + 1;
+      return acc;
+    }, {});
+
+    const renamedLocations = locations.map((l) => {
+      const isDuplicate = locationNameCounts[l.value] > 1;
+      if (isDuplicate) {
+        const parentLoaction = allParentLocations.find((parentClass) => parentClass.id === l.parent);
+        const newName = `${l.value} (${parentLoaction?.value || ''})`;
+        return { ...l, value: newName };
+      }
+      return l;
+    });
+    return renamedLocations;
   };
+
+  const getRenamedLocations = () => {
+    const distrcits = getNextDistricts();
+    const renamedDivisions = renameDublicateLocationNames(getNextDivisions(), distrcits);
+    const renamedSubDivisions = renameDublicateLocationNames(getNextSubDivisions(), renamedDivisions);
+    return {
+      districts: listItemsToOption(distrcits),
+      divisions: listItemsToOption(renamedDivisions),
+      subDivisions: listItemsToOption(renamedSubDivisions)
+    }
+  }
+
+  return getRenamedLocations();
 };
 
 export default useMultiLocationOptions;

--- a/src/hooks/useMultiLocationOptions.ts
+++ b/src/hooks/useMultiLocationOptions.ts
@@ -88,7 +88,7 @@ const useMultiLocationOptions = (
       const isDuplicate = locationNameCounts[l.value] > 1;
       if (isDuplicate) {
         const parentLoaction = allParentLocations.find((parentClass) => parentClass.id === l.parent);
-        const newName = `${l.value} (${parentLoaction?.value || ''})`;
+        const newName = `${l.value} (${parentLoaction?.value ?? ''})`;
         return { ...l, value: newName };
       }
       return l;


### PR DESCRIPTION
- ticket: [https://futurice.atlassian.net/browse/HKISD-119](https://futurice.atlassian.net/browse/HKISD-119)
- duplucate class and location options now have the parent class/location after it
- for example "Esirakentaminen" is now "Esirakentaminen (8 01 Kiinteä omaisuus)" and "Esirakentaminen (8 08 Projektialueiden infrarakentaminen)"
- location options has the same fix