### PR TITLE
fix: IO-412 red background if the diff is more than the threshold value

### DIFF
--- a/src/components/Report/PdfReports/TableRow.tsx
+++ b/src/components/Report/PdfReports/TableRow.tsx
@@ -448,7 +448,7 @@ const getForecastDeviationStyle = (type: string, deviationValueString: string) =
   const THRESHOLD = 200;
   const dValue = formattedNumberToNumber(deviationValueString);
 
-  if (dValue >= THRESHOLD) {
+  if (Math.abs(dValue) >= THRESHOLD) {
     return forecastReportStyles.forecastDeviationCostOver;
   }
 


### PR DESCRIPTION
A fix that will change the cell background if the value is less than -200 or more than 200.