### PR TITLE
test pagination for loading forced to frame projects

### DIFF
--- a/src/components/Report/ReportRow.tsx
+++ b/src/components/Report/ReportRow.tsx
@@ -32,11 +32,11 @@ const ReportRow: FC<IReportRowProps> = ({ type }) => {
       forcedToFrame: forcedToFrame,
       year: year,
     }, true);
-    const resultArray = res.results;
+    let resultArray = res.results;
     let nextResultsPath = res.next;
     while (nextResultsPath != null) {
       const nextResults = await getProjectsWithParams({fullPath: nextResultsPath})
-      resultArray.concat(nextResults.results);
+      resultArray = resultArray.concat(nextResults.results);
       nextResultsPath = nextResults.next;
     }
     const projects = resultArray.filter((p) => p.phase.value !== 'proposal' && p.phase.value !== 'design' && p.phase.value !== 'completed');

--- a/src/components/Report/ReportRow.tsx
+++ b/src/components/Report/ReportRow.tsx
@@ -26,12 +26,20 @@ const ReportRow: FC<IReportRowProps> = ({ type }) => {
   const getForcedToFrameData = async (year: number, forcedToFrame: boolean) => {
     // projects
     const res = await getProjectsWithParams({
+      params: "limit=100",
       direct: false,
       programmed: false,
       forcedToFrame: forcedToFrame,
       year: year,
     }, true);
-    const projects = res.results.filter((p) => p.phase.value !== 'proposal' && p.phase.value !== 'design' && p.phase.value !== 'completed');
+    const resultArray = res.results;
+    let nextResultsPath = res.next;
+    while (nextResultsPath != null) {
+      const nextResults = await getProjectsWithParams({fullPath: nextResultsPath})
+      resultArray.concat(nextResults.results);
+      nextResultsPath = nextResults.next;
+    }
+    const projects = resultArray.filter((p) => p.phase.value !== 'proposal' && p.phase.value !== 'design' && p.phase.value !== 'completed');
 
     /* needed for the operational environment analysis report. The budgets of the projects that are in the warranty phase
        need to be added to the sums there separately and because of that we check here which projects are in this phase

--- a/src/interfaces/projectInterfaces.ts
+++ b/src/interfaces/projectInterfaces.ts
@@ -246,6 +246,7 @@ export interface IProjectArea {
 export interface IProjectsResponse {
   results: Array<IProject>;
   count: number;
+  next?: string | null;
 }
 
 export interface IProjectResponse {

--- a/src/interfaces/searchInterfaces.ts
+++ b/src/interfaces/searchInterfaces.ts
@@ -51,10 +51,11 @@ export interface ISearchRequest {
 
 export interface IProjectSearchRequest
   extends Omit<ISearchRequest, 'fullPath' | 'limit' | 'order'> {
-  direct: boolean;
+  direct?: boolean;
   programmed?: boolean;
-  forcedToFrame: boolean;
-  year: number;
+  forcedToFrame?: boolean;
+  year?: number;
+  fullPath?: string;
 }
 
 export type SearchLimit = '10' | '20' | '30';

--- a/src/services/projectServices.ts
+++ b/src/services/projectServices.ts
@@ -89,7 +89,7 @@ export const getProjectsWithParams = async (
   req: IProjectSearchRequest,
   isCoordinator?: boolean,
 ): Promise<IProjectsResponse> => {
-  const { params, direct, programmed, forcedToFrame, year } = req;
+  const { params, direct, programmed, forcedToFrame, year, fullPath } = req;
 
   const allParams = `${params}&year=${year}&forcedToFrame=${forcedToFrame}&direct=${direct}${
     programmed ? '&programmed=true' : ''
@@ -101,7 +101,7 @@ export const getProjectsWithParams = async (
 
 
   try {
-    const res = await axios.get(url);
+    const res = await axios.get(fullPath ? fullPath : url);
     return res.data;
   } catch (e) {
     return Promise.reject(e);


### PR DESCRIPTION
- added pagination for when forced to frame projects are fetched for reports to see if it would make the api not crash cause of too large responses