### PR TITLE
fix: remove duplicate case labels after merge from main

### DIFF
--- a/src/components/Report/DownloadPdfButton.tsx
+++ b/src/components/Report/DownloadPdfButton.tsx
@@ -152,29 +152,6 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({
           }
           break;
         }
-        case Reports.OperationalEnvironmentAnalysisForcedToFrame: {
-          const res = await getForcedToFrameData(year, true);
-          const categories = await getCategories();
-
-          if (viewHasProjects(res) && categories) {
-            const coordinatorRows = getCoordinationTableRows(
-              res.classHierarchy,
-              res.forcedToFrameDistricts.districts,
-              res.initialSelections,
-              res.projects,
-              res.groupRes,
-            );
-            document = getPdfDocument(
-              type,
-              coordinatorRows,
-              undefined,
-              undefined,
-              categories,
-              res.projectsInWarrantyPhase,
-            );
-          }
-          break;
-        }
         case Reports.ConstructionProgram: {
           const res = await getPlanningData(year + 1);
           const resDivisions = await getDistricts();

--- a/src/hooks/useCsvData.ts
+++ b/src/hooks/useCsvData.ts
@@ -89,29 +89,6 @@ export const useCsvData = ({
           }
           break;
         }
-        case Reports.OperationalEnvironmentAnalysisForcedToFrame: {
-          const res = await getForcedToFrameData(year, true);
-          const categories = await getCategories();
-          if (res && res.projects.length > 0 && categories) {
-            const coordinatorRows = getCoordinationTableRows(
-              res.classHierarchy,
-              res.forcedToFrameDistricts.districts,
-              res.initialSelections,
-              res.projects,
-              res.groupRes,
-            );
-            data = await getReportData(
-              t,
-              type,
-              coordinatorRows,
-              undefined,
-              undefined,
-              categories,
-              res.projectsInWarrantyPhase,
-            );
-          }
-          break;
-        }
         case Reports.ConstructionProgram: {
           const res = await getPlanningData(year + 1);
           const resDivisions = await getDistricts();


### PR DESCRIPTION
After merging main to dev, the merge added extra case labels. This PR removes these.