### PR TITLE
IO-388: automate setting takuuaika phase to two years

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
@@ -254,11 +254,6 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
     return {
       validate: {
         isWarrantyPeriodStartValid: (date: string | null) => {
-          const phase = getValues('phase').label;
-
-          if (phase === 'warrantyPeriod' && !date) {
-            return t('validation.required', { field: t('validation.estWarrantyPhaseStart') });
-          }
 
           const afterConstructionEnd = validateAfter(date, 'estConstructionEnd', getValues, t);
 

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -119,11 +119,6 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
               fields.push(...fieldsIfEmpty([...combinedRequirements, 'constructionPhaseDetail']));
               break;
             case warrantyPeriodPhase:
-              if (isBefore(getToday(), getValues('estConstructionEnd'))) {
-                return t('validation.phaseTooEarly', { value: phase.label });
-              }
-              fields.push(...fieldsIfEmpty([...combinedRequirements]));
-              break;
             case completedPhase:
               if (isBefore(getToday(), getValues('estConstructionEnd'))) {
                 return t('validation.phaseTooEarly', { value: phase.label });

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -98,7 +98,6 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
             'estConstructionEnd',
             'personConstruction',
           ];
-          const warrantyPhaseRequirements = ['estWarrantyPhaseStart', 'estWarrantyPhaseEnd'];
           const combinedRequirements = [
             ...programmedRequirements,
             ...planningRequirements,
@@ -120,7 +119,6 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
               fields.push(...fieldsIfEmpty([...combinedRequirements, 'constructionPhaseDetail']));
               break;
             case warrantyPeriodPhase:
-              fields.push(...fieldsIfEmpty([...warrantyPhaseRequirements]));
               if (isBefore(getToday(), getValues('estConstructionEnd'))) {
                 return t('validation.phaseTooEarly', { value: phase.label });
               }

--- a/src/services/projectServices.ts
+++ b/src/services/projectServices.ts
@@ -19,7 +19,6 @@ const { REACT_APP_API_URL } = process.env;
 export const getProject = async (id: string): Promise<IProject> => {
   try {
     const res = await axios.get(`${REACT_APP_API_URL}/projects/${id}/`);
-    console.log(res.data)
     return res.data;
   } catch (e) {
     return Promise.reject(e);


### PR DESCRIPTION
- removed validation so that date scan be set in the backend instead