### PR TITLE
HKISD-220 & HKISD-227: Project manager right to change construction end year forwards and fix validation errors for dates

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -487,6 +487,7 @@ const ProjectForm = () => {
       {/* SECTION 2 - STATUS */}
       <ProjectStatusSection
         {...formProps}
+        constructionEndYear={project?.constructionEndYear}
         isInputDisabled={isInputDisabled}
         isUserOnlyProjectManager={isUserProjectManagerCheck}
         isUserOnlyViewer={isOnlyViewer}

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -25,7 +25,7 @@ import './styles.css';
 import { canUserEditProjectFormField } from '@/utils/validation';
 import { selectUser } from '@/reducers/authSlice';
 import { getProjectSapCosts } from '@/reducers/sapCostSlice';
-import { getYear } from '@/utils/dates';
+import { getYear, isSameYear, updateYear } from '@/utils/dates';
 import {
   selectPlanningDistricts,
   selectPlanningDivisions,
@@ -264,6 +264,24 @@ const ProjectForm = () => {
     return data;
   };
 
+  const updateDateBasedOnYear = (data: IProjectRequest, project: IProject) => {
+    if (data.planningStartYear) {
+      const estPlanningStart = data.estPlanningStart ?? project.estPlanningStart;
+      const isSamePlanningStartYear = isSameYear(estPlanningStart, data.planningStartYear);
+      if (!isSamePlanningStartYear) {
+        data.estPlanningStart = updateYear(data.planningStartYear, estPlanningStart)
+      }
+    }
+    if (data.constructionEndYear) {
+      const estConstructionEnd = data.estConstructionEnd ?? project.estConstructionEnd;
+      const isSameConstructionEndYear = isSameYear(estConstructionEnd, data.constructionEndYear);
+      if (!isSameConstructionEndYear) {
+        data.estConstructionEnd = updateYear(data.constructionEndYear, estConstructionEnd)
+      }
+    }
+    return data;
+  }
+
   // useEffect which triggers when form fields are reset by setting selectedProject after successful POST request
   useEffect(() => {
     if (projectMode !== 'new') {
@@ -301,6 +319,7 @@ const ProjectForm = () => {
         if (project?.id && projectMode === 'edit') {
           if (data.planningStartYear || data.constructionEndYear) {
             data = updateFinances(data, project);
+            data = updateDateBasedOnYear(data, project);
           }
 
           if (data?.projectClass && project.projectGroup) {

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
@@ -226,9 +226,6 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
           const yearInFormYearCell = getValues('constructionEndYear');
 
           if (!getFieldState('constructionEndYear').isDirty && yearToBeSet !== yearInFormYearCell && yearToBeSet) {
-            if (isUserOnlyProjectManager) {
-              return t('validation.userIsNotAllowedToModifyConstructionEndYear');
-            }
             return t('validation.constructionEndYearValidator');
           }
 

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -1,5 +1,5 @@
 import { FormSectionTitle, NumberField, SelectField } from '@/components/shared';
-import { FC, memo, useMemo, useState, useEffect } from 'react';
+import { FC, memo, useMemo, useState, useEffect, useCallback } from 'react';
 import { useOptions } from '@/hooks/useOptions';
 import { Control, UseFormGetValues } from 'react-hook-form';
 import { IProjectForm } from '@/interfaces/formInterfaces';
@@ -22,6 +22,7 @@ interface IProjectStatusSectionProps {
     label: string;
     control: Control<IProjectForm>;
   };
+  constructionEndYear: number | null | undefined;
   isInputDisabled: boolean;
   isUserOnlyProjectManager: boolean;
   isUserOnlyViewer: boolean;
@@ -35,6 +36,7 @@ const getPhaseIndexByPhaseId = (phaseId: string | undefined, phasesWithIndexes: 
 const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
   getFieldProps,
   getValues,
+  constructionEndYear,
   isInputDisabled,
   isUserOnlyProjectManager,
   isUserOnlyViewer
@@ -241,13 +243,17 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
     [getValues, t],
   );
 
-  const validateConstructionEndYear = useMemo(
+  const validateConstructionEndYear = useCallback(
     () => ({
       ...validateMaxNumber(3000, t),
       validate: {
         isConstructionEndYearValid: (date: string | null) => {
           if (!date) {
             return true;
+          }
+
+          if (isUserOnlyProjectManager && constructionEndYear && constructionEndYear > parseInt(date)) {
+            return t('validation.userNotAllowedToChangeYearBackwards');
           }
 
           const planStart = getValues('planningStartYear');
@@ -281,7 +287,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
         },
       },
     }),
-    [getValues, t],
+    [t, constructionEndYear, isUserOnlyProjectManager, getValues],
   );
 
   const validateCategory = useMemo(
@@ -367,8 +373,8 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
         <div className="form-col-md">
           <NumberField
             {...getFieldProps('constructionEndYear')}
-            rules={validateConstructionEndYear}
-            disabled={isInputDisabled}
+            rules={validateConstructionEndYear()}
+            disabled={isUserOnlyProjectManager ? false : isInputDisabled}
             readOnly={isUserOnlyViewer}
           />
         </div>

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -117,6 +117,7 @@
     "userIsNotAllowedToModifyPlanningStartYear": "Et voi muuttaa tämän kentän vuotta, vain päivää ja kuukautta. Muuttaaksesi Suunnittelun aloitusvuosi -kenttää ota yhteys alueen ohjelmoijaan.",
     "userIsNotAllowedToModifyConstructionEndYear": "Et voi muuttaa tämän kentän vuotta, vain päivää ja kuukautta. Muuttaaksesi Rakentamisen valmistumisvuosi -kenttää ota yhteys alueen ohjelmoijaan.",
     "userNotAllowedToChangePhaseBackwards": "Projektipäällikkönä voit muuttaa vaihetta vain eteenpäin",
+    "userNotAllowedToChangeYearBackwards": "Projektipäällikkönä voit muuttaa rakentamisen päättymisvuotta vain eteenpäin.",
     "estPlanningStart": "Suunnittelu alkaa",
     "estPlanningEnd": "Suunnittelu päättyy",
     "estConstructionStart": "Rakentaminen alkaa",


### PR DESCRIPTION
- added the right for project managers to change construction end year forwards
- added automation for changing the year in the date fields when year is modified form planningStartYear or constructionEndYear since it was intended to modify the year from the year fields only, it doesn't make sense that the user should modify it from two separate places.
- tickets: [https://futurice.atlassian.net/browse/HKISD-220](https://futurice.atlassian.net/browse/HKISD-220), [https://futurice.atlassian.net/browse/HKISD-227](https://futurice.atlassian.net/browse/HKISD-227)