### PR TITLE
IO-446: require dates when years are required

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -88,6 +88,8 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
           const programmedRequirements = [
             'planningStartYear',
             'constructionEndYear',
+            'estPlanningStart',
+            'estConstructionEnd',
             'category',
             'masterClass',
             'class',


### PR DESCRIPTION
- changed project card validation so that estPlanningStart and estConstructionEnd are required if planningStartYear or constructionEndYear is required
- ticket: [https://helsinkisolutionoffice.atlassian.net/browse/IO-446](https://helsinkisolutionoffice.atlassian.net/browse/IO-446)