### PR TITLE
IO-449/forecast report minor changes

### DIFF
--- a/src/components/Report/PdfReports/ReportContainer.tsx
+++ b/src/components/Report/PdfReports/ReportContainer.tsx
@@ -115,7 +115,7 @@ const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data, proje
             date={(reportType === Reports.OperationalEnvironmentAnalysis || reportType === Reports.OperationalEnvironmentAnalysisForcedToFrame) ? currentDate : ''}
           />
           <ReportTable reportType={reportType} data={data} projectsInWarrantyPhase={projectsInWarrantyPhase} hierarchyInForcedToFrame={forcedToFrameRows}/>
-          {reportType === Reports.Strategy || reportType === Reports.StrategyForcedToFrame || reportType == Reports.ForecastReport?
+          {reportType === Reports.Strategy || reportType === Reports.StrategyForcedToFrame || reportType == Reports.ForecastReport ?
             <StrategyReportFooter
               infoText={t('report.strategy.footerInfoText')}
               colorInfoTextOne={t('report.strategy.planning')}

--- a/src/components/Report/PdfReports/ReportTable.tsx
+++ b/src/components/Report/PdfReports/ReportTable.tsx
@@ -21,7 +21,7 @@ import {
 import { IProject } from '@/interfaces/projectInterfaces';
 import { IPlanningRow } from '@/interfaces/planningInterfaces';
 import BudgetBookSummaryTableHeader from './reportHeaders/BudgetBookSummaryTableHeader';
-import StrategyTableHeader from './reportHeaders/StrategyTableHeader';
+import StrategyAndForecastTableHeader from './reportHeaders/StrategyAndForecastTableHeader';
 import OperationalEnvironmentAnalysisTableHeader from './reportHeaders/OperationalEnvironmentAnalysisTableHeader';
 import OperationalEnvironmentCategorySummary from './OperationalEnvironmentCategorySummary';
 import TableRow from './TableRow';
@@ -91,9 +91,9 @@ const ReportTable: FC<IReportTableProps> = ({
         return <OperationalEnvironmentAnalysisTableHeader />
       case Reports.Strategy:
       case Reports.StrategyForcedToFrame:
-        return <StrategyTableHeader isForecastReport={false}/>;
+        return <StrategyAndForecastTableHeader isForecastReport={false}/>;
       case Reports.ForecastReport:
-        return <StrategyTableHeader isForecastReport={true} />;
+        return <StrategyAndForecastTableHeader isForecastReport={true} />;
       case Reports.ConstructionProgram:
         return <ConstructionProgramTableHeader />;
       case Reports.BudgetBookSummary:

--- a/src/components/Report/PdfReports/ReportTable.tsx
+++ b/src/components/Report/PdfReports/ReportTable.tsx
@@ -56,7 +56,7 @@ const getFlattenedRows = (
   }
 }
 
-const getStrategyReportRows = (type: ReportType, rows: IReportFlattenedRows[]) => {
+const getStrategyAndForecastReportRows = (type: ReportType, rows: IReportFlattenedRows[]) => {
   if (type === Reports.Strategy || type === Reports.StrategyForcedToFrame) {
     return flattenStrategyTableRows(rows);
   } else if (type === Reports.ForecastReport) {
@@ -82,7 +82,7 @@ const ReportTable: FC<IReportTableProps> = ({
     reportType === Reports.ConstructionProgram)
       ? getFlattenedRows(reportRows as IReportFlattenedRows[], reportType) : [];
 
-  const strategyReportRows = getStrategyReportRows(reportType, reportRows);
+  const strategyAndForecastReportRows = getStrategyAndForecastReportRows(reportType, reportRows);
 
   const getTableHeader = () => {
     switch (reportType) {
@@ -113,7 +113,7 @@ const ReportTable: FC<IReportTableProps> = ({
         <View fixed>{tableHeader}</View>
         <TableRow reportType={reportType} flattenedRows={
           reportType === Reports.Strategy || reportType === Reports.StrategyForcedToFrame || reportType == Reports.ForecastReport ?
-            strategyReportRows : flattenedRows
+            strategyAndForecastReportRows : flattenedRows
         }/>
       </View>
     </View>

--- a/src/components/Report/PdfReports/TableRow.tsx
+++ b/src/components/Report/PdfReports/TableRow.tsx
@@ -372,12 +372,16 @@ const getMonthCellStyle = (monthCell: string | undefined, side: string) => {
         return {
           ...strategyReportStyles.monthCellBlack,
           borderRight: '0px',
+          paddingLeft: '0px',
+          paddingRight: '0px',
           width: "15px"
         }
       } else {
         return {
           ...strategyReportStyles.monthCellGreen,
           borderLeft: '0px',
+          paddingLeft: '0px',
+          paddingRight: '0px',
           width: "15px"
         }
       }

--- a/src/components/Report/PdfReports/TableRow.tsx
+++ b/src/components/Report/PdfReports/TableRow.tsx
@@ -390,7 +390,7 @@ const getMonthCellStyle = (monthCell: string | undefined, side: string) => {
   }
 }
 
-const getStrategyRowStyle = (rowType: string, depth: number) => {
+const getStrategyAndForecastRowStyle = (rowType: string, depth: number) => {
   switch (rowType) {
     case 'masterClass':
       return strategyReportStyles.masterClassRow;
@@ -479,7 +479,7 @@ const Row: FC<IRowProps> = memo(({ flattenedRow, index, reportType }) => {
 
           if (flattenedRow) {
               tableRow =
-                <View wrap={false} style={getStrategyRowStyle(flattenedRow.type ?? '', index ?? 0)} key={flattenedRow.id}>
+                <View wrap={false} style={getStrategyAndForecastRowStyle(flattenedRow.type ?? '', index ?? 0)} key={flattenedRow.id}>
                     <Text style={
                       classNameTypes.includes(flattenedRow.type ?? '')
                       ? strategyReportStyles.classNameCell

--- a/src/components/Report/PdfReports/reportHeaders/StrategyAndForecastTableHeader.tsx
+++ b/src/components/Report/PdfReports/reportHeaders/StrategyAndForecastTableHeader.tsx
@@ -56,7 +56,7 @@ interface StrategyTableHeaderProps {
   isForecastReport: boolean;
 }
 
-const StrategyTableHeader = ({ isForecastReport }: StrategyTableHeaderProps) => {
+const StrategyAndForecastTableHeader = ({ isForecastReport }: StrategyTableHeaderProps) => {
   const { t } = useTranslation();
   const year = isForecastReport ? new Date().getFullYear() : new Date().getFullYear() + 1;
 
@@ -94,4 +94,4 @@ const StrategyTableHeader = ({ isForecastReport }: StrategyTableHeaderProps) => 
   );
 };
 
-export default memo(StrategyTableHeader);
+export default memo(StrategyAndForecastTableHeader);

--- a/src/components/Report/PdfReports/reportHeaders/StrategyAndForecastTableHeader.tsx
+++ b/src/components/Report/PdfReports/reportHeaders/StrategyAndForecastTableHeader.tsx
@@ -40,6 +40,7 @@ const styles = StyleSheet.create({
   },
   budgetCell: {
     ...cellStyles,
+    paddingRight: '3px',
     width: '80px',
   },
   monthCell: {
@@ -67,13 +68,13 @@ const StrategyAndForecastTableHeader = ({ isForecastReport }: StrategyTableHeade
         <Text style={styles.projectCell}>{`\n${t('report.strategy.projectNameTitle')}`}</Text>
         <Text style={styles.projectManagerCell}>{`${t('report.strategy.projectsTitle')}\n${t('report.strategy.projectManagerTitle')}`}</Text>
         <Text style={styles.projectPhaseCell}>{`\n${t('projectPhase')}`}</Text>
-        <Text style={styles.budgetCell}>{`\nTA ${year}`}</Text>
-        <Text style={styles.budgetCell}>{`\nTS ${year}`}</Text>
+        <Text style={styles.budgetCell}>{`${t('report.shared.ta')} ${year}\n${t('report.shared.kiloEuro')}`}</Text>
+        <Text style={styles.budgetCell}>{`${t('report.shared.ts')} ${year}\n${t('report.shared.kiloEuro')}`}</Text>
         {
           isForecastReport ?
             <>
-              <Text style={styles.budgetCell}>{`\nEnnuste ${year}`}</Text>
-              <Text style={styles.budgetCell}>{`\nPoikkeama`}</Text>
+              <Text style={styles.budgetCell}>{`${t('report.forecastReport.forecastValue')} ${year}\n${t('report.shared.kiloEuro')}`}</Text>
+              <Text style={styles.budgetCell}>{`${t('report.forecastReport.differenceValue')}\n${t('report.shared.kiloEuro')}`}</Text>
             </> : null
         }
         <Text style={styles.monthCell}>{`${year}\n01`}</Text>

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -460,6 +460,11 @@
   "proceed": "Jatka",
   "newProject": "Uusi hanke",
   "report": {
+    "shared": {
+      "ta": "TA",
+      "ts": "TS",
+      "kiloEuro": "k€"
+    },
     "warrantyPeriodPhaseNotIncluded": "Huomaa ettei takuuajalla olevat hankkeet tule mukaan tälle raportille.",
     "operationalEnvironmentAnalysis": {
       "rowTitle": "Kategorisointiraportti (Koordinointinäkymä)",
@@ -533,7 +538,9 @@
       "subtitleTwo": "Ennusteraportti {{currentDate}}",
       "projectNameTitle": "Hanke",
       "projectsTitle": "Kohteen",
-      "projectManagerTitle": "projektipäällikkö"
+      "projectManagerTitle": "projektipäällikkö",
+      "forecastValue": "Ennuste",
+      "differenceValue": "Poikkeama"
     }
   },
   "downloadPdf": "Lataa {{name}} (.pdf)",

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -155,22 +155,25 @@ const getProjectPhase = (type: ReportType , project: IProject) => {
 }
 
 const getStrategyReportProjectPhasePerMonth = (type: ReportType, project: IProject, month: number) => {
-  const yearsForward = type == Reports.ForecastReport ? 0 : 1;
-  const monthStartDate = new Date(new Date().getFullYear() + yearsForward, month - 1, 1);
-  const monthEndDate = new Date(new Date().getFullYear() + yearsForward, month, 0);
+  const isForecastReport = type === Reports.ForecastReport;
+  const yearsForward = isForecastReport ? 0 : 1;
+  const currentYearPlusYearsForward = new Date().getFullYear() + yearsForward;
+  const monthStartDate = new Date(currentYearPlusYearsForward, month - 1, 1);
+  const monthEndDate = new Date(currentYearPlusYearsForward, month, 0);
+  const isForecastOrStrategyReport = [Reports.Strategy, Reports.ForecastReport].includes(type as Reports)
   const dateFormat = "DD.MM.YYYY";
 
   const planningStartYear = () => {
-    if (type === Reports.Strategy) return project.planningStartYear;
+    if (isForecastOrStrategyReport) return project.planningStartYear;
 
     return project.frameEstPlanningStart ? getYear(project.frameEstPlanningStart) : project.planningStartYear;
   }
 
-  const isPlanning = type === Reports.Strategy ?
+  const isPlanning = isForecastOrStrategyReport ?
     projectIsInPlanningPhase(project.estPlanningStart, monthStartDate, project.estPlanningEnd, monthEndDate, planningStartYear(), dateFormat) :
     projectIsInPlanningPhase(project.frameEstPlanningStart, monthStartDate, project.frameEstPlanningEnd, monthEndDate, planningStartYear(), dateFormat);
 
-  const isConstruction = type === Reports.Strategy ?
+  const isConstruction = isForecastOrStrategyReport ?
     projectIsInConstructionPhase(project.estConstructionStart, monthStartDate, project.estConstructionEnd, monthEndDate, project.estPlanningStart, planningStartYear(), dateFormat) :
     projectIsInConstructionPhase(project.frameEstConstructionStart, monthStartDate, project.frameEstConstructionEnd, monthEndDate, project.frameEstPlanningStart, planningStartYear(), dateFormat);
 

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -139,25 +139,19 @@ const getPlannedBudgetsByCategories = (classItem: IPlanningRow, category: string
   return totals;
 }
 
-const getProjectPhase = (project: IProject) => {
+const getProjectPhase = (type: ReportType , project: IProject) => {
   const yearStartDate = new Date(new Date().getFullYear() + 1, 0, 1);
   const yearEndDate = new Date(new Date().getFullYear() + 1, 11, 0);
   const dateFormat = "DD.MM.YYYY";
   const isPlanning = projectIsInPlanningPhase(project.estPlanningStart, yearStartDate, project.estPlanningEnd, yearEndDate, project.planningStartYear, dateFormat);
   const isConstruction = projectIsInConstructionPhase(project.estConstructionStart, yearStartDate, project.estConstructionEnd, yearEndDate, project.estPlanningStart, project.planningStartYear, dateFormat);
+  const isForecastReport = type === Reports.ForecastReport;
 
-  if (isPlanning && isConstruction) {
-    return "s r";
-  }
-  else if (isPlanning) {
-      return "s";
-  }
-  else if (isConstruction) {
-      return "r";
-  }
-  else {
-    return "";
-  }
+  if (isForecastReport) return t(`option.${project.phase.value}`);
+  if (isPlanning && isConstruction) return "s r";
+  if (isPlanning) return "s";
+  if (isConstruction) return "r";
+  return "";
 }
 
 const getStrategyReportProjectPhasePerMonth = (type: ReportType, project: IProject, month: number) => {
@@ -327,7 +321,7 @@ const convertToStrategyReportProjects = (
       costForcedToFrameBudget: costForcedToFrameBudget,   // Ennuste
       costForecastDeviation: costForecastDeviation,       // Poikkeama
       projectManager: p.personPlanning?.lastName ?? (t('report.strategy.projectManagerMissing') as string),
-      projectPhase: getProjectPhase(p),
+      projectPhase: getProjectPhase(type, p),
       januaryStatus: getStrategyReportProjectPhasePerMonth(type, p, 1),
       februaryStatus: getStrategyReportProjectPhasePerMonth(type, p, 2),
       marchStatus: getStrategyReportProjectPhasePerMonth(type, p, 3),

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -272,7 +272,7 @@ const isProjectInPlanningOrConstruction = (props: IYearCheck, yearsForward: numb
   }
 }
 
-const convertToStrategyReportProjects = (
+const convertToStrategyAndForecastReportProjects = (
   type: ReportType,
   projects: IProject[],
   forcedToFrameProjects?: IProject[]
@@ -766,7 +766,7 @@ export const convertToReportRows = (
           const forcedToFrameChildren = forcedToFrameData ? forcedToFrameData[0].children : [];
           const forcedToFrameBudget = forcedToFrameClass?.cells[0].plannedBudget ?? "0";
           const frameBudget = frameBudgetHandler(c.type, c.cells, c.path);
-          const rowProjects = c.projectRows.length ? convertToStrategyReportProjects(reportType, c.projectRows, forcedToFrameClass?.projectRows) : [];
+          const rowProjects = c.projectRows.length ? convertToStrategyAndForecastReportProjects(reportType, c.projectRows, forcedToFrameClass?.projectRows) : [];
 
           if (isNotGroupOrRowHasProjects(c.type, rowProjects)) {
             const rowChildren = c.children.length ? convertToReportRows(c.children, reportType, categories, t, undefined, undefined, undefined, forcedToFrameChildren) : [];
@@ -795,7 +795,7 @@ export const convertToReportRows = (
 
       for (const c of rows) {
         const frameBudget = frameBudgetHandler(c.type, c.cells, c.path);
-        const rowProjects = c.projectRows.length ? convertToStrategyReportProjects(reportType, c.projectRows) : [];
+        const rowProjects = c.projectRows.length ? convertToStrategyAndForecastReportProjects(reportType, c.projectRows) : [];
 
         if (hasBudgetData(c) && (isNotGroupOrRowHasProjects(c.type, rowProjects))) {
           const rowChildren = c.children.length ? convertToReportRows(c.children, reportType, categories, t) : [];


### PR DESCRIPTION
- add kilo euros on header row and refactor texts
- show project phase on Forecast report instead of "r" and "s"
- show coordinator timeline on Forecast report instead of forcedToFrame dates

extra:
- fix: set correct width for split planning and customer cells
- refactor: change file and function names

https://helsinkisolutionoffice.atlassian.net/browse/IO-449