### PR TITLE
IO-426: budget overrun reason to project card

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -30,6 +30,7 @@ import {
   mockSubDivisions,
 } from './mocks/mockLocations';
 import {
+  mockBudgetOverrunReasons,
   mockConstructionPhaseDetails,
   mockConstructionPhases,
   mockPlanningPhases,
@@ -99,6 +100,7 @@ describe('App', () => {
       expect(lists.constructionPhases).toStrictEqual(mockConstructionPhases.data);
       expect(lists.planningPhases).toStrictEqual(mockPlanningPhases.data);
       expect(lists.responsibleZones).toStrictEqual(mockResponsibleZones.data);
+      expect(lists.budgetOverrunReasons).toStrictEqual(mockBudgetOverrunReasons.data);
       expect(hashTags.hashTags).toStrictEqual(sortByHashtagName(mockHashTags.data.hashTags));
       expect(hashTags.popularHashTags).toStrictEqual(mockHashTags.data.popularHashTags);
       // Planning classes

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
@@ -88,6 +88,7 @@ const render = async () =>
             projectDistricts: [],
             projectDivisions: [],
             projectSubDivisions: [],
+            budgetOverrunReasons: [],
             error: {},
           },
           hashTags: {

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -538,7 +538,11 @@ const ProjectForm = () => {
         isUserOnlyViewer={isOnlyViewer}
       />
       {/* SECTION 7 - PROJECT PROGRAM */}
-      <ProjectProgramSection {...formProps} isUserOnlyViewer={isOnlyViewer} />
+      <ProjectProgramSection 
+        {...formProps}
+        isUserOnlyViewer={isOnlyViewer}
+        isInputDisabled={isInputDisabled}
+      />
       {/* BANNER */}
       {!isOnlyViewer &&
         <ProjectFormBanner

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectProgramSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectProgramSection.tsx
@@ -1,8 +1,11 @@
-import { FormSectionTitle } from '@/components/shared';
+import { FormSectionTitle, SelectField } from '@/components/shared';
 import TextAreaField from '@/components/shared/TextAreaField';
 import { FC, memo } from 'react';
 import { Control } from 'react-hook-form';
 import { IProjectForm } from '@/interfaces/formInterfaces';
+import { useOptions } from '@/hooks/useOptions';
+import { validateMaxLength } from '@/utils/validation';
+import { t } from 'i18next';
 
 interface IProjectProgramSectionProps {
   getFieldProps: (name: string) => {
@@ -11,11 +14,34 @@ interface IProjectProgramSectionProps {
     control: Control<IProjectForm>;
   };
   isUserOnlyViewer: boolean;
+  isInputDisabled: boolean;
 }
-const ProjectProgramSection: FC<IProjectProgramSectionProps> = ({ getFieldProps, isUserOnlyViewer }) => {
+const ProjectProgramSection: FC<IProjectProgramSectionProps> = ({ getFieldProps, isUserOnlyViewer, isInputDisabled }) => {
+  const budgetOverrunReasons = useOptions('budgetOverrunReasons');
+
   return (
     <div className="w-full" id="basics-location-section">
       <FormSectionTitle {...getFieldProps('projectProgramTitle')} />
+      <div className="form-row">
+        <div className="form-col-xxl">
+          <SelectField
+              {...getFieldProps('budgetOverrunReason')}
+              options={budgetOverrunReasons}
+              size='full'
+              disabled={isInputDisabled}
+              readOnly={isUserOnlyViewer}
+            />
+        </div>
+      </div>
+      <div className="form-row">
+        <div className="form-col-xxl">
+          <TextAreaField
+            {...getFieldProps('otherBudgetOverrunReason')}
+            rules={{ ...validateMaxLength(200, t) }}
+            readOnly={isUserOnlyViewer}
+          />
+        </div>
+      </div>
       <div className="form-row">
         <div className="form-col-xxl">
           <TextAreaField {...getFieldProps('projectProgram')} readOnly={isUserOnlyViewer}/>

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectProgramSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectProgramSection.tsx
@@ -1,13 +1,15 @@
 import { FormSectionTitle, SelectField } from '@/components/shared';
 import TextAreaField from '@/components/shared/TextAreaField';
-import { FC, memo } from 'react';
-import { Control } from 'react-hook-form';
+import { FC, memo, useMemo } from 'react';
+import { Control, UseFormGetValues } from 'react-hook-form';
 import { IProjectForm } from '@/interfaces/formInterfaces';
 import { useOptions } from '@/hooks/useOptions';
 import { validateMaxLength } from '@/utils/validation';
 import { t } from 'i18next';
+import { IOption } from '@/interfaces/common';
 
 interface IProjectProgramSectionProps {
+  getValues: UseFormGetValues<IProjectForm>;
   getFieldProps: (name: string) => {
     name: string;
     label: string;
@@ -16,8 +18,42 @@ interface IProjectProgramSectionProps {
   isUserOnlyViewer: boolean;
   isInputDisabled: boolean;
 }
-const ProjectProgramSection: FC<IProjectProgramSectionProps> = ({ getFieldProps, isUserOnlyViewer, isInputDisabled }) => {
+const ProjectProgramSection: FC<IProjectProgramSectionProps> = ({ getValues, getFieldProps, isUserOnlyViewer, isInputDisabled }) => {
   const budgetOverrunReasons = useOptions('budgetOverrunReasons');
+
+  const validateBudgetOverrunReason = useMemo(
+    () => ({
+      validate: {
+        isBudgetOverrunReasonValid: (budgetOverrunReason: IOption) => {
+          const mappedBudgetOverrunReason = budgetOverrunReasons.find(item => item.value === budgetOverrunReason.value);
+          const otherReason = getValues('otherBudgetOverrunReason');
+
+          if (mappedBudgetOverrunReason?.label == 'otherReason' && otherReason == '') {
+            return t('validation.required', { field: t('projectForm.otherBudgetOverrunReason') });
+          }
+          return true;
+        },
+      },
+    }),
+    [budgetOverrunReasons, getValues],
+  );
+
+  const validateOtherReasonField = useMemo(
+    () => ({
+      validate: {
+        isOtherReasonFieldValid: (otherReasonField: string) => {
+          const budgetOverrunReason = budgetOverrunReasons.find(item => item.value === getValues('budgetOverrunReason').value);
+          const isBudgetOverrunReasonOtherReason = budgetOverrunReason?.label == 'otherReason'
+
+          if (isBudgetOverrunReasonOtherReason && otherReasonField == '') {
+            return t('validation.required', { field: t('projectForm.otherBudgetOverrunReason') });
+          }
+          return true;
+        },
+      },
+    }),
+    [budgetOverrunReasons, getValues],
+  );
 
   return (
     <div className="w-full" id="basics-location-section">
@@ -27,6 +63,7 @@ const ProjectProgramSection: FC<IProjectProgramSectionProps> = ({ getFieldProps,
           <SelectField
               {...getFieldProps('budgetOverrunReason')}
               options={budgetOverrunReasons}
+              rules={validateBudgetOverrunReason}
               size='full'
               disabled={isInputDisabled}
               readOnly={isUserOnlyViewer}
@@ -37,7 +74,7 @@ const ProjectProgramSection: FC<IProjectProgramSectionProps> = ({ getFieldProps,
         <div className="form-col-xxl">
           <TextAreaField
             {...getFieldProps('otherBudgetOverrunReason')}
-            rules={{ ...validateMaxLength(200, t) }}
+            rules={{ ...validateMaxLength(200, t), ...validateOtherReasonField }}
             readOnly={isUserOnlyViewer}
           />
         </div>

--- a/src/components/TopBar/TopBar.test.tsx
+++ b/src/components/TopBar/TopBar.test.tsx
@@ -55,6 +55,7 @@ const render = async (customRoute?: string) =>
             projectDistricts: [],
             projectDivisions: [],
             projectSubDivisions: [],
+            budgetOverrunReasons: [],
             error: {},
           },
         },

--- a/src/components/shared/TextField.tsx
+++ b/src/components/shared/TextField.tsx
@@ -14,6 +14,7 @@ interface ITextFieldProps {
   tooltip?: string;
   disabled?: boolean;
   readOnlyValue?: string;
+  size?: string;
 }
 
 const TextField: FC<ITextFieldProps> = ({
@@ -51,6 +52,7 @@ const TextField: FC<ITextFieldProps> = ({
             helperText={tooltip}
             style={{ paddingTop: hideLabel ? '1.745rem' : '0' }}
             disabled={disabled}
+            size={1000}
           />
         </div>
       )}

--- a/src/components/shared/TextField.tsx
+++ b/src/components/shared/TextField.tsx
@@ -14,7 +14,6 @@ interface ITextFieldProps {
   tooltip?: string;
   disabled?: boolean;
   readOnlyValue?: string;
-  size?: string;
 }
 
 const TextField: FC<ITextFieldProps> = ({

--- a/src/components/shared/TextField.tsx
+++ b/src/components/shared/TextField.tsx
@@ -51,7 +51,6 @@ const TextField: FC<ITextFieldProps> = ({
             helperText={tooltip}
             style={{ paddingTop: hideLabel ? '1.745rem' : '0' }}
             disabled={disabled}
-            size={1000}
           />
         </div>
       )}

--- a/src/forms/useProjectForm.ts
+++ b/src/forms/useProjectForm.ts
@@ -162,6 +162,8 @@ const useProjectFormValues = () => {
       personConstruction: personToOption(project?.personConstruction),
       personProgramming: personToOption(project?.personProgramming),
       otherPersons: value(project?.otherPersons),
+      budgetOverrunReason: listItemToOption(project?.budgetOverrunReason),
+      otherBudgetOverrunReason: value(project?.otherBudgetOverrunReason)
     }),
 
     [project, classes, subClasses, masterClasses, districts, divisions, subDivisions ],

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -100,7 +100,19 @@
     "north": "Pohjoinen",
     "cityRenewal": "Kaupunkiuudistus",
     "bigTrafficProjects": "Suuret liikennehankkeet",
-    "spesialtyStructures": "Taitorakenne"
+    "spesialtyStructures": "Taitorakenne",
+    "consultancyPlanningDelay": "Konsulttisuunnittelun viivästyminen",
+    "permitProcessingDelay": "Lupakäsittelyiden viivästyminen",
+    "complaintsDelay": "Valituksista aiheutunut viivästyminen",
+    "personnelResourcesDelay": "Henkilöstöresursseista johtuva viivästyminen",
+    "budgetDeficitDelay": "Määrärahavajeesta johtuva myöhäistäminen",
+    "earlierSchedule": "Aikataulun aikaistus",
+    "totalCostsClarification": "Kokonaiskustannusten tarkentuminen",
+    "projectCoordinationScheduleChange": "Hankkeiden yhteensovituksesta johtuva aikataulumuutos",
+    "weatherConditionsChange": "Sääolosuhteista johtuva muutos",
+    "contractorScheduleChange": "Urakan toteuttajasta johtuva aikataulumuutos",
+    "cityPlanScheduleChange": "Asemakaavan aikataulumuutokset",
+    "otherReason": "Muu syy"
   },
   "validation": {
     "required": "Täytä {{field}}",
@@ -230,7 +242,9 @@
     },
     "warrantyPhase": "Takuuaika",
     "estWarrantyPhaseStart": "Alkaa",
-    "estWarrantyPhaseEnd": "Päättyy"
+    "estWarrantyPhaseEnd": "Päättyy",
+    "budgetOverrunReason": "Budjettipoikkeaman selitys",
+    "otherBudgetOverrunReason": "Muu syy budjettipoikkeamalle"
   },
   "searchForm": {
     "searchWord": "Mitä haet?",

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -70,7 +70,8 @@ export type ListType =
   | 'programmedYears'
   | 'projectDistricts'
   | 'projectSubDistricts'
-  | 'projectSubSubDistricts';
+  | 'projectSubSubDistricts'
+  | 'budgetOverrunReasons';
 
 type NotificationType = 'notification' | 'toast';
 export type NotificationColorType = 'error' | 'info' | 'success';

--- a/src/interfaces/formInterfaces.ts
+++ b/src/interfaces/formInterfaces.ts
@@ -82,6 +82,8 @@ export interface IProjectForm {
   district: IOption;
   division: IOption;
   subDivision: IOption;
+  budgetOverrunReason: IOption;
+  otherBudgetOverrunReason: string;
 }
 
 export interface ISearchForm {

--- a/src/interfaces/projectInterfaces.ts
+++ b/src/interfaces/projectInterfaces.ts
@@ -93,6 +93,8 @@ export interface IProject {
   frameEstWarrantyPhaseStart: string | null;
   frameEstWarrantyPhaseEnd: string | null;
   currentYearsSapValues?: Array<ISapCost> | null;
+  budgetOverrunReason?: IListItem;
+  otherBudgetOverrunReason?: string;
 }
 
 export interface IProjectRequest {
@@ -164,6 +166,8 @@ export interface IProjectRequest {
   frameEstPlanningEnd?: string | null;
   frameEstConstructionStart?: string | null;
   frameEstConstructionEnd?: string | null;
+  budgetOverrunReason?: string;
+  otherBudgetOverrunReason?: string;
 }
 
 export interface IProjectPatchRequestObject {

--- a/src/mocks/mockLists.ts
+++ b/src/mocks/mockLists.ts
@@ -314,3 +314,20 @@ export const mockResponsiblePersons: { data: Array<IListItem> } = {
     },
   ],
 };
+
+export const mockBudgetOverrunReasons: {data: Array<IListItem> } = {
+  data: [
+    {
+      id: '14cb7de8-233c-415f-9b46-235d3d7989d5',
+      value: 'permitProcessingDelay'
+    },
+    {
+      id: 'f777fed1-e6b3-4222-a42c-e67fbb6d5277',
+      value: 'complaintsDelay'
+    },
+    {
+      id: 'dc33a8e5-40fb-4660-884c-38f0423fb898',
+      value: 'otherReason'
+    },
+  ]
+}

--- a/src/reducers/listsSlice.ts
+++ b/src/reducers/listsSlice.ts
@@ -13,6 +13,7 @@ import {
   getResponsibleZones,
   getPersons,
   getDistricts,
+  getBudgetOverrunReasons,
 } from '@/services/listServices';
 import { RootState } from '@/store';
 import { setProgrammedYears } from '@/utils/common';
@@ -34,6 +35,7 @@ export interface IListState {
   projectDistricts: Array<IListItem>;
   projectDivisions: Array<IListItem>;
   projectSubDivisions: Array<IListItem>;
+  budgetOverrunReasons: Array<IListItem>;
   error: IError | null | unknown;
 }
 
@@ -52,6 +54,7 @@ const initialState: IListState = {
   projectDistricts: [],
   projectDivisions: [],
   projectSubDivisions: [],
+  budgetOverrunReasons: [],
   programmedYears: setProgrammedYears(),
   error: null,
 };
@@ -101,7 +104,8 @@ export const getListsThunk = createAsyncThunk('lists/get', async (_, thunkAPI) =
       programmedYears: setProgrammedYears(),
       projectDistricts: getProjectDistricts(districts, "district"),
       projectDivisions: getProjectDistricts(districts, "division"),
-      projectSubDivisions: getProjectDistricts(districts, "subDivision")
+      projectSubDivisions: getProjectDistricts(districts, "subDivision"),
+      budgetOverrunReasons: await getBudgetOverrunReasons(),
     };
   } catch (err) {
     return thunkAPI.rejectWithValue(err);
@@ -131,5 +135,6 @@ export const selectProjectDivisions = (state: RootState) => state.lists.projectD
 export const selectProjectSubDivisions = (state: RootState) => state.lists.projectSubDivisions;
 export const selectCategories = (state: RootState) => state.lists.categories;
 export const selectProjectPhases = (state: RootState) => state.lists.phases;
+export const selectBudgetOverrunReasons = (state: RootState) => state.lists.budgetOverrunReasons;
 
 export default listsSlice.reducer;

--- a/src/services/listServices.ts
+++ b/src/services/listServices.ts
@@ -112,3 +112,12 @@ export const getDistricts = async (): Promise<Array<IProjectDistrict>> => {
     return Promise.reject(e);
   }
 }
+
+export const getBudgetOverrunReasons = async () => {
+  try {
+    const res = await axios.get(`${REACT_APP_API_URL}/budget-overrun-reasons/`);
+    return res.data;
+  } catch (e) {
+    return Promise.reject(e);
+  }
+};

--- a/src/utils/mockGetResponseProvider.ts
+++ b/src/utils/mockGetResponseProvider.ts
@@ -3,6 +3,7 @@ import { mockCoordinatorNotes } from '@/mocks/mockCoordinatorNotes';
 import { mockGroups } from '@/mocks/mockGroups';
 import { mockHashTags } from '@/mocks/mockHashTags';
 import {
+  mockBudgetOverrunReasons,
   mockConstructionPhaseDetails,
   mockConstructionPhases,
   mockPlanningPhases,
@@ -108,6 +109,8 @@ export const mockGetResponseProvider = () =>
         return Promise.resolve(mockCoordinatorNotes);
       case url.toLocaleLowerCase().includes(`/sap-current-year-costs/${year}/`):
         return Promise.resolve(mockSapCosts);
+      case url.toLocaleLowerCase().includes('/budget-overrun-reasons/'):
+        return Promise.resolve(mockBudgetOverrunReasons);
       default:
         console.log('not found!: ', url);
 


### PR DESCRIPTION
- added two new fields to project card (budgetOverrunReason, otherBudgetOverrunReason)
- added validation so that other reason field can't be null if "other reason" is selected from the budgetOverrunReasons
- ticket: [https://helsinkisolutionoffice.atlassian.net/browse/IO-426](https://helsinkisolutionoffice.atlassian.net/browse/IO-426)
- API PR: [https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/294](https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/294)