### PR TITLE
fix: show default phase correctly when creating a new project

### DIFF
--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -87,6 +87,7 @@ const ProjectHeader: FC = () => {
   );
 
   const phase = watch('phase');
+  const projectHeaderPhaseString = getValues('phase')?.label ? t(`option.${(getValues('phase')).label}`) : "";
 
   useEffect(() => {
     const newIconKey = mapIconKey(phase?.label);
@@ -110,10 +111,12 @@ const ProjectHeader: FC = () => {
             data-testid="project-header-name-fields"
           >
             <ProjectNameFields control={control} />
-            <div className="project-header-phase">
-              <div className="project-header-icon">{icon}</div>
-              <div>{t(`option.${getValues('phase').label}`)}</div>
-            </div>
+            { projectHeaderPhaseString &&
+              <div className="project-header-phase">
+                  <div className="project-header-icon">{icon}</div>
+                  <div>{projectHeaderPhaseString}</div>
+              </div>
+            }
           </div>
         </div>
         <div className="mr-3 flex-1" data-testid="project-header-right">


### PR DESCRIPTION
When a new project is created, it shows string that is not translated because missing variable

![image](https://github.com/user-attachments/assets/08afceee-4c51-409c-beee-915bdb63ef19)

This hides both icon and the phase string when phase is not selected.

![image](https://github.com/user-attachments/assets/a1f3ac4b-b18d-4aea-86b3-b610102ff210)
