### PR TITLE
IO-390 make it possible to select year for strategy report

### DIFF
--- a/src/components/Report/DownloadCsvButton.tsx
+++ b/src/components/Report/DownloadCsvButton.tsx
@@ -24,15 +24,16 @@ const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({
   getPlanningData,
   getPlanningRows,
   getCategories,
+  year = new Date().getFullYear(),
 }) => {
   const { t } = useTranslation();
-  const year = new Date().getFullYear();
   const { getCsvData } = useCsvData({
     type,
     getForcedToFrameData,
     getPlanningData,
     getPlanningRows,
     getCategories,
+    year,
   });
   const navigate = useNavigate();
 
@@ -61,7 +62,7 @@ const DownloadCsvButton: FC<IDownloadCsvButtonProps> = ({
         downloadCSV(
           data,
           `${documentName} ${
-            ['strategy', 'strategyForcedToFrame'].includes(type) ? year + 1 : year
+            ['strategyForcedToFrame'].includes(type) ? year + 1 : year
           }.csv`,
         );
       } else {

--- a/src/components/Report/DownloadPdfButton.tsx
+++ b/src/components/Report/DownloadPdfButton.tsx
@@ -41,6 +41,7 @@ const getPdfDocument = (
   forcedToFrameRows?: IPlanningRow[],
   sapCosts?: Record<string, IProjectSapCost>,
   currentYearSapValues?: Record<string, IProjectSapCost>,
+  year?: number,
 ) => {
   const pdfDocument = {
     operationalEnvironmentAnalysis: (
@@ -57,7 +58,7 @@ const getPdfDocument = (
         projectsInWarrantyPhase={projectsInWarrantyPhase}
     />
     ),
-    strategy: <ReportContainer data={{ rows }} reportType={Reports.Strategy} />,
+    strategy: <ReportContainer data={{ rows }} reportType={Reports.Strategy} year={year} />,
     strategyForcedToFrame: (
       <ReportContainer data={{ rows }} reportType={Reports.StrategyForcedToFrame} />
     ),
@@ -99,6 +100,7 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({
   getPlanningData,
   getPlanningRows,
   getCategories,
+  year = new Date().getFullYear(),
 }) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
@@ -110,7 +112,6 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({
 
   const downloadPdf = useCallback(async () => {
     try {
-      const year = new Date().getFullYear();
       dispatch(setLoading({ text: 'Loading pdf data', id: LOADING_PDF_DATA }));
 
       let document: JSX.Element | undefined = undefined;
@@ -118,7 +119,8 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({
         case Reports.Strategy:
         case Reports.StrategyForcedToFrame:
         case Reports.BudgetBookSummary: {
-          // For Strategy report, we will fetch next year data
+          // For Strategy report, we will fetch data from the year user selected
+          // For StrategyForcedToFrame report, we will fetch next year data
           const res = await getForcedToFrameDataForReports(getForcedToFrameData, type, year);
 
           if (viewHasProjects(res)) {
@@ -129,7 +131,18 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({
               res.projects,
               res.groupRes,
             );
-            document = getPdfDocument(type, coordinatorRows);
+            document = getPdfDocument(
+              type,
+              coordinatorRows,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              year,
+            );
           }
           break;
         }
@@ -211,7 +224,19 @@ const DownloadPdfButton: FC<IDownloadPdfButtonProps> = ({
       // without refreshing the page, the report is fetched from cache and will show incorrect data.
       if ([Reports.Strategy, Reports.StrategyForcedToFrame, Reports.ForecastReport, Reports.OperationalEnvironmentAnalysis, Reports.OperationalEnvironmentAnalysisForcedToFrame].includes(type as Reports)) navigate(0);
     }
-  }, [documentName, type]);
+  }, [
+    dispatch,
+    documentName,
+    getCategories,
+    getForcedToFrameData,
+    getPlanningData,
+    getPlanningRows,
+    navigate,
+    projectCurrentYearSapValues,
+    projectSapCosts,
+    type,
+    year,
+  ]);
 
   return (
     <Button

--- a/src/components/Report/PdfReports/ReportContainer.tsx
+++ b/src/components/Report/PdfReports/ReportContainer.tsx
@@ -27,9 +27,10 @@ interface IPdfReportContainerProps {
   forcedToFrameRows?: IPlanningRow[],
   sapCosts?: Record<string, IProjectSapCost>,
   currentYearSapValues?: Record<string, IProjectSapCost>,
+  year?: number;
 }
 
-const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data, projectsInWarrantyPhase, forcedToFrameRows, sapCosts, currentYearSapValues }) => {
+const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data, projectsInWarrantyPhase, forcedToFrameRows, sapCosts, currentYearSapValues, year = new Date().getFullYear() }) => {
   const { t } = useTranslation();
 
   const date = new Date();
@@ -73,6 +74,9 @@ const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data, proje
           year: currentYear
         });
       case Reports.Strategy:
+        return t('report.strategy.subtitle', {
+          startYear: year,
+        });
       case Reports.StrategyForcedToFrame:
         return t('report.strategy.subtitle', {
           startYear: currentYear + 1
@@ -134,6 +138,7 @@ const ReportContainer: FC<IPdfReportContainerProps> = ({ reportType, data, proje
             hierarchyInForcedToFrame={forcedToFrameRows}
             sapCosts={sapCosts}
             currentYearSapValues={currentYearSapValues}
+            year={year}
           />
           {
             [Reports.Strategy, Reports.StrategyForcedToFrame, Reports.ForecastReport].includes(reportType as Reports) ?

--- a/src/components/Report/PdfReports/ReportTable.tsx
+++ b/src/components/Report/PdfReports/ReportTable.tsx
@@ -93,7 +93,8 @@ const ReportTable: FC<IReportTableProps> = ({
     projectsInWarrantyPhase,
     hierarchyInForcedToFrame,
     sapCosts,
-    currentYearSapValues
+    currentYearSapValues,
+    year,
   );
 
   // We need to use one dimensional data for budgetBookSummary to style the report more easily

--- a/src/components/Report/PdfReports/ReportTable.tsx
+++ b/src/components/Report/PdfReports/ReportTable.tsx
@@ -44,6 +44,7 @@ interface IReportTableProps {
   hierarchyInForcedToFrame?: IPlanningRow[];
   sapCosts?: Record<string, IProjectSapCost>;
   currentYearSapValues?: Record<string, IProjectSapCost>;
+  year?: number;
 }
 
 type IReportFlattenedRows = IBudgetBookSummaryTableRow | IOperationalEnvironmentAnalysisTableRow | IConstructionProgramTableRow;
@@ -79,6 +80,7 @@ const ReportTable: FC<IReportTableProps> = ({
   hierarchyInForcedToFrame,
   sapCosts,
   currentYearSapValues,
+  year = new Date().getFullYear(),
 }) => {
   const { t } = useTranslation();
   const reportRows = convertToReportRows(
@@ -112,8 +114,9 @@ const ReportTable: FC<IReportTableProps> = ({
       case Reports.OperationalEnvironmentAnalysisForcedToFrame:
         return <OperationalEnvironmentAnalysisTableHeader />
       case Reports.Strategy:
+        return <StrategyAndForecastTableHeader isForecastReport={false} year={year} />;
       case Reports.StrategyForcedToFrame:
-        return <StrategyAndForecastTableHeader isForecastReport={false}/>;
+        return <StrategyAndForecastTableHeader isForecastReport={false} year={year + 1} />;
       case Reports.ForecastReport:
         return <StrategyAndForecastTableHeader isForecastReport={true} />;
       case Reports.ConstructionProgram:

--- a/src/components/Report/PdfReports/reportHeaders/StrategyAndForecastTableHeader.tsx
+++ b/src/components/Report/PdfReports/reportHeaders/StrategyAndForecastTableHeader.tsx
@@ -61,11 +61,11 @@ const styles = StyleSheet.create({
 
 interface StrategyTableHeaderProps {
   isForecastReport: boolean;
+  year?: number;
 }
 
-const StrategyAndForecastTableHeader = ({ isForecastReport }: StrategyTableHeaderProps) => {
+const StrategyAndForecastTableHeader = ({ isForecastReport, year = new Date().getFullYear() }: StrategyTableHeaderProps) => {
   const { t } = useTranslation();
-  const year = isForecastReport ? new Date().getFullYear() : new Date().getFullYear() + 1;
 
   return (
     <View style={styles.tableHeader}>

--- a/src/components/Report/ReportRow.tsx
+++ b/src/components/Report/ReportRow.tsx
@@ -1,6 +1,6 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IPlanningData, ReportType } from '@/interfaces/reportInterfaces';
+import { IPlanningData, Reports, ReportType } from '@/interfaces/reportInterfaces';
 import { IClassHierarchy, ICoordinatorClassHierarchy, separateClassesIntoHierarchy } from '@/reducers/classSlice';
 import DownloadPdfButton from './DownloadPdfButton';
 import DownloadCsvButton from './DownloadCsvButton';
@@ -15,6 +15,8 @@ import { getProjectsWithParams } from '@/services/projectServices';
 import { buildPlanningTableRows } from '@/hooks/usePlanningRows';
 import { getProjectCategories } from '@/services/listServices';
 import { IListItem } from '@/interfaces/common';
+import { Option } from 'hds-react';
+import ReportYearSelect from './ReportYearSelect/ReportYearSelect';
 
 interface IReportRowProps {
   type: ReportType;
@@ -22,6 +24,13 @@ interface IReportRowProps {
 
 const ReportRow: FC<IReportRowProps> = ({ type }) => {
   const { t } = useTranslation();
+  const isStrategyReport = type === Reports.Strategy;
+  const currentYear = new Date().getFullYear();
+  const [selectedYear, setSelectedYear] = useState<number>(currentYear + 1);
+
+  const handleYearChange = (_: Option[], clickedOption: Option) => {
+    setSelectedYear(parseInt(clickedOption.value, 10));
+  };
 
   const getForcedToFrameData = async (year: number, forcedToFrame: boolean) => {
     // projects
@@ -137,13 +146,33 @@ const ReportRow: FC<IReportRowProps> = ({ type }) => {
       <h3 className="report-title" data-testid={`report-title-${type}`}>
         {t(`report.${type}.rowTitle`)}
       </h3>
-      {type === 'constructionProgram' &&
-        <p>{t(`report.warrantyPeriodPhaseNotIncluded`)}</p>
-      }
+      {type === 'constructionProgram' && <p>{t(`report.warrantyPeriodPhaseNotIncluded`)}</p>}
+      {/* year selection dropdown for Strategy report */}
+      {isStrategyReport && (
+        <ReportYearSelect
+          className="report-year-select"
+          value={selectedYear.toString()}
+          onChange={handleYearChange}
+        />
+      )}
       {/* download pdf button */}
-      <DownloadPdfButton type={type} getForcedToFrameData={getForcedToFrameData} getPlanningData={getPlanningData} getPlanningRows={getPlanningRows} getCategories={getCategories} />
+      <DownloadPdfButton
+        type={type}
+        getForcedToFrameData={getForcedToFrameData}
+        getPlanningData={getPlanningData}
+        getPlanningRows={getPlanningRows}
+        getCategories={getCategories}
+        year={isStrategyReport ? selectedYear : undefined}
+      />
       {/* download csv button */}
-      <DownloadCsvButton type={type} getForcedToFrameData={getForcedToFrameData} getPlanningData={getPlanningData} getPlanningRows={getPlanningRows} getCategories={getCategories}/>
+      <DownloadCsvButton
+        type={type}
+        getForcedToFrameData={getForcedToFrameData}
+        getPlanningData={getPlanningData}
+        getPlanningRows={getPlanningRows}
+        getCategories={getCategories}
+        year={isStrategyReport ? selectedYear : undefined}
+      />
     </div>
   );
 };

--- a/src/components/Report/ReportYearSelect/ReportYearSelect.tsx
+++ b/src/components/Report/ReportYearSelect/ReportYearSelect.tsx
@@ -1,0 +1,41 @@
+import { FC } from 'react';
+import { Option, Select, SelectData, SupportedLanguage } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+
+const currentYear = new Date().getFullYear();
+
+interface IReportYearSelectProps {
+  value: string;
+  onChange: (selectedOptions: Option[], clickedOption: Option, data: SelectData) => void;
+  className?: string;
+}
+
+const ReportYearSelect: FC<IReportYearSelectProps> = ({
+  value,
+  onChange,
+  className,
+}) => {
+  const { i18n, t } = useTranslation();
+
+  const startYear = currentYear - 1;
+  const yearOptions = Array.from({ length: 12 }, (_, i) => startYear + i).map((year) => ({
+    label: year.toString(),
+  }));
+
+  return (
+    <Select
+      id="report-year-select"
+      className={className}
+      texts={{
+        language: i18n.language as SupportedLanguage,
+        label: t('report.yearLabel'),
+      }}
+      value={value}
+      options={yearOptions}
+      onChange={onChange}
+      clearable={false}
+    />
+  );
+};
+
+export default ReportYearSelect;

--- a/src/components/Report/common.tsx
+++ b/src/components/Report/common.tsx
@@ -20,7 +20,7 @@ export const getForcedToFrameDataForReports = async (
     // OperationalEnvironmentAnalysis and OperationalEnvironmentAnalysisForcedToFrame
     if (type === Reports.OperationalEnvironmentAnalysis) return await getForcedToFrameData(year, false)
     if (type === Reports.OperationalEnvironmentAnalysisForcedToFrame) return await getForcedToFrameData(year, true)
-    if (type === Reports.Strategy) return await getForcedToFrameData(year + 1, false);
+    if (type === Reports.Strategy) return await getForcedToFrameData(year, false);
     if (type === Reports.StrategyForcedToFrame) return await getForcedToFrameData(year + 1, true);
     if (type === Reports.ForecastReport || type === Reports.ConstructionProgramForecast) {
         if (coordinatorData) return await getForcedToFrameData(year, false);

--- a/src/components/Report/styles.css
+++ b/src/components/Report/styles.css
@@ -17,3 +17,7 @@
 .report-download-csv-button {
   @apply mt-4;
 }
+
+.report-year-select {
+  @apply mb-2 w-48;
+}

--- a/src/hooks/useCsvData.ts
+++ b/src/hooks/useCsvData.ts
@@ -23,6 +23,7 @@ export const useCsvData = ({
   getCategories,
   sapCosts,
   currentYearSapValues,
+  year = new Date().getFullYear(),
 }: IDownloadCsvButtonProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
@@ -30,7 +31,6 @@ export const useCsvData = ({
     Array<IConstructionProgramCsvRow | IBudgetBookSummaryCsvRow | IOperationalEnvironmentAnalysisSummaryCsvRow>
   >([]);
   const LOADING_CSV_DATA = 'loading-csv-data';
-  const year = new Date().getFullYear();
 
   const getCsvData = async () => {
     try {
@@ -51,7 +51,7 @@ export const useCsvData = ({
               res.projects,
               res.groupRes,
             );
-            data = await getReportData(t, type, coordinatorRows);
+            data = await getReportData(t, type, coordinatorRows, undefined, undefined, undefined, undefined, undefined, undefined, undefined, year);
           }
           break;
         }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -474,6 +474,7 @@
       "millionEuro": "milj. €"
     },
     "warrantyPeriodPhaseNotIncluded": "Huomaa ettei takuuajalla olevat hankkeet tule mukaan tälle raportille.",
+    "yearLabel": "Vuosi",
     "operationalEnvironmentAnalysis": {
       "rowTitle": "Kategorisointiraportti (Koordinointinäkymä)",
       "documentName": "kategorisointiraportti - koordinointinäkymä",

--- a/src/interfaces/reportInterfaces.ts
+++ b/src/interfaces/reportInterfaces.ts
@@ -350,6 +350,7 @@ export interface IDownloadCsvButtonProps {
   getCategories: () => Promise<IListItem[]>;
   sapCosts?: Record<string, IProjectSapCost>;
   currentYearSapValues?: Record<string, IProjectSapCost>;
+  year?: number;
 }
 
 export interface IDownloadPdfButtonProps {
@@ -358,4 +359,5 @@ export interface IDownloadPdfButtonProps {
   getPlanningData: (year: number) => Promise<IPlanningData>;
   getPlanningRows: (res: IPlanningData) => IPlanningRow[];
   getCategories: () => Promise<IListItem[]>;
+  year?: number;
 }

--- a/src/mocks/mockResizeObserver.ts
+++ b/src/mocks/mockResizeObserver.ts
@@ -1,0 +1,17 @@
+class ResizeObserverMock {
+  observe() {
+    // mock implementation
+  }
+  unobserve() {
+    // mock implementation
+  }
+  disconnect() {
+    // mock implementation
+  }
+}
+
+export const mockResizeObserver = () => {
+  Object.defineProperty(window, 'ResizeObserver', {
+    value: ResizeObserverMock,
+  });
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -6,8 +6,10 @@
 import '@testing-library/jest-dom';
 import { mockEventSource } from './mocks/mockEventSource';
 import { TextEncoder, TextDecoder } from 'util';
+import { mockResizeObserver } from './mocks/mockResizeObserver';
 
 mockEventSource();
+mockResizeObserver();
 
 process.env.REACT_APP_API_URL = 'localhost:4000';
 process.env.REACT_APP_AUTHORITY = 'test-authority-url';

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -1662,6 +1662,40 @@ export const operationalEnvironmentAnalysisTableRows = (
   return cleanSummaryData(summaryClasses);
 };
 
+function generateStrategyAndForecastCsvRows(
+  reportRows: IStrategyAndForecastTableRow[],
+  reportType: ReportType,
+  reportYear: number,
+) {
+  //Flatten rows to one dimension
+  const flattenedRows = flattenForecastTableRows(reportRows as IStrategyAndForecastTableRow[]);
+  return flattenedRows.map((r) => ({
+    [`\n${t('report.strategy.projectNameTitle')}`]: r.name,
+    [`${t('report.strategy.projectsTitle')}\n${t('report.strategy.projectManagerTitle')}`]:
+      r.projectManager,
+    [`\n${t('projectPhase')}`]: r.projectPhase,
+    [`\nTA ${reportYear}`]: r.costPlan,
+    [`\nTS ${reportYear}`]: r.costForecast,
+    ...(reportType === Reports.ForecastReport && {
+      [`\nEnnuste ${reportYear}`]: r.costForcedToFrameBudget,
+      [`\nPoikkeama`]: r.costForecastDeviation,
+      [t('report.constructionProgramForecast.differenceReasonTitle')]: r.budgetOverrunReason,
+    }),
+    [`${reportYear}\n01`]: r.januaryStatus,
+    [`\n02`]: r.februaryStatus,
+    [`\n03`]: r.marchStatus,
+    [`\n04`]: r.aprilStatus,
+    [`\n05`]: r.mayStatus,
+    [`\n06`]: r.juneStatus,
+    [`\n07`]: r.julyStatus,
+    [`\n08`]: r.augustStatus,
+    [`\n09`]: r.septemberStatus,
+    [`\n10`]: r.octoberStatus,
+    [`\n11`]: r.novemberStatus,
+    [`\n12`]: r.decemberStatus,
+  }));
+}
+
 export const getReportData = async (
   t: TFunction<'translation', undefined>,
   reportType: ReportType,
@@ -1673,12 +1707,12 @@ export const getReportData = async (
   hierarchyInForcedToFrame?: IPlanningRow[],
   sapCosts?: Record<string, IProjectSapCost>,
   currentYearSapValues?: Record<string, IProjectSapCost>,
+  year: number = new Date().getFullYear()
 ): Promise<Array<IConstructionProgramCsvRow>
   | Array<IBudgetBookSummaryCsvRow>
   | Array<IStrategyTableCsvRow>
   | Array<IOperationalEnvironmentAnalysisCsvRow>
   | Array<IOperationalEnvironmentAnalysisSummaryCsvRow>> => {
-  const year = new Date().getFullYear();
   const previousYear = year - 1;
 
   const reportRows = convertToReportRows(rows, reportType, categories, t, divisions, subDivisions, projectsInWarrantyPhase, hierarchyInForcedToFrame, sapCosts, currentYearSapValues);
@@ -1686,34 +1720,10 @@ export const getReportData = async (
   try {
     switch (reportType) {
       case Reports.Strategy:
+        return generateStrategyAndForecastCsvRows(reportRows, reportType, year);
       case Reports.StrategyForcedToFrame:
       case Reports.ForecastReport: {
-        //Flatten rows to one dimension
-        const flattenedRows = flattenForecastTableRows(reportRows as IStrategyAndForecastTableRow[]);
-        return flattenedRows.map((r) => ({
-          [`\n${t('report.strategy.projectNameTitle')}`]: r.name,
-          [`${t('report.strategy.projectsTitle')}\n${t('report.strategy.projectManagerTitle')}`]: r.projectManager,
-          [`\n${t('projectPhase')}`]: r.projectPhase,
-          [`\nTA ${year + 1}`]: r.costPlan,
-          [`\nTS ${year + 1}`]: r.costForecast,
-          ...(reportType === Reports.ForecastReport && {
-            [`\nEnnuste ${year + 1}`]: r.costForcedToFrameBudget,
-            [`\nPoikkeama`]: r.costForecastDeviation,
-            [t('report.constructionProgramForecast.differenceReasonTitle')]: r.budgetOverrunReason,
-          }),
-          [`${year + 1}\n01`]: r.januaryStatus,
-          [`\n02`]: r.februaryStatus,
-          [`\n03`]: r.marchStatus,
-          [`\n04`]: r.aprilStatus,
-          [`\n05`]: r.mayStatus,
-          [`\n06`]: r.juneStatus,
-          [`\n07`]: r.julyStatus,
-          [`\n08`]: r.augustStatus,
-          [`\n09`]: r.septemberStatus,
-          [`\n10`]: r.octoberStatus,
-          [`\n11`]: r.novemberStatus,
-          [`\n12`]: r.decemberStatus,
-        }));
+        return generateStrategyAndForecastCsvRows(reportRows, reportType, year + 1);
       }
       case Reports.ConstructionProgram: {
         // Flatten rows into one dimension

--- a/src/views/ReportsView/ReportsView.tsx
+++ b/src/views/ReportsView/ReportsView.tsx
@@ -19,7 +19,7 @@ const ReportsView = () => {
     } else {
       dispatch(clearLoading(LOADING_DATA_ID));
     }
-  }, [isPlanningLoading]);
+  }, [isPlanningLoading, dispatch]);
 
   return (
     <div className="reports-view" data-testid="reports-view">


### PR DESCRIPTION
User can select year from a dropdown for strategy report ranging from previous year to ten years ahead.

ticket: https://helsinkisolutionoffice.atlassian.net/browse/IO-390