### PR TITLE
fix: HAI-710 allow warranty phase start date to be same as construction end date

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectScheduleSection.tsx
@@ -6,7 +6,7 @@ import { IProjectForm } from '@/interfaces/formInterfaces';
 import { useTranslation } from 'react-i18next';
 import { Fieldset } from 'hds-react';
 import DateField from '@/components/shared/DateField';
-import { validateAfter, validateBefore } from '@/utils/validation';
+import { validateAfter, validateBefore, validateSameOrAfter } from '@/utils/validation';
 import _ from 'lodash';
 
 interface IProjectScheduleSectionProps {
@@ -26,7 +26,7 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
   getValues,
   getFieldState,
   isUserOnlyProjectManager,
-  isUserOnlyViewer
+  isUserOnlyViewer,
 }) => {
   const { t } = useTranslation();
 
@@ -49,7 +49,11 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
           const yearToBeSet = date?.split('.')[2];
           const yearInFormYearCell = getValues('planningStartYear');
 
-          if (!getFieldState('planningStartYear').isDirty && yearToBeSet !== yearInFormYearCell && yearToBeSet) {
+          if (
+            !getFieldState('planningStartYear').isDirty &&
+            yearToBeSet !== yearInFormYearCell &&
+            yearToBeSet
+          ) {
             if (isUserOnlyProjectManager) {
               return t('validation.userIsNotAllowedToModifyPlanningStartYear');
             }
@@ -72,7 +76,7 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
         },
       },
     };
-  }, [getValues, phasesThatNeedPlanning, t]);
+  }, [getValues, phasesThatNeedPlanning, t, getFieldState, isUserOnlyProjectManager]);
 
   const validateEstPlanningEnd = useCallback(() => {
     return {
@@ -225,7 +229,11 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
           const yearToBeSet = date?.split('.')[2];
           const yearInFormYearCell = getValues('constructionEndYear');
 
-          if (!getFieldState('constructionEndYear').isDirty && yearToBeSet !== yearInFormYearCell && yearToBeSet) {
+          if (
+            !getFieldState('constructionEndYear').isDirty &&
+            yearToBeSet !== yearInFormYearCell &&
+            yearToBeSet
+          ) {
             return t('validation.constructionEndYearValidator');
           }
 
@@ -245,23 +253,27 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
         },
       },
     };
-  }, [getValues, phasesThatNeedConstruction, t]);
+  }, [getValues, phasesThatNeedConstruction, t, getFieldState]);
 
   const validateWarrantyPhaseStart = useCallback(() => {
     return {
       validate: {
         isWarrantyPeriodStartValid: (date: string | null) => {
+          const sameOrAfterConstructionEnd = validateSameOrAfter(
+            date,
+            'estConstructionEnd',
+            getValues,
+            t,
+          );
 
-          const afterConstructionEnd = validateAfter(date, 'estConstructionEnd', getValues, t);
-
-          if (afterConstructionEnd !== true) {
-            return afterConstructionEnd;
+          if (sameOrAfterConstructionEnd !== true) {
+            return sameOrAfterConstructionEnd;
           }
 
           const beforeWarrantyEnd = validateBefore(date, 'estWarrantyPhaseEnd', getValues, t);
 
           if (beforeWarrantyEnd !== true) {
-            return beforeWarrantyEnd
+            return beforeWarrantyEnd;
           }
 
           return true;
@@ -274,14 +286,18 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
     return {
       validate: {
         isWarrantyPhaseValid: (date: string | null) => {
-
           const phase = getValues('phase').value;
 
           if (phase === 'warrantyPeriod' && !date) {
             return t('validation.required', { field: t('validation.estWarrantyPhaseEnd') });
           }
 
-          const afterWarrantyPhaseStart = validateAfter(date, 'estWarrantyPhaseStart', getValues, t);
+          const afterWarrantyPhaseStart = validateAfter(
+            date,
+            'estWarrantyPhaseStart',
+            getValues,
+            t,
+          );
 
           if (afterWarrantyPhaseStart !== true) {
             return afterWarrantyPhaseStart;
@@ -299,26 +315,50 @@ const ProjectScheduleSection: FC<IProjectScheduleSectionProps> = ({
       <Fieldset heading={t('projectForm.planning')} className="w-full" id="planning">
         <div className="form-row">
           <div className="form-col-md">
-            <DateField {...getFieldProps('estPlanningStart')} rules={validateEstPlanningStart()} readOnly={isUserOnlyViewer}/>
+            <DateField
+              {...getFieldProps('estPlanningStart')}
+              rules={validateEstPlanningStart()}
+              readOnly={isUserOnlyViewer}
+            />
           </div>
           <div className="form-col-md">
-            <DateField {...getFieldProps('estPlanningEnd')} rules={validateEstPlanningEnd()} readOnly={isUserOnlyViewer}/>
+            <DateField
+              {...getFieldProps('estPlanningEnd')}
+              rules={validateEstPlanningEnd()}
+              readOnly={isUserOnlyViewer}
+            />
           </div>
         </div>
         <div className="form-row">
           <div className="form-col-md">
-            <DateField {...getFieldProps('presenceStart')} rules={validatePresenceStart()} readOnly={isUserOnlyViewer}/>
+            <DateField
+              {...getFieldProps('presenceStart')}
+              rules={validatePresenceStart()}
+              readOnly={isUserOnlyViewer}
+            />
           </div>
           <div className="form-col-md">
-            <DateField {...getFieldProps('presenceEnd')} rules={validatePresenceEnd()} readOnly={isUserOnlyViewer}/>
+            <DateField
+              {...getFieldProps('presenceEnd')}
+              rules={validatePresenceEnd()}
+              readOnly={isUserOnlyViewer}
+            />
           </div>
         </div>
         <div className="form-row">
           <div className="form-col-md">
-            <DateField {...getFieldProps('visibilityStart')} rules={validateVisibilityStart()} readOnly={isUserOnlyViewer}/>
+            <DateField
+              {...getFieldProps('visibilityStart')}
+              rules={validateVisibilityStart()}
+              readOnly={isUserOnlyViewer}
+            />
           </div>
           <div className="form-col-md">
-            <DateField {...getFieldProps('visibilityEnd')} rules={validateVisibilityEnd()} readOnly={isUserOnlyViewer}/>
+            <DateField
+              {...getFieldProps('visibilityEnd')}
+              rules={validateVisibilityEnd()}
+              readOnly={isUserOnlyViewer}
+            />
           </div>
         </div>
       </Fieldset>

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -119,6 +119,7 @@
     "incorrectLocation": "Valittu {{field}} ei voi kuulua valitun alaluokan alle.",
     "isBefore": "Aika on oltava ennen kuin {{value}}",
     "isAfter": "Aika on oltava myöhemmin kuin {{value}}",
+    "isSameOrAfter": "Aika on oltava sama tai myöhemmin kuin {{value}}",
     "maxLength": "Maksimipituus on {{value}} merkkiä",
     "wholeNumber": "Anna kokonaisluku",
     "minValue": "Arvon on oltava vähintään {{value}}",

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -148,3 +148,15 @@ export const isBefore = (start?: string | null, end?: string | null) => {
   }
   return true;
 };
+
+/**
+ * Returns true if the given start date is the same or before the end date
+ */
+export const isSameOrBefore = (start?: string | null, end?: string | null) => {
+  if (start && end) {
+    const startMoment = momentFromHDSDate(start);
+    const endMoment = momentFromHDSDate(end);
+    return moment(startMoment).isSameOrBefore(endMoment);
+  }
+  return true;
+};

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -3,14 +3,11 @@ import { IProjectForm } from '@/interfaces/formInterfaces';
 import { TFunction } from 'i18next';
 import { UseFormGetValues } from 'react-hook-form';
 import _ from 'lodash';
-import { isBefore } from './dates';
+import { isBefore, isSameOrBefore } from './dates';
 import { isUserOnlyProjectAreaPlanner, isUserOnlyProjectManager } from './userRoleHelpers';
 import { IUser } from '@/interfaces/userInterfaces';
 
-export const validateMaxLength = (
-  value: number,
-  t: TFunction<'translation'>,
-) => ({
+export const validateMaxLength = (value: number, t: TFunction<'translation'>) => ({
   maxLength: { value: value, message: t('validation.maxLength', { value: value }) },
 });
 
@@ -20,17 +17,11 @@ export const validateInteger = (t: TFunction<'translation'>) => ({
       Number.isInteger(Number(value)) ? true : t('validation.wholeNumber'),
   },
 });
-export const validateRequired = (
-  field: string,
-  t: TFunction<'translation'>,
-) => ({
+export const validateRequired = (field: string, t: TFunction<'translation'>) => ({
   required: t('validation.required', { field: t(`validation.${field}`) }) ?? '',
 });
 
-export const validateMaxNumber = (
-  max: number,
-  t: TFunction<'translation'>,
-) => ({
+export const validateMaxNumber = (max: number, t: TFunction<'translation'>) => ({
   min: {
     value: 0,
     message: t('validation.minValue', { value: '0' }),
@@ -63,6 +54,20 @@ export const validateAfter = (
 ) => {
   if (!isBefore(getValues(startDateField as keyof IProjectForm) as string, endDate)) {
     return t('validation.isAfter', {
+      value: t(`validation.${startDateField}`),
+    });
+  }
+  return true;
+};
+
+export const validateSameOrAfter = (
+  endDate: string | null,
+  startDateField: string,
+  getValues: UseFormGetValues<IProjectForm>,
+  t: TFunction<'translation'>,
+) => {
+  if (!isSameOrBefore(getValues(startDateField as keyof IProjectForm) as string, endDate)) {
+    return t('validation.isSameOrAfter', {
       value: t(`validation.${startDateField}`),
     });
   }


### PR DESCRIPTION
Fixed a problem where warranty phase start date could not be set as same date as construction end date even though they should be allowed to be the same date also.

ticket: https://helsinkisolutionoffice.atlassian.net/browse/IO-710