### PR TITLE
fix: IO-746 Frame budget sums not displayed for some subclasses in planning view

### DIFF
--- a/src/hooks/usePlanningRows.ts
+++ b/src/hooks/usePlanningRows.ts
@@ -61,7 +61,8 @@ const sortLocationsByName = (list: Array<ILocation>) =>
  *          subclass finances if no district is provided
  */
 function mergeSubClassFinancesWithDistrictFrameBudget(subClass: IClass, districtForSubClass?: ILocation): IClassFinances {
-  if (!districtForSubClass) {
+  // Return original subclass finances if no matching district is found
+  if (!districtForSubClass || subClass.name !== districtForSubClass.name) {
     return subClass.finances;
   }
 


### PR DESCRIPTION
Fix problem where frame budget sums entered in coordination view would not be displayed for subclasses that are not 'suurpiiri' in planning view.

https://helsinkisolutionoffice.atlassian.net/browse/IO-746