### PR TITLE
fix: IO-739 Project or group on schedule in reports when budget overrun reason is other

### DIFF
--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -466,21 +466,21 @@ const isProjectInPlanningOrConstruction = (
   }
 };
 
-const isProjectOnSchedule = (
+export const isProjectOnSchedule = (
   budgetOverrunReason: string | undefined,
   onSchedule: boolean | undefined | null,
 ): boolean => {
   if (
     !budgetOverrunReason ||
     ['earlierSchedule', 'totalCostsClarification'].includes(budgetOverrunReason) ||
-    (budgetOverrunReason === 'otherReason' && onSchedule)
+    (budgetOverrunReason === 'otherReason' && onSchedule !== false)
   ) {
     return true;
   }
   return false;
 };
 
-const getIsProjectOnSchedule = (
+export const getIsProjectOnSchedule = (
   budgetOverrunReason: string | undefined,
   onSchedule: boolean | undefined | null,
 ): string => {
@@ -490,7 +490,7 @@ const getIsProjectOnSchedule = (
   return t('option.false');
 };
 
-const getIsGroupOnSchedule = (projects: IProject[]): string => {
+export const getIsGroupOnSchedule = (projects: IProject[]): string => {
   for (const p of projects) {
     if (!isProjectOnSchedule(p.budgetOverrunReason?.value, p.onSchedule)) {
       return t('option.false');


### PR DESCRIPTION
Fix problem in reports with other budget overrun reason so that project or group is shown to be on schedule even if `onSchedule` is undefined or null, meaning that project is only not on schedule if `onSchedule` is set to `false`.

https://helsinkisolutionoffice.atlassian.net/browse/IO-739