### PR TITLE
fix: IO-821 Fix logic for determining default budget account in Talpa form

### DIFF
--- a/src/components/Project/ProjectTalpa/ProjectClasses.tsx
+++ b/src/components/Project/ProjectTalpa/ProjectClasses.tsx
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 import { selectTalpaAssetClasses, selectTalpaServiceClasses } from '@/reducers/listsSlice';
 import { useFormContext } from 'react-hook-form';
 import { IProjectTalpaForm } from '@/interfaces/formInterfaces';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { groupOptions } from '@/utils/common';
 import { BudgetItemNumber } from './budgetItemNumber';
 import { InvestmentProfile } from './investmentProfile';
@@ -28,18 +28,20 @@ export default function ProjectClassesSection() {
   const [budgetItemNumber, assetClass] = watch(['budgetItemNumber', 'assetClass']);
   const budgetItemNumberTouched = Boolean(touchedFields?.budgetItemNumber);
 
-  const filteredServiceClasses = talpaServiceClasses.filter(
-    (serviceClass) => serviceClass.projectTypePrefix === budgetItemNumber,
-  );
+  const serviceClassOptions = useMemo(() => {
+    const filteredServiceClasses = talpaServiceClasses.filter(
+      (serviceClass) => serviceClass.projectTypePrefix === budgetItemNumber,
+    );
 
-  const serviceClassOptions = filteredServiceClasses.map((serviceClass) => ({
-    label: `${serviceClass.code} ${serviceClass.name}`,
-    value: serviceClass.id,
-    selected: false,
-    isGroupLabel: false,
-    visible: true,
-    disabled: false,
-  }));
+    return filteredServiceClasses.map((serviceClass) => ({
+      label: `${serviceClass.code} ${serviceClass.name}`,
+      value: serviceClass.id,
+      selected: false,
+      isGroupLabel: false,
+      visible: true,
+      disabled: false,
+    }));
+  }, [talpaServiceClasses, budgetItemNumber]);
 
   const assetClassGroups = groupOptions(
     talpaAssetClasses,

--- a/src/forms/useTalpaForm.test.tsx
+++ b/src/forms/useTalpaForm.test.tsx
@@ -116,6 +116,71 @@ describe('useTalpaForm', () => {
     });
   });
 
+  it.each([
+    {
+      className: '8 08 01 Esirakentaminen',
+      subClassName: '8 08 01 02 Länsisatama',
+      expectedBudgetAccount: '8 08 01 02 Länsisatama',
+    },
+    {
+      className: '8 09 01 Malminkartano-Kannelmäki',
+      subClassName: '8 09 01 02 Kadut uudisrakentaminen',
+      expectedBudgetAccount: '8 09 01 02 Kadut uudisrakentaminen',
+    },
+    {
+      className: '8 03 01 01 Uudisrakentaminen',
+      subClassName: 'Eteläinen suurpiiri',
+      expectedBudgetAccount: '8 03 01 01 Uudisrakentaminen',
+    },
+    {
+      className:
+        '8 01 01 Kiinteistöjen ostot ja lunastukset sekä kaavoitus- ja täydennysrakennuskorvaukset',
+      subClassName: null,
+      expectedBudgetAccount:
+        '8 01 01 Kiinteistöjen ostot ja lunastukset sekä kaavoitus- ja täydennysrakennuskorvaukset',
+    },
+  ])(
+    'sets budgetAccount correctly for class "$className"',
+    ({ className, subClassName, expectedBudgetAccount }) => {
+      const project = {
+        id: 'project-2',
+        estPlanningStart: '01.01.2026',
+        estConstructionEnd: '31.12.2026',
+        projectClass: 'sub-class-1',
+        address: 'Testitie 1',
+      };
+
+      const planningClass = {
+        id: 'class-1',
+        name: className,
+      };
+
+      const planningSubClass = {
+        id: 'sub-class-1',
+        name: subClassName,
+        parent: 'class-1',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const selectors: Record<SelectorName, any> = {
+        selectProject: project,
+        selectTalpaProject: null,
+        selectPlanningClasses: [planningClass],
+        selectPlanningSubClasses: [planningSubClass],
+        selectResponsiblePersonsRaw: [],
+      };
+
+      mockUseAppSelector.mockImplementation((selector: { name: SelectorName }) => {
+        return selectors[selector.name];
+      });
+
+      const { result } = renderHook(() => useTalpaForm());
+      const values = result.current.getValues();
+
+      expect(values.budgetAccount).toBe(expectedBudgetAccount);
+    },
+  );
+
   it('populates form values when talpa project data is loaded', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const selectors: Record<SelectorName, any> = {

--- a/src/forms/useTalpaForm.ts
+++ b/src/forms/useTalpaForm.ts
@@ -85,6 +85,15 @@ const buildReadinessOption = (readiness: string): IProjectTalpaForm['readiness']
   value: readiness,
 });
 
+/**
+ * Determines whether a sub-class name should be used for a budget account.
+ * @param subClassName - The sub-class name to validate. If undefined or empty, returns false.
+ * @returns True if the sub-class name is defined and starts with a digit; otherwise false.
+ */
+function shouldUseSubClassForBudgetAccount(subClassName?: string): boolean {
+  return !!subClassName && /^\d/gm.test(subClassName);
+}
+
 function useResponsiblePerson(project: IProject | null): {
   responsiblePersonName: string;
   responsiblePersonEmail: string;
@@ -122,9 +131,13 @@ const useTalpaProjectOpeningToFormValues = (): IProjectTalpaForm => {
       ? classes.find(({ id }) => id === projectClassId)
       : undefined;
 
+    const budgetAccount = shouldUseSubClassForBudgetAccount(selectedSubClass?.name)
+      ? selectedSubClass?.name
+      : selectedClass?.name;
+
     return {
       budgetItemNumber: BudgetItemNumber.InfraInvestment,
-      budgetAccount: selectedClass ? selectedClass.name : '',
+      budgetAccount: budgetAccount || '',
       templateProject: infraInvestmentTemplateProject,
       projectStart: project?.estPlanningStart ?? null,
       projectEnd: addYears(project?.estWarrantyPhaseEnd ?? project?.estConstructionEnd, 6),


### PR DESCRIPTION
Use project subClass name as default budget account if it is defined and starts with number, like "8 09 01 02 Kadut uudisrakentaminen", otherwise use class name.

https://helsinkisolutionoffice.atlassian.net/browse/IO-821