### PR TITLE
fix: IO-825 Fix problem where data from wrong project might be shown in project form

### DIFF
--- a/src/api/projectApi.ts
+++ b/src/api/projectApi.ts
@@ -1,4 +1,8 @@
-import { IProject } from '@/interfaces/projectInterfaces';
+import {
+  IProject,
+  IProjectPatchRequestObject,
+  IProjectPostRequestObject,
+} from '@/interfaces/projectInterfaces';
 import { infraohjelmointiApi } from './infraohjelmointiApi';
 
 export const projectApi = infraohjelmointiApi.injectEndpoints({
@@ -9,8 +13,36 @@ export const projectApi = infraohjelmointiApi.injectEndpoints({
       }),
       providesTags: (result, error, projectId) => [{ type: 'Projects', id: projectId }],
     }),
+    postProject: build.mutation<IProject, IProjectPostRequestObject>({
+      query: (request) => ({
+        url: '/projects/',
+        method: 'POST',
+        data: request.data,
+      }),
+    }),
+    patchProject: build.mutation<IProject, IProjectPatchRequestObject>({
+      query: (request) => ({
+        url: `/projects/${request.id}/`,
+        method: 'PATCH',
+        data: request.data,
+      }),
+      invalidatesTags: (result, error, request) => [{ type: 'Projects', id: request.id }],
+    }),
+    deleteProject: build.mutation<{ id: string }, string>({
+      query: (projectId) => ({
+        url: `/projects/${projectId}/`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (result, error, projectId) => [{ type: 'Projects', id: projectId }],
+    }),
   }),
   overrideExisting: false,
 });
 
-export const { useGetProjectByIdQuery, useLazyGetProjectByIdQuery } = projectApi;
+export const {
+  useGetProjectByIdQuery,
+  useLazyGetProjectByIdQuery,
+  usePostProjectMutation,
+  usePatchProjectMutation,
+  useDeleteProjectMutation,
+} = projectApi;

--- a/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/ProjectCell.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/ProjectCell.tsx
@@ -24,7 +24,6 @@ import {
   selectForcedToFrame,
   selectSelectedYears,
   selectSelections,
-  updateProject,
 } from '@/reducers/planningSlice';
 import {
   getCellTypeUpdateRequestData,
@@ -37,6 +36,9 @@ import {
 import { selectUser } from '@/reducers/authSlice';
 import { isUserOnlyProjectAreaPlanner, isUserOnlyViewer } from '@/utils/userRoleHelpers';
 import { IProjectSapCost } from '@/interfaces/sapCostsInterfaces';
+import { usePatchProjectMutation } from '@/api/projectApi';
+import { notifyError } from '@/reducers/notificationSlice';
+import { clearLoading, setLoading } from '@/reducers/loaderSlice';
 
 interface IProjectCellProps {
   cell: IProjectCell;
@@ -51,6 +53,8 @@ interface IProjectCellState {
   formValue: number | null | string;
 }
 
+const UPDATE_PROJECT = 'update-project';
+
 const ProjectCell: FC<IProjectCellProps> = ({
   cell,
   projectFinances,
@@ -63,6 +67,7 @@ const ProjectCell: FC<IProjectCellProps> = ({
   const selectedYears = useAppSelector(selectSelectedYears);
   const currentYear = new Date().getFullYear();
   const forcedToFrame = useAppSelector(selectForcedToFrame);
+  const [patchProject] = usePatchProjectMutation();
 
   const user = useAppSelector(selectUser);
   const selectedMasterClass = useAppSelector(selectSelections).selectedMasterClass;
@@ -97,22 +102,21 @@ const ProjectCell: FC<IProjectCellProps> = ({
   }, [type, user, selectedMasterClass]);
 
   const updateCell = useCallback(
-    (req: IProjectRequest) => {
+    async (req: IProjectRequest) => {
       if (forcedToFrame) {
         convertToForcedToFrameProjectRequest(req);
       }
 
-      dispatch(
-        updateProject({
-          request: {
-            id,
-            data: req,
-          },
-          errorNotification: { message: 'financeChangeError', title: 'patchError' },
-        }),
-      );
+      try {
+        dispatch(setLoading({ text: 'Update project data', id: UPDATE_PROJECT }));
+        await patchProject({ id, data: req }).unwrap();
+      } catch (error) {
+        dispatch(notifyError({ message: 'financeChangeError', title: 'patchError' }));
+      } finally {
+        dispatch(clearLoading(UPDATE_PROJECT));
+      }
     },
-    [forcedToFrame, id, dispatch],
+    [forcedToFrame, id, dispatch, patchProject],
   );
 
   const canTypeUpdate = useCallback(() => {

--- a/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/ProjectCell.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/ProjectCell.tsx
@@ -111,6 +111,7 @@ const ProjectCell: FC<IProjectCellProps> = ({
         dispatch(setLoading({ text: 'Update project data', id: UPDATE_PROJECT }));
         await patchProject({ id, data: req }).unwrap();
       } catch (error) {
+        console.error('Failed to update project:', error);
         dispatch(notifyError({ message: 'financeChangeError', title: 'patchError' }));
       } finally {
         dispatch(clearLoading(UPDATE_PROJECT));

--- a/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/ProjectHead.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/ProjectRow/ProjectHead.tsx
@@ -2,7 +2,6 @@ import { CustomTag } from '@/components/shared';
 import { IProjectSums } from '@/interfaces/planningInterfaces';
 import { ContextMenuType } from '@/interfaces/eventInterfaces';
 import { IProject, IProjectRequest } from '@/interfaces/projectInterfaces';
-import { patchProject } from '@/services/projectServices';
 import { dispatchContextMenuEvent } from '@/utils/events';
 import { useCallback, MouseEvent as ReactMouseEvent, memo, FC } from 'react';
 import { Link } from 'react-router-dom';
@@ -15,6 +14,7 @@ import { selectUser } from '@/reducers/authSlice';
 import { useOptions } from '@/hooks/useOptions';
 import { useProjectPhaseValidation } from '@/hooks/useProjectValidation';
 import TooltipWrapper from '../HoverTooltip/TooltipWrapper';
+import { usePatchProjectMutation } from '@/api/projectApi';
 
 const PRIORITY_VALUE_MAP: Record<string, string> = {
   high: '1',
@@ -42,6 +42,7 @@ interface IProjectHeadProps {
 const ProjectHead: FC<IProjectHeadProps> = ({ project, sums }) => {
   const { costEstimateBudget, availableFrameBudget } = sums;
   const user = useAppSelector(selectUser);
+  const [patchProject] = usePatchProjectMutation();
   const phases = useOptions('phases');
   const dispatch = useAppDispatch();
   const isPhaseValid = useProjectPhaseValidation({
@@ -69,11 +70,11 @@ const ProjectHead: FC<IProjectHeadProps> = ({ project, sums }) => {
           return;
         }
       }
-      patchProject({ data: req, id: project.id }).catch(() =>
-        dispatch(notifyError({ message: 'phaseChangeError', title: 'patchError' })),
-      );
+      patchProject({ data: req, id: project.id })
+        .unwrap()
+        .catch(() => dispatch(notifyError({ message: 'phaseChangeError', title: 'patchError' })));
     },
-    [dispatch, isPhaseValid, phases, project.id],
+    [dispatch, isPhaseValid, phases, project.id, patchProject],
   );
 
   // Open the custom context menu for editing the project phase on click

--- a/src/components/Planning/PlanningToolbar/PlanningToolbar.tsx
+++ b/src/components/Planning/PlanningToolbar/PlanningToolbar.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/reducers/planningSlice';
 import { t } from 'i18next';
 import './styles.css';
-import { resetProject, setProjectMode } from '@/reducers/projectSlice';
+import { setProjectMode } from '@/reducers/projectSlice';
 import { useNavigate } from 'react-router-dom';
 import {
   selectBatchedCoordinationClasses,
@@ -111,7 +111,6 @@ const PlanningToolbar = () => {
   }, [dispatch, hoverTooltipsEnabled]);
 
   const onOpenNewProjectForm = useCallback(() => {
-    dispatch(resetProject());
     dispatch(setProjectMode('new'));
     navigate('/project/new');
   }, [dispatch, navigate]);

--- a/src/components/Project/ProjectBasics/ProjectBasics.test.tsx
+++ b/src/components/Project/ProjectBasics/ProjectBasics.test.tsx
@@ -7,25 +7,30 @@ import mockProject from '@/mocks/mockProject';
 import { Route } from 'react-router';
 import { mockProjectPhases } from '@/mocks/mockLists';
 import { mockUser } from '@/mocks/mockUsers';
+import { mockGetResponseProvider } from '@/utils/mockGetResponseProvider';
 
+jest.mock('axios');
 jest.mock('react-i18next', () => mockI18next());
 const store = setupStore();
 
 const render = async () =>
   await act(async () =>
-    renderWithProviders(<Route path="/" element={<ProjectBasics />} />, {
-      preloadedState: {
-        auth: { user: mockUser.data, error: {} },
-        project: {
-          ...store.getState().project,
-          selectedProject: mockProject.data,
-        },
-        lists: {
-          ...store.getState().lists,
-          phases: mockProjectPhases.data,
+    renderWithProviders(
+      <Route path="/project/:projectId/basics" element={<ProjectBasics />} />,
+      {
+        preloadedState: {
+          auth: { user: mockUser.data, error: {} },
+          project: {
+            ...store.getState().project,
+          },
+          lists: {
+            ...store.getState().lists,
+            phases: mockProjectPhases.data,
+          },
         },
       },
-    }),
+      { route: `/project/${mockProject.data.id}/basics` },
+    ),
   );
 describe('ProjectBasics', () => {
   const spyScrollTo = jest.fn();
@@ -34,17 +39,18 @@ describe('ProjectBasics', () => {
 
   beforeEach(() => {
     spyScrollTo.mockClear();
+    mockGetResponseProvider();
   });
 
   it('renders all component wrappers', async () => {
-    const { getByTestId } = await render();
+    const { getByTestId, findByTestId } = await render();
     expect(getByTestId('project-basics')).toBeInTheDocument();
-    expect(getByTestId('side-panel')).toBeInTheDocument();
-    expect(getByTestId('form-panel')).toBeInTheDocument();
+    expect(await findByTestId('side-panel')).toBeInTheDocument();
+    expect(await findByTestId('form-panel')).toBeInTheDocument();
   });
 
   it('renders SideNavigation and links', async () => {
-    const { container, getByRole, getByTestId } = await render();
+    const { findByRole, findByTestId } = await render();
 
     const navItems = [
       'nav.basics',
@@ -56,21 +62,21 @@ describe('ProjectBasics', () => {
       'nav.projectProgram',
     ];
 
-    expect(container.getElementsByClassName('side-nav').length).toBe(2);
-    expect(getByTestId('pw-folder-container')).toBeInTheDocument();
+    expect(await findByTestId('side-panel')).toBeInTheDocument();
+    expect(await findByTestId('pw-folder-container')).toBeInTheDocument();
+    expect(await findByTestId('pw-folder-link')).toBeInTheDocument();
 
-    expect(getByTestId('pw-folder-link')).toBeInTheDocument();
-    navItems.forEach((n) => {
+    for (const navItem of navItems) {
       expect(
-        getByRole('link', {
-          name: n,
+        await findByRole('link', {
+          name: navItem,
         }),
       ).toBeInTheDocument();
-    });
+    }
   });
 
   it('renders ProjectForm', async () => {
-    const { getByTestId } = await render();
-    expect(getByTestId('project-form')).toBeInTheDocument();
+    const { findByTestId } = await render();
+    expect(await findByTestId('project-form')).toBeInTheDocument();
   });
 });

--- a/src/components/Project/ProjectBasics/ProjectBasics.tsx
+++ b/src/components/Project/ProjectBasics/ProjectBasics.tsx
@@ -1,12 +1,13 @@
 import { useTranslation } from 'react-i18next';
 import { useAppSelector } from '@/hooks/common';
-import { selectProjectMode, selectProject } from '@/reducers/projectSlice';
+import { selectProjectMode } from '@/reducers/projectSlice';
 import ProjectSidePanel from './ProjectFormSidePanel/ProjectFormSidePanel';
 import ProjectForm from './ProjectForm/ProjectForm';
 import './styles.css';
+import useGetProject from '@/hooks/useGetProject';
 
 const ProjectBasics = () => {
-  const project = useAppSelector(selectProject);
+  const { data: project } = useGetProject();
   const projectMode = useAppSelector(selectProjectMode);
   const { t } = useTranslation();
 
@@ -25,10 +26,10 @@ const ProjectBasics = () => {
       {(project || projectMode === 'new') && (
         <>
           <div className="flex w-[35%] justify-center">
-            <ProjectSidePanel navItems={navItems} pwFolderLink={project?.pwFolderLink} />
+            <ProjectSidePanel navItems={navItems} project={project ?? null} />
           </div>
           <div className="flex w-[65%]" data-testid="form-panel">
-            <ProjectForm />
+            <ProjectForm project={project ?? null} />
           </div>
         </>
       )}

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectFinancialSection.tsx
@@ -7,13 +7,15 @@ import { IOption } from '@/interfaces/common';
 import { validateInteger, validateMaxLength } from '@/utils/validation';
 import { useTranslation } from 'react-i18next';
 import { useAppSelector } from '@/hooks/common';
-import { selectIsProjectSaving, selectProject } from '@/reducers/projectSlice';
+import { selectIsProjectSaving } from '@/reducers/projectSlice';
 import TextAreaField from '@/components/shared/TextAreaField';
 import RadioCheckboxField from '@/components/shared/RadioCheckboxField';
 import { Option } from 'hds-react';
 import { getProjectSapCosts } from '@/reducers/sapCostSlice';
+import { IProject } from '@/interfaces/projectInterfaces';
 
 interface IProjectFinancialSectionProps {
+  project: IProject | null;
   control: Control<IProjectForm>;
   getValues: UseFormGetValues<IProjectForm>;
   watch: UseFormWatch<IProjectForm>;
@@ -32,6 +34,7 @@ interface IProjectFinancialSectionProps {
   isUserOnlyViewer: boolean;
 }
 const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
+  project,
   getValues,
   getFieldProps,
   watch,
@@ -45,7 +48,6 @@ const ProjectFinancialSection: FC<IProjectFinancialSectionProps> = ({
   const { masterClasses, classes, subClasses } = classOptions;
 
   const isSaving = useAppSelector(selectIsProjectSaving);
-  const project = useAppSelector(selectProject);
   const sapCosts = useAppSelector(getProjectSapCosts);
 
   const currentYearSapValues = useMemo(() => {

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import mockProject from '@/mocks/mockProject';
 import { renderWithProviders, sendProjectUpdateEvent } from '@/utils/testUtils';
 import { arrayHasValue, formatNumberToContainSpaces, matchExact } from '@/utils/common';
+import { routeAxiosConfigCallsToMethodMocks } from '@/utils/routeAxiosConfigCallsToMethodMocks';
 import { IProject } from '@/interfaces/projectInterfaces';
 import {
   mockBudgetOverrunReasons,
@@ -24,15 +25,12 @@ import { mockHashTags } from '@/mocks/mockHashTags';
 import { addProjectUpdateEventListener, removeProjectUpdateEventListener } from '@/utils/events';
 import { waitFor, act, within, screen } from '@testing-library/react';
 import { Route } from 'react-router';
-import { resetProject, setProjectMode, setSelectedProject } from '@/reducers/projectSlice';
-import { Dispatch } from '@reduxjs/toolkit';
+import { setProjectMode } from '@/reducers/projectSlice';
 import ProjectForm from './ProjectForm';
 import { mockGetResponseProvider } from '@/utils/mockGetResponseProvider';
-import ProjectView from '@/views/ProjectView';
-import ProjectBasics from '../ProjectBasics';
-import PlanningView from '@/views/PlanningView/PlanningView';
 import ConfirmDialog from '@/components/shared/ConfirmDialog';
 import ConfirmDialogContextProvider from '@/components/context/ConfirmDialogContext';
+import * as projectApiHooks from '@/api/projectApi';
 import { mockUser } from '@/mocks/mockUsers';
 import { IPerson } from '@/interfaces/personsInterfaces';
 import { mockAllSapCostsProject, mockCurrentYearSapCostsProject } from '@/mocks/mockSapCosts';
@@ -45,7 +43,12 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const getFormField = (name: string) => `projectForm.${name}`;
 
-const render = async () =>
+const render = async (
+  { project = mockProject.data, mode = 'edit' }: { project?: IProject; mode?: 'edit' | 'new' } = {
+    project: mockProject.data,
+    mode: 'edit',
+  },
+) =>
   await act(async () =>
     renderWithProviders(
       <Route>
@@ -53,26 +56,21 @@ const render = async () =>
           path="/"
           element={
             <ConfirmDialogContextProvider>
-              <ProjectForm />
+              <ProjectForm project={project} />
               <ConfirmDialog />
             </ConfirmDialogContextProvider>
           }
         />
-        <Route path="/project/:projectId?" element={<ProjectView />}>
-          <Route path="basics" element={<ProjectBasics />} />
-        </Route>
-        <Route path="/planning" element={<PlanningView />} />
       </Route>,
 
       {
         preloadedState: {
           project: {
-            selectedProject: mockProject.data,
             count: 1,
             error: null,
             page: 1,
             isSaving: false,
-            mode: 'edit',
+            mode,
           },
           auth: { user: mockUser.data, error: null },
           lists: {
@@ -121,13 +119,9 @@ const render = async () =>
     ),
   );
 
-/**
- * simulate event and setting selected project since it happens in projectview
- */
-const sendProjectUpdateEventAndUpdateRedux = async (dispatch: Dispatch, project: IProject) => {
+const sendProjectUpdateEventForProject = async (project: IProject) => {
   try {
     await sendProjectUpdateEvent(project);
-    dispatch(setSelectedProject(project));
   } catch (e) {
     console.log('Error setting project update event listener: ', e);
   }
@@ -136,6 +130,7 @@ const sendProjectUpdateEventAndUpdateRedux = async (dispatch: Dispatch, project:
 describe('projectForm', () => {
   beforeEach(() => {
     mockGetResponseProvider();
+    routeAxiosConfigCallsToMethodMocks(mockedAxios);
   });
   afterEach(async () => {
     jest.clearAllMocks();
@@ -265,9 +260,8 @@ describe('projectForm', () => {
 
     const expectedValues = [...(mockProject.data.hashTags as Array<string>), 'hashtag-3'];
 
-    const project = store.getState().project.selectedProject as IProject;
     const responseProject: { data: IProject } = {
-      data: { ...project, hashTags: expectedValues },
+      data: { ...mockProject.data, hashTags: expectedValues },
     };
 
     // Open modal
@@ -277,7 +271,9 @@ describe('projectForm', () => {
     mockedAxios.patch.mockResolvedValueOnce(responseProject);
 
     // Expect all elements
-    expect(await dialog.findByText(`${project.name} - manageHashTags`)).toBeInTheDocument();
+    expect(
+      await dialog.findByText(`${mockProject.data.name} - manageHashTags`),
+    ).toBeInTheDocument();
     expect(await dialog.findByText('projectHashTags')).toBeInTheDocument();
     expect(await dialog.findByText('popularHashTags')).toBeInTheDocument();
     expect(await dialog.findByText('addHashTagsToProject')).toBeInTheDocument();
@@ -293,7 +289,7 @@ describe('projectForm', () => {
     await user.click(await dialog.findByRole('button', { name: matchExact('save') }));
 
     await act(async () => {
-      sendProjectUpdateEventAndUpdateRedux(store.dispatch, responseProject.data);
+      sendProjectUpdateEventForProject(responseProject.data);
     });
 
     await waitFor(() => expect(dialog).not.toBeInTheDocument);
@@ -350,7 +346,7 @@ describe('projectForm', () => {
     );
 
     // simulate event and setting selected project since it happens in projectview
-    await act(() => sendProjectUpdateEventAndUpdateRedux(dispatch, mockPatchProjectResponse.data));
+    await act(() => sendProjectUpdateEventForProject(mockPatchProjectResponse.data));
 
     const formPatchRequest = mockedAxios.patch.mock.lastCall[1] as IProject;
     const hashTagsAfterSubmit = mockHashTags.data.hashTags.filter((h) =>
@@ -513,8 +509,10 @@ describe('projectForm', () => {
   });
 
   it('can post a new project', async () => {
-    const { user, findByDisplayValue, findByTestId, findByRole, store } = await render();
-    const { dispatch } = store;
+    const { user, findByDisplayValue, findByTestId, findByRole, store } = await render({
+      project: undefined,
+      mode: 'new',
+    });
 
     const expectedName = 'Post project';
     const expectedDescription = 'Post project description';
@@ -525,24 +523,21 @@ describe('projectForm', () => {
     };
 
     const project = mockProject.data;
+    const createdProject: IProject = {
+      ...project,
+      id: 'post-project-id',
+      description: expectedDescription,
+      programmed: expectedProgrammed,
+      phase: expectedPhase,
+      name: expectedName,
+    };
+
     const mockPostResponse: { data: IProject; status: number } = {
-      data: {
-        ...project,
-        id: 'post-project-id',
-        description: expectedDescription,
-        programmed: expectedProgrammed,
-        phase: expectedPhase,
-        name: expectedName,
-      },
+      data: createdProject,
       status: 201,
     };
 
     // reset the form and set project mode to new
-    await waitFor(() => {
-      store.dispatch(resetProject());
-      store.dispatch(setProjectMode('new'));
-    });
-    expect(store.getState().project.selectedProject).toBe(null);
     expect(store.getState().project.mode).toBe('new');
 
     mockedAxios.post.mockResolvedValueOnce(mockPostResponse);
@@ -563,16 +558,14 @@ describe('projectForm', () => {
 
     // save project
     const submitProjectButton = await findByTestId('submit-project-button');
-    mockedAxios.get.mockResolvedValueOnce(mockPostResponse);
     await waitFor(async () => {
       await user.click(submitProjectButton);
-      dispatch(setSelectedProject(mockPostResponse.data));
       store.dispatch(setProjectMode('edit'));
     });
 
     // Ensure that mode is edit and store contains the saved project
     expect(store.getState().project.mode).toBe('edit');
-    expect(store.getState().project.selectedProject).toBe(mockPostResponse.data);
+    // expect(store.getState().project.selectedProject).toBe(mockPostResponse.data);
     expect(await findByTestId('open-delete-project-dialog-button')).toBeInTheDocument();
 
     // Ensure that correct values are present on the form
@@ -613,8 +606,11 @@ describe('projectForm', () => {
 
   it('can delete a project', async () => {
     const project = mockProject.data;
-    const deleteResponse = { data: { id: project.id } };
-    mockedAxios.delete.mockResolvedValueOnce(deleteResponse);
+    const deleteProjectInitiateSpy = jest.spyOn(
+      projectApiHooks.projectApi.endpoints.deleteProject,
+      'initiate',
+    );
+
     const { user, findByTestId, findByRole } = await render();
 
     const openDeleteDialogButton = await findByTestId('open-delete-project-dialog-button');
@@ -625,7 +621,12 @@ describe('projectForm', () => {
     expect(deleteProjectButton).toBeInTheDocument();
     await user.click(deleteProjectButton);
 
-    expect(mockedAxios.delete).toHaveBeenCalledWith('localhost:4000/projects/mock-project-id/');
+    await waitFor(() => {
+      expect(deleteProjectInitiateSpy).toHaveBeenCalledTimes(1);
+      expect(deleteProjectInitiateSpy.mock.calls[0][0]).toBe(project.id);
+    });
+
+    deleteProjectInitiateSpy.mockRestore();
   });
 
   describe('budget overrun reason selection', () => {

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -2,15 +2,9 @@ import useProjectForm from '@/forms/useProjectForm';
 import { useAppDispatch, useAppSelector } from '@/hooks/common';
 import { IAppForms, IProjectForm } from '@/interfaces/formInterfaces';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  selectProjectMode,
-  selectProject,
-  setIsSaving,
-  setSelectedProject,
-} from '@/reducers/projectSlice';
+import { selectProjectMode, setIsSaving, setProjectMode } from '@/reducers/projectSlice';
 import { IProject, IProjectFinances, IProjectRequest } from '@/interfaces/projectInterfaces';
 import { dirtyFieldsToRequestObject } from '@/utils/common';
-import { patchProject, postProject } from '@/services/projectServices';
 import ProjectStatusSection from './ProjectStatusSection';
 import ProjectInfoSection from './ProjectInfoSection';
 import ProjectScheduleSection from './ProjectScheduleSection';
@@ -38,15 +32,21 @@ import { isUserOnlyProjectManager, isUserOnlyViewer } from '@/utils/userRoleHelp
 import { AxiosError } from 'axios';
 import { selectPlanningGroups } from '@/reducers/groupSlice';
 import { moveBudgetBackwards, moveBudgetForwards } from './financesUtils';
+import { usePatchProjectMutation, usePostProjectMutation } from '@/api/projectApi';
 
-const ProjectForm = () => {
+interface IProjectFormProps {
+  project: IProject | null;
+}
+
+const ProjectForm = ({ project }: IProjectFormProps) => {
   const { formMethods, classOptions, locationOptions, selectedMasterClassName, useWatchField } =
-    useProjectForm();
+    useProjectForm(project);
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const [postProject] = usePostProjectMutation();
+  const [patchProject] = usePatchProjectMutation();
 
   const user = useAppSelector(selectUser);
-  const project = useAppSelector(selectProject);
   const projectMode = useAppSelector(selectProjectMode);
 
   const isOnlyViewer = isUserOnlyViewer(user);
@@ -61,6 +61,7 @@ const ProjectForm = () => {
     getFieldState,
     watch,
     setValue,
+    reset,
   } = formMethods;
 
   usePromptConfirmOnNavigate({
@@ -219,10 +220,11 @@ const ProjectForm = () => {
     }
 
     if (!isDirty && newProjectId) {
+      dispatch(setProjectMode('edit'));
       navigate(`/project/${newProjectId}/basics`);
       setNewProjectId('');
     }
-  }, [isDirty, newProjectId, navigate, projectMode]);
+  }, [isDirty, newProjectId, navigate, projectMode, dispatch]);
 
   const hierarchyDistricts = useAppSelector(selectPlanningDistricts);
   const hierarchyDivisions = useAppSelector(selectPlanningDivisions);
@@ -266,11 +268,8 @@ const ProjectForm = () => {
           }
 
           try {
-            const response = await patchProject({ id: project?.id, data });
-            if (response.status === 200) {
-              dispatch(setSelectedProject(response.data));
-              dispatch(setIsSaving(false));
-            }
+            await patchProject({ id: project?.id, data }).unwrap();
+            dispatch(setIsSaving(false));
           } catch (error: unknown) {
             console.log('project patch error: ', error);
             if ((error as AxiosError).status === 403) {
@@ -301,12 +300,10 @@ const ProjectForm = () => {
         // Post project
         if (projectMode === 'new') {
           try {
-            const response = await postProject({ data });
-            if (response.status === 201) {
-              dispatch(setIsSaving(false));
-              dispatch(setSelectedProject(response.data));
-              setNewProjectId(response.data.id);
-            }
+            const response = await postProject({ data }).unwrap();
+            dispatch(setIsSaving(false));
+            reset(form);
+            setNewProjectId(response.id);
           } catch (error) {
             console.log('project post error: ', error);
             if ((error as AxiosError).status === 403) {
@@ -433,6 +430,7 @@ const ProjectForm = () => {
       {/* SECTION 2 - STATUS */}
       <ProjectStatusSection
         {...formProps}
+        project={project}
         constructionEndYear={project?.constructionEndYear}
         isInputDisabled={isInputDisabled}
         isUserOnlyProjectManager={isUserProjectManagerCheck}
@@ -447,6 +445,7 @@ const ProjectForm = () => {
       {/* SECTION 4 - FINANCIALS */}
       <ProjectFinancialSection
         {...formProps}
+        project={project}
         classOptions={classOptions}
         isInputDisabled={isInputDisabled}
         isUserOnlyViewer={isOnlyViewer}
@@ -469,6 +468,7 @@ const ProjectForm = () => {
       {/* BANNER */}
       {!isOnlyViewer && (
         <ProjectFormBanner
+          project={project}
           onSubmit={submitCallback}
           isDirty={isDirty}
           isInputDisabled={isInputDisabled}

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectFormBanner.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectFormBanner.tsx
@@ -2,14 +2,15 @@ import { Button, ButtonVariant, IconTrash } from 'hds-react';
 import { useAppDispatch, useAppSelector } from '@/hooks/common';
 import { BaseSyntheticEvent, FC, memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { selectProject } from '@/reducers/projectSlice';
 import useConfirmDialog from '@/hooks/useConfirmDialog';
-import { deleteProject } from '@/services/projectServices';
 import { useNavigate } from 'react-router';
 import { selectStartYear } from '@/reducers/planningSlice';
 import { loadCoordinationData, loadPlanningData } from '@/App';
+import { IProject } from '@/interfaces/projectInterfaces';
+import { useDeleteProjectMutation } from '@/api/projectApi';
 
 interface IProjectFormbannerProps {
+  project: IProject | null;
   onSubmit: () =>
     | ((e?: BaseSyntheticEvent<object, unknown, unknown> | undefined) => Promise<void>)
     | undefined;
@@ -17,12 +18,17 @@ interface IProjectFormbannerProps {
   isInputDisabled: boolean;
 }
 
-const ProjectFormBanner: FC<IProjectFormbannerProps> = ({ onSubmit, isDirty, isInputDisabled }) => {
+const ProjectFormBanner: FC<IProjectFormbannerProps> = ({
+  project,
+  onSubmit,
+  isDirty,
+  isInputDisabled,
+}) => {
   const dispatch = useAppDispatch();
   const startYear = useAppSelector(selectStartYear);
   const { t } = useTranslation();
-  const project = useAppSelector(selectProject);
   const navigate = useNavigate();
+  const [deleteProject] = useDeleteProjectMutation();
 
   const { isConfirmed } = useConfirmDialog();
 
@@ -50,7 +56,7 @@ const ProjectFormBanner: FC<IProjectFormbannerProps> = ({ onSubmit, isDirty, isI
         console.log('Error deleting project');
       }
     }
-  }, [isConfirmed, project, t, navigate, dispatch, startYear]);
+  }, [isConfirmed, project, t, navigate, dispatch, startYear, deleteProject]);
 
   return (
     <div className="project-form-banner">

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/ProjectHashTags.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectHashTags/ProjectHashTags.tsx
@@ -23,9 +23,9 @@ import { IListItem } from '@/interfaces/common';
 import { arrayHasValue } from '@/utils/common';
 import { selectHashTags } from '@/reducers/hashTagsSlice';
 import { IProject } from '@/interfaces/projectInterfaces';
-import { patchProject } from '@/services/projectServices';
 import './styles.css';
 import _ from 'lodash';
+import { usePatchProjectMutation } from '@/api/projectApi';
 
 export interface IHashTagsObject {
   [key: string]: { value: string; id: string };
@@ -68,6 +68,7 @@ const ProjectHashTagsDialog: FC<IProjectHashTagsDialogProps> = forwardRef(
     const { Header, Content, ActionButtons } = Dialog;
     const allHashTags = useAppSelector(selectHashTags);
     const { t } = useTranslation();
+    const [patchProject] = usePatchProjectMutation();
 
     const [formState, setFormState] = useState<IFormState>({
       hashTagsObject: {},
@@ -202,6 +203,7 @@ const ProjectHashTagsDialog: FC<IProjectHashTagsDialogProps> = forwardRef(
         hashTagsObject,
         projectMode,
         setHashTagsState,
+        patchProject,
       ],
     );
 

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectStatusSection.tsx
@@ -12,11 +12,13 @@ import { getFieldsIfEmpty, validateMaxNumber, validateRequiredSelect } from '@/u
 import _ from 'lodash';
 import { mapIconKey } from '@/utils/common';
 import { useAppSelector } from '@/hooks/common';
-import { selectProject, selectProjectMode } from '@/reducers/projectSlice';
+import { selectProjectMode } from '@/reducers/projectSlice';
 import { selectProjectPhases } from '@/reducers/listsSlice';
 import { Tooltip } from 'hds-react';
+import { IProject } from '@/interfaces/projectInterfaces';
 
 interface IProjectStatusSectionProps {
+  project: IProject | null;
   getValues: UseFormGetValues<IProjectForm>;
   setValue: UseFormSetValue<IProjectForm>;
   getFieldProps: (name: string) => {
@@ -41,6 +43,7 @@ const getPhaseIndexByPhaseId = (phaseId: string | undefined, phasesWithIndexes: 
 };
 
 const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
+  project,
   getFieldProps,
   getValues,
   setValue,
@@ -373,7 +376,7 @@ const ProjectStatusSection: FC<IProjectStatusSectionProps> = ({
   );
 
   const projectFormPhase = getValues('phase').label;
-  const projectPhase = useAppSelector(selectProject)?.phase;
+  const projectPhase = project?.phase;
   const [iconKey, setIconKey] = useState(mapIconKey(getValues('phase').label));
   useEffect(() => {
     setIconKey(mapIconKey(getValues('phase').label));

--- a/src/components/Project/ProjectBasics/ProjectFormSidePanel/ProjectFormSidePanel.tsx
+++ b/src/components/Project/ProjectBasics/ProjectFormSidePanel/ProjectFormSidePanel.tsx
@@ -4,17 +4,18 @@ import PWContainer from './PWContainer';
 import SaveIndicator from './SaveIndicator';
 import { INavigationItem } from '@/interfaces/common';
 import './styles.css';
+import { IProject } from '@/interfaces/projectInterfaces';
 
 interface IProjectFormSidePanelProps {
+  project: IProject | null;
   navItems: INavigationItem[];
-  pwFolderLink?: string | null;
   showSaveIndicator?: boolean;
   formStatusSection?: React.ReactNode;
 }
 
 const ProjectFormSidePanel: FC<IProjectFormSidePanelProps> = ({
+  project,
   navItems,
-  pwFolderLink,
   showSaveIndicator = true,
   formStatusSection,
 }) => {
@@ -27,8 +28,8 @@ const ProjectFormSidePanel: FC<IProjectFormSidePanelProps> = ({
             <SideNavigation navItems={navItems} />
           </div>
           {formStatusSection && <div className="form-status-container">{formStatusSection}</div>}
-          <PWContainer pwFolderLink={pwFolderLink} />
-          {showSaveIndicator && <SaveIndicator />}
+          <PWContainer pwFolderLink={project?.pwFolderLink} />
+          {showSaveIndicator && <SaveIndicator project={project} />}
         </div>
       </div>
     </div>

--- a/src/components/Project/ProjectBasics/ProjectFormSidePanel/SaveIndicator.tsx
+++ b/src/components/Project/ProjectBasics/ProjectFormSidePanel/SaveIndicator.tsx
@@ -1,19 +1,24 @@
 import { useTranslation } from 'react-i18next';
 import { CustomTag } from '@/components/shared';
 import { useAppSelector } from '@/hooks/common';
-import { selectIsProjectSaving, selectProject, selectProjectMode } from '@/reducers/projectSlice';
+import { selectIsProjectSaving, selectProjectMode } from '@/reducers/projectSlice';
 import moment from 'moment';
 import './styles.css';
+import { IProject } from '@/interfaces/projectInterfaces';
 
-const SaveIndicator = () => {
+interface ISaveIndicatorProps {
+  project: IProject | null;
+}
+
+const SaveIndicator = ({ project }: ISaveIndicatorProps) => {
   const { t } = useTranslation();
-  const project = useAppSelector(selectProject);
   const isSaving = useAppSelector(selectIsProjectSaving);
   const updatedMoment = moment(project?.updatedDate).format('D.M.YYYY HH:mm:ss');
   const projectMode = useAppSelector(selectProjectMode);
-  const updateText = projectMode === 'new' ? t('notSaved') : t('savedTime', { time: updatedMoment });
+  const updateText =
+    projectMode === 'new' ? t('notSaved') : t('savedTime', { time: updatedMoment });
 
-    return (
+  return (
     <div className="mt-4 flex justify-start">
       <CustomTag
         color={'var(--color-success)'}
@@ -22,7 +27,8 @@ const SaveIndicator = () => {
         textColor={'var(--color-white)'}
         showLoading={isSaving}
       />
-    </div>)
-  }
+    </div>
+  );
+};
 
 export default SaveIndicator;

--- a/src/components/Project/ProjectHeader/ProjectHeader.test.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.test.tsx
@@ -5,6 +5,7 @@ import axios from 'axios';
 import mockProject from '@/mocks/mockProject';
 import { IProject } from '@/interfaces/projectInterfaces';
 import { matchExact } from '@/utils/common';
+import { routeAxiosConfigCallsToMethodMocks } from '@/utils/routeAxiosConfigCallsToMethodMocks';
 import { act } from 'react-dom/test-utils';
 import { Route } from 'react-router';
 import { setupStore } from '@/store';
@@ -19,10 +20,9 @@ const store = setupStore();
 
 const render = async () =>
   await act(async () =>
-    renderWithProviders(<Route path="/" element={<ProjectHeader />} />, {
+    renderWithProviders(<Route path="/" element={<ProjectHeader project={mockProject.data} />} />, {
       preloadedState: {
         project: {
-          selectedProject: mockProject.data,
           count: 1,
           error: null,
           page: 1,
@@ -38,6 +38,10 @@ const render = async () =>
   );
 
 describe('ProjectHeader', () => {
+  beforeEach(() => {
+    routeAxiosConfigCallsToMethodMocks(mockedAxios);
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -51,10 +55,9 @@ describe('ProjectHeader', () => {
   });
 
   it('renders all left side elements', async () => {
-    const { getByRole, getByText, store, getByTestId } = await render();
+    const { getByRole, getByText, getByTestId } = await render();
 
-    const project = store.getState().project.selectedProject as IProject;
-    const { name, phase, address } = project;
+    const { name, phase, address } = mockProject.data;
 
     expect(getByRole('button', { name: /edit-project-name/i })).toBeInTheDocument();
     expect(getByTestId('project-header-name-fields')).toHaveTextContent(matchExact(name));

--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -1,30 +1,34 @@
 import { FC, useCallback, useMemo, useState, useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '@/hooks/common';
 import { dirtyFieldsToRequestObject, mapIconKey } from '@/utils/common';
-import { IProjectRequest } from '@/interfaces/projectInterfaces';
-import { selectProject, setIsSaving, setSelectedProject } from '@/reducers/projectSlice';
+import { IProject, IProjectRequest } from '@/interfaces/projectInterfaces';
+import { setIsSaving } from '@/reducers/projectSlice';
 import { FieldValues, SubmitHandler } from 'react-hook-form';
 import { HookFormControlType, IAppForms, IProjectHeaderForm } from '@/interfaces/formInterfaces';
 import ProjectNameFields from './ProjectNameFields';
 import useProjectHeaderForm from '@/forms/useProjectHeaderForm';
 import { selectUser } from '@/reducers/authSlice';
 import { useTranslation } from 'react-i18next';
-import { patchProject } from '@/services/projectServices';
 import { selectPlanningGroups } from '@/reducers/groupSlice';
 import { notifyError } from '@/reducers/notificationSlice';
 import optionIcon from '@/utils/optionIcon';
+import { usePatchProjectMutation } from '@/api/projectApi';
 
 export interface IProjectHeaderFieldProps {
   control: HookFormControlType;
 }
 
-const ProjectHeader: FC = () => {
+interface IProjectHeaderProps {
+  project: IProject | null;
+}
+
+const ProjectHeader: FC<IProjectHeaderProps> = ({ project }) => {
   const dispatch = useAppDispatch();
-  const project = useAppSelector(selectProject);
   const user = useAppSelector(selectUser);
   const groups = useAppSelector(selectPlanningGroups);
   const { t } = useTranslation();
-  const { formMethods } = useProjectHeaderForm();
+  const [patchProject] = usePatchProjectMutation();
+  const { formMethods } = useProjectHeaderForm(project);
 
   const projectGroupName = useMemo(() => {
     return project?.projectGroup
@@ -59,11 +63,8 @@ const ProjectHeader: FC = () => {
 
         if (project?.id) {
           try {
-            const response = await patchProject({ id: project?.id, data });
-            if (response.status === 200) {
-              dispatch(setSelectedProject(response.data));
-              dispatch(setIsSaving(false));
-            }
+            await patchProject({ id: project?.id, data }).unwrap();
+            dispatch(setIsSaving(false));
           } catch (error) {
             console.log('project patch error: ', error);
             dispatch(setIsSaving(false));
@@ -79,7 +80,7 @@ const ProjectHeader: FC = () => {
         }
       }
     },
-    [isDirty, dispatch, dirtyFields, project?.id, project?.favPersons, user?.uuid],
+    [isDirty, dispatch, dirtyFields, project?.id, project?.favPersons, user?.uuid, patchProject],
   );
 
   const phase = watch('phase');

--- a/src/components/Project/ProjectNotes/ProjectNotes.test.tsx
+++ b/src/components/Project/ProjectNotes/ProjectNotes.test.tsx
@@ -33,7 +33,6 @@ const normalizeConfig = (config?: AxiosRequestConfig | string): AxiosRequestConf
   typeof config === 'string' ? { url: config } : config ?? {};
 
 const createProjectState = () => ({
-  selectedProject: mockProject.data,
   count: 1,
   error: null,
   page: 1,
@@ -47,9 +46,13 @@ const getPreloadedState = () => ({
 
 const render = async () =>
   await act(async () =>
-    renderWithProviders(<Route path="/" element={<ProjectNotes />} />, {
-      preloadedState: getPreloadedState(),
-    }),
+    renderWithProviders(
+      <Route path="/project/:projectId/notes" element={<ProjectNotes />} />,
+      {
+        preloadedState: getPreloadedState(),
+      },
+      { route: `/project/${mockProject.data.id}/notes` },
+    ),
   );
 
 const renderWithNotesLoaded = async () => {

--- a/src/components/Project/ProjectNotes/ProjectNotes.tsx
+++ b/src/components/Project/ProjectNotes/ProjectNotes.tsx
@@ -1,16 +1,16 @@
-import { useAppSelector } from '@/hooks/common';
 import { useCallback } from 'react';
 import ProjectNote from './ProjectNote';
 import NewNoteForm from './NewNoteForm';
 import './styles.css';
 import { t } from 'i18next';
-import { selectProject } from '@/reducers/projectSlice';
 import { sortArrayByDates } from '@/utils/dates';
 import { useGetNotesByProjectQuery } from '@/api/notesApi';
+import { useParams } from 'react-router-dom';
+import { skipToken } from '@reduxjs/toolkit/query';
 
 const ProjectNotes = () => {
-  const projectId = useAppSelector(selectProject)?.id;
-  const { data: notes = [] } = useGetNotesByProjectQuery(projectId || '');
+  const { projectId } = useParams<{ projectId: string }>();
+  const { data: notes = [] } = useGetNotesByProjectQuery(projectId ?? skipToken);
 
   const sortedNotes = useCallback(() => sortArrayByDates(notes, 'createdDate', true), [notes]);
 

--- a/src/components/Project/ProjectTalpa/ProjectTalpa.tsx
+++ b/src/components/Project/ProjectTalpa/ProjectTalpa.tsx
@@ -1,14 +1,14 @@
 import { useTranslation } from 'react-i18next';
 import { ProjectFormSidePanel } from '../ProjectBasics/ProjectFormSidePanel';
 import { useAppDispatch, useAppSelector } from '@/hooks/common';
-import { selectProject } from '@/reducers/projectSlice';
 import ProjectTalpaForm from './ProjectTalpaForm';
 import { markTalpaProjectAsSentThunk, selectTalpaProject } from '@/reducers/talpaSlice';
 import TalpaStatusSection from './TalpaStatusSection';
+import useGetProject from '@/hooks/useGetProject';
 
 export default function ProjectTalpa() {
   const { t } = useTranslation();
-  const project = useAppSelector(selectProject);
+  const { data: project } = useGetProject();
   const talpaProject = useAppSelector(selectTalpaProject);
   const dispatch = useAppDispatch();
 
@@ -31,7 +31,7 @@ export default function ProjectTalpa() {
       <div className="flex w-[35%] flex-shrink-0 justify-center">
         <ProjectFormSidePanel
           navItems={navItems}
-          pwFolderLink={project?.pwFolderLink}
+          project={project ?? null}
           showSaveIndicator={false}
           formStatusSection={
             talpaProject?.status ? (
@@ -41,7 +41,7 @@ export default function ProjectTalpa() {
         />
       </div>
       <div className="mb-20 w-full pr-4" data-testid="talpa-form">
-        <ProjectTalpaForm />
+        <ProjectTalpaForm project={project ?? null} />
       </div>
     </div>
   );

--- a/src/components/Project/ProjectTalpa/ProjectTalpaForm.test.tsx
+++ b/src/components/Project/ProjectTalpa/ProjectTalpaForm.test.tsx
@@ -50,7 +50,7 @@ const saveAsMock = saveAs as jest.MockedFunction<typeof saveAs>;
 
 async function render(talpaProjectOverrides: Partial<ITalpaProjectOpening> = {}) {
   return await act(async () =>
-    renderWithProviders(<Route path="/" element={<ProjectTalpaForm />} />, {
+    renderWithProviders(<Route path="/" element={<ProjectTalpaForm project={null} />} />, {
       preloadedState: {
         talpa: {
           talpaProject: { ...mockTalpaProject, ...talpaProjectOverrides },

--- a/src/components/Project/ProjectTalpa/ProjectTalpaForm.tsx
+++ b/src/components/Project/ProjectTalpa/ProjectTalpaForm.tsx
@@ -16,13 +16,13 @@ import {
   TalpaReadiness,
   TalpaSubject,
 } from '@/interfaces/talpaInterfaces';
-import { useAppDispatch, useAppSelector } from '@/hooks/common';
-import { selectProject } from '@/reducers/projectSlice';
+import { useAppDispatch } from '@/hooks/common';
 import { patchTalpaProjectOpeningThunk, postTalpaProjectOpeningThunk } from '@/reducers/talpaSlice';
 import { BudgetItemNumber } from './budgetItemNumber';
 import { IOption } from '@/interfaces/common';
 import { downloadExcel } from '@/services/talpaServices';
 import { saveAs } from 'file-saver';
+import { IProject } from '@/interfaces/projectInterfaces';
 
 export function getFieldProps(name: FieldPath<IProjectTalpaForm>) {
   return {
@@ -80,13 +80,16 @@ export function mapTalpaFormToRequest(
   };
 }
 
-export default function ProjectTalpaForm() {
+interface IProjectTalpaFormProps {
+  project: IProject | null;
+}
+
+export default function ProjectTalpaForm({ project }: IProjectTalpaFormProps) {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const formMethods = useTalpaForm();
+  const formMethods = useTalpaForm(project);
   const { isSubmitting } = formMethods.formState;
   const { handleSubmit, getValues } = formMethods;
-  const project = useAppSelector(selectProject);
 
   const talpaProjectLocked = getValues('isLocked');
 

--- a/src/components/Project/ProjectTalpa/ProjectTalpaForm.tsx
+++ b/src/components/Project/ProjectTalpa/ProjectTalpaForm.tsx
@@ -84,7 +84,7 @@ interface IProjectTalpaFormProps {
   project: IProject | null;
 }
 
-export default function ProjectTalpaForm({ project }: IProjectTalpaFormProps) {
+export default function ProjectTalpaForm({ project }: Readonly<IProjectTalpaFormProps>) {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const formMethods = useTalpaForm(project);

--- a/src/components/Sidebar/SideBar.test.tsx
+++ b/src/components/Sidebar/SideBar.test.tsx
@@ -5,7 +5,6 @@ import { matchExact } from '@/utils/common';
 import { act } from 'react-dom/test-utils';
 import { Route } from 'react-router';
 import { setupStore } from '@/store';
-import mockProject from '@/mocks/mockProject';
 import { mockGetResponseProvider } from '@/utils/mockGetResponseProvider';
 import PlanningView from '@/views/PlanningView';
 import { mockProjectPhases } from '@/mocks/mockLists';
@@ -30,7 +29,6 @@ const render = async () =>
           auth: { user: mockUser.data, error: {} },
           project: {
             ...store.getState().project,
-            selectedProject: mockProject.data,
           },
           lists: {
             ...store.getState().lists,

--- a/src/components/TopBar/TopBar.test.tsx
+++ b/src/components/TopBar/TopBar.test.tsx
@@ -38,7 +38,7 @@ const render = async (customRoute?: string) =>
       {
         preloadedState: {
           auth: { user: null, error: {} },
-          project: { ...store.getState().project, selectedProject: mockProject.data },
+          project: { ...store.getState().project },
           lists: {
             phases: mockLists.mockProjectPhases.data,
             types: mockLists.mockProjectTypes.data,

--- a/src/forms/useNoteForm.ts
+++ b/src/forms/useNoteForm.ts
@@ -3,12 +3,12 @@ import { useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { useAppSelector } from '../hooks/common';
 import { INote } from '@/interfaces/noteInterfaces';
-import { selectProject } from '@/reducers/projectSlice';
 import { selectUser } from '@/reducers/authSlice';
+import { useParams } from 'react-router-dom';
 
 const useNoteValues = (note?: INote) => {
   const userId = useAppSelector(selectUser)?.uuid;
-  const projectId = useAppSelector(selectProject)?.id;
+  const { projectId } = useParams<{ projectId: string }>();
 
   const formValues = useMemo(
     () => ({
@@ -37,7 +37,7 @@ const useProjectNoteForm = (note?: INote) => {
     if (projectId) {
       reset(formValues);
     }
-  }, [projectId, formValues, userId]);
+  }, [projectId, formValues, userId, reset]);
 
   return { formMethods, formValues };
 };

--- a/src/forms/useProjectForm.refresh.test.tsx
+++ b/src/forms/useProjectForm.refresh.test.tsx
@@ -74,7 +74,7 @@ describe('useProjectForm - Refresh Bug Fix', () => {
   });
 
   it('should NOT reset form when user has made changes (isDirty = true)', async () => {
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     // Simulate user entering data
     act(() => {
@@ -94,7 +94,7 @@ describe('useProjectForm - Refresh Bug Fix', () => {
   });
 
   it('should NOT reset form when formValues are empty/default', async () => {
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     // Simulate user entering data
     act(() => {
@@ -115,7 +115,7 @@ describe('useProjectForm - Refresh Bug Fix', () => {
   });
 
   it('should reset form when legitimate new data arrives and form is not dirty', async () => {
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     // Form starts clean (not dirty)
     expect(result.current.formMethods.formState.isDirty).toBe(false);
@@ -131,7 +131,7 @@ describe('useProjectForm - Refresh Bug Fix', () => {
   });
 
   it('should NOT reset form during submission', async () => {
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     // Simulate form submission state
     // Note: This would require mocking the form submission state
@@ -150,7 +150,7 @@ describe('Form Refresh Scenarios - Integration Tests', () => {
     // 3. Loading states change
     // 4. Form should retain user data
 
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     // Step 1: User fills form
     act(() => {
@@ -166,7 +166,7 @@ describe('Form Refresh Scenarios - Integration Tests', () => {
 
   it('should handle dropdown fields on page refresh', async () => {
     // This test specifically addresses the dropdown refresh issue
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     // User fills dropdown fields (like Pääluokka, Luokka, Alaluokka)
     act(() => {
@@ -206,7 +206,7 @@ describe('Form Refresh Scenarios - Integration Tests', () => {
 
   it('should preserve programmer field when changing class selections', async () => {
     // This test ensures programmer field is not cleared when changing classes
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     // User sets a programmer
     act(() => {
@@ -237,7 +237,7 @@ describe('Form Refresh Scenarios - Integration Tests', () => {
 describe('Edge Cases - Advanced Form Refresh Scenarios', () => {
   it('should handle mixed field types on refresh', async () => {
     // Test edge case: mix of text fields, dropdowns, numbers, dates
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     act(() => {
       // Text field
@@ -280,7 +280,7 @@ describe('Edge Cases - Advanced Form Refresh Scenarios', () => {
 
   it('should handle empty dropdown options on refresh', async () => {
     // Edge case: user selected dropdown option that becomes unavailable after refresh
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     act(() => {
       // User selects a dropdown option
@@ -300,7 +300,7 @@ describe('Edge Cases - Advanced Form Refresh Scenarios', () => {
 
   it('should handle null and undefined values properly', async () => {
     // Edge case: form fields with null/undefined values should not trigger false reset
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     act(() => {
       // Set some fields to null/undefined (common during form initialization)
@@ -324,7 +324,7 @@ describe('Edge Cases - Advanced Form Refresh Scenarios', () => {
 
   it('should handle rapid consecutive field changes', async () => {
     // Edge case: user quickly changes multiple fields before state updates
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     act(() => {
       // Rapid consecutive changes
@@ -346,7 +346,7 @@ describe('Edge Cases - Advanced Form Refresh Scenarios', () => {
 
   it('should handle special characters and Unicode in form fields', async () => {
     // Edge case: ensure special characters don't break the refresh logic
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     const specialText = 'Projekti äöüßñ 特殊字符 🚀 @#$%^&*()';
     const unicodePath = 'Helsinki/Käpylä/Östra_delen';
@@ -364,7 +364,7 @@ describe('Edge Cases - Advanced Form Refresh Scenarios', () => {
 
   it('should handle very long form field values', async () => {
     // Edge case: ensure large text values don't affect refresh logic
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     const longDescription = 'A'.repeat(5000); // Very long text
     const longName =
@@ -384,7 +384,7 @@ describe('Edge Cases - Advanced Form Refresh Scenarios', () => {
 
   it('should handle dropdown with empty string value', async () => {
     // Edge case: dropdown with empty string value (different from null/undefined)
-    const { result } = renderHook(() => useProjectForm(), { wrapper });
+    const { result } = renderHook(() => useProjectForm(null), { wrapper });
 
     act(() => {
       // Dropdown with empty value (but still valid IOption structure)

--- a/src/forms/useProjectForm.test.tsx
+++ b/src/forms/useProjectForm.test.tsx
@@ -84,7 +84,6 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => {
 
 // Type for our selectors
 type SelectorName =
-  | 'selectProject'
   | 'selectProjectMode'
   | 'selectProjectUpdate'
   | 'selectIsLoading'
@@ -106,7 +105,6 @@ describe('useProjectForm', () => {
   it('initializes with empty values when no project is selected', () => {
     // Mock the selectors to return stable values
     const mockSelectors: Record<SelectorName, any> = {
-      selectProject: null,
       selectProjectMode: 'new',
       selectProjectUpdate: { project: { id: null } }, // Properly structured project update
       selectIsLoading: false,
@@ -124,7 +122,7 @@ describe('useProjectForm', () => {
       (selector: { name: SelectorName }) => mockSelectors[selector.name] ?? [],
     );
 
-    const { result } = renderHook(() => useProjectForm(), {
+    const { result } = renderHook(() => useProjectForm(null), {
       wrapper: Wrapper,
     });
 
@@ -168,7 +166,6 @@ describe('useProjectForm', () => {
     };
 
     const mockSelectors: Record<SelectorName, any> = {
-      selectProject: null,
       selectProjectMode: 'new',
       selectProjectUpdate: { project: { id: null } },
       selectIsLoading: false,
@@ -185,7 +182,7 @@ describe('useProjectForm', () => {
       (selector: { name: SelectorName }) => mockSelectors[selector.name] ?? [],
     );
 
-    const { result } = renderHook(() => useProjectForm(), {
+    const { result } = renderHook(() => useProjectForm(null), {
       wrapper: Wrapper,
     });
 

--- a/src/forms/useProjectForm.ts
+++ b/src/forms/useProjectForm.ts
@@ -6,7 +6,7 @@ import { listItemToOption } from '@/utils/common';
 import { IProject } from '@/interfaces/projectInterfaces';
 import { IListItem, IOption } from '@/interfaces/common';
 import { IClass } from '@/interfaces/classInterfaces';
-import { selectProjectMode, selectProject } from '@/reducers/projectSlice';
+import { selectProjectMode } from '@/reducers/projectSlice';
 import {
   selectPlanningClasses,
   selectAllPlanningClasses,
@@ -28,14 +28,11 @@ import { useProjectProgrammer } from '@/utils/projectProgrammerUtils';
 import { usePostalCode } from '@/hooks/usePostalCode';
 
 /**
- * Creates the memoized initial values for react-hook-form useForm()-hook. It also returns the
- * project which can be needed to check for updates.
+ * Creates the memoized initial values for react-hook-form useForm()-hook.
  *
- * @returns formValues, project
+ * @returns formValues
  */
-const useProjectFormValues = () => {
-  const project = useAppSelector(selectProject);
-
+const useProjectFormValues = (project: IProject | null) => {
   const masterClasses = useAppSelector(selectAllPlanningClasses);
   const classes = useAppSelector(selectPlanningClasses);
   const subClasses = useAppSelector(selectPlanningSubClasses);
@@ -196,7 +193,6 @@ const useProjectFormValues = () => {
 
   return {
     formValues,
-    project,
     classes,
     subClasses,
     masterClasses,
@@ -207,16 +203,14 @@ const useProjectFormValues = () => {
 };
 
 /**
- * This hook initializes a react-hook-form control for the project form. It will keep the
- * form up to date with the selectedProject from redux and return all needed functions to handle
- * the form.
+ * This hook initializes a react-hook-form control for the project form. It returns
+ * all needed functions to handle the form.
  *
  * @returns handleSubmit, reset, formFields, dirtyFields
  */
-const useProjectForm = () => {
-  const selectedProject = useAppSelector(selectProject);
+const useProjectForm = (project: IProject | null) => {
   const projectUpdate = useAppSelector(selectProjectUpdate);
-  const { formValues, project } = useProjectFormValues();
+  const { formValues } = useProjectFormValues(project);
   const projectMode = useAppSelector(selectProjectMode);
   const formMethods = useForm<IProjectForm>({
     defaultValues: formValues,
@@ -396,7 +390,7 @@ const useProjectForm = () => {
     const projectUpdateMatchesCurrentProject = project?.id === projectUpdate?.project?.id;
     const triggeredByProjectUpdate =
       (projectMode === 'edit' && projectUpdateMatchesCurrentProject) ||
-      (projectMode === 'new' && selectedProject !== null);
+      (projectMode === 'new' && project !== null);
 
     const canResetAfterLoading = !isProjectCardLoading && !isLoading;
     let triggeredByLoadingStates = false;
@@ -441,7 +435,6 @@ const useProjectForm = () => {
     projectMode,
     projectUpdate,
     reset,
-    selectedProject,
   ]);
 
   return {

--- a/src/forms/useProjectHeaderForm.ts
+++ b/src/forms/useProjectHeaderForm.ts
@@ -3,18 +3,16 @@ import { useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { useAppSelector } from '../hooks/common';
 import { listItemToOption } from '@/utils/common';
-import { selectProject } from '@/reducers/projectSlice';
 import { selectUser } from '@/reducers/authSlice';
 import { usePostalCode } from '@/hooks/usePostalCode';
+import { IProject } from '@/interfaces/projectInterfaces';
 
 /**
- * Creates the memoized initial values for react-hook-form useForm()-hook. It also returns the
- * project which can be needed to check for updates.
+ * Creates the memoized initial values for react-hook-form useForm()-hook.
  *
  * @returns formValues, project
  */
-const useProjectHeaderValues = () => {
-  const selectedProject = useAppSelector(selectProject);
+const useProjectHeaderValues = (selectedProject: IProject | null) => {
   const user = useAppSelector(selectUser);
 
   const formValues = useMemo(
@@ -29,18 +27,17 @@ const useProjectHeaderValues = () => {
     [selectedProject, user],
   );
 
-  return { formValues, selectedProject };
+  return formValues;
 };
 
 /**
- * This hook initializes a react-hook-form control for a project header form. It will keep the
- * form up to date with the selectedProject from redux and return all needed functions to handle
- * the form.
+ * This hook initializes a react-hook-form control for a project header form. It returns
+ * all needed functions to handle the form.
  *
  * @returns handleSubmit, control, dirtyFields
  */
-const useProjectHeaderForm = () => {
-  const { formValues, selectedProject } = useProjectHeaderValues();
+const useProjectHeaderForm = (project: IProject | null) => {
+  const formValues = useProjectHeaderValues(project);
 
   const formMethods = useForm<IProjectHeaderForm>({
     defaultValues: useMemo(() => formValues, [formValues]),
@@ -49,12 +46,12 @@ const useProjectHeaderForm = () => {
 
   const { control, reset, watch, setValue } = formMethods;
 
-  // Updates form when the selectedProject changes in redux
+  // Updates form when the project changes
   useEffect(() => {
-    if (selectedProject) {
+    if (project) {
       reset(formValues);
     }
-  }, [selectedProject, formValues, reset]);
+  }, [project, formValues, reset]);
 
   const address = watch('address');
   const { postalCode, city } = usePostalCode(address || '');

--- a/src/forms/useTalpaForm.test.tsx
+++ b/src/forms/useTalpaForm.test.tsx
@@ -4,6 +4,7 @@ import { BudgetItemNumber } from '@/components/Project/ProjectTalpa/budgetItemNu
 import { ITalpaProjectOpening, TalpaReadiness } from '@/interfaces/talpaInterfaces';
 import mockTalpaProject from '@/mocks/mockTalpaProject';
 import { TalpaProfileName } from '@/components/Project/ProjectTalpa/profileName';
+import { IProject } from '@/interfaces/projectInterfaces';
 
 const mockUseAppSelector = jest.fn();
 const mockDispatch = jest.fn();
@@ -24,7 +25,6 @@ jest.mock('@/hooks/usePostalCode', () => ({
 }));
 
 type SelectorName =
-  | 'selectProject'
   | 'selectTalpaProject'
   | 'selectPlanningClasses'
   | 'selectPlanningSubClasses'
@@ -57,7 +57,7 @@ describe('useTalpaForm', () => {
         person: 'person-1',
       },
       address: 'Testitie 1',
-    };
+    } as IProject;
 
     const planningClass = {
       id: 'ddbf3ce8-5bc4-410b-8759-e68d80dad99e',
@@ -66,7 +66,6 @@ describe('useTalpaForm', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const selectors: Record<SelectorName, any> = {
-      selectProject: project,
       selectTalpaProject: null,
       selectPlanningClasses: [planningClass],
       selectPlanningSubClasses: [],
@@ -84,7 +83,7 @@ describe('useTalpaForm', () => {
       return selectors[selector.name];
     });
 
-    const { result } = renderHook(() => useTalpaForm());
+    const { result } = renderHook(() => useTalpaForm(project));
 
     expect(mockDispatch).toHaveBeenCalledTimes(1);
 
@@ -148,7 +147,7 @@ describe('useTalpaForm', () => {
         estConstructionEnd: '31.12.2026',
         projectClass: 'sub-class-1',
         address: 'Testitie 1',
-      };
+      } as IProject;
 
       const planningClass = {
         id: 'class-1',
@@ -163,7 +162,6 @@ describe('useTalpaForm', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const selectors: Record<SelectorName, any> = {
-        selectProject: project,
         selectTalpaProject: null,
         selectPlanningClasses: [planningClass],
         selectPlanningSubClasses: [planningSubClass],
@@ -174,7 +172,7 @@ describe('useTalpaForm', () => {
         return selectors[selector.name];
       });
 
-      const { result } = renderHook(() => useTalpaForm());
+      const { result } = renderHook(() => useTalpaForm(project));
       const values = result.current.getValues();
 
       expect(values.budgetAccount).toBe(expectedBudgetAccount);
@@ -184,7 +182,6 @@ describe('useTalpaForm', () => {
   it('populates form values when talpa project data is loaded', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const selectors: Record<SelectorName, any> = {
-      selectProject: { id: 'f0edf54d-4367-49c7-bb42-1420cacebb3e' },
       selectTalpaProject: null,
       selectPlanningClasses: [],
       selectPlanningSubClasses: [],
@@ -195,9 +192,11 @@ describe('useTalpaForm', () => {
       return selectors[selector.name];
     });
 
+    const project = { id: 'f0edf54d-4367-49c7-bb42-1420cacebb3e' } as IProject;
+
     const talpaProject = buildTalpaProject();
 
-    const { result, rerender } = renderHook(() => useTalpaForm());
+    const { result, rerender } = renderHook(() => useTalpaForm(project));
 
     expect(mockDispatch).toHaveBeenCalledTimes(1);
 
@@ -241,7 +240,6 @@ describe('useTalpaForm', () => {
   it('wraps template project label to option when budget item number is not infra investment', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const selectors: Record<SelectorName, any> = {
-      selectProject: null,
       selectTalpaProject: buildTalpaProject({
         id: 'a5566bf7-a6fc-49bc-99b9-65341a684a33',
         budgetAccount: '8 01 03 01 Muu esirakentaminen',
@@ -307,7 +305,7 @@ describe('useTalpaForm', () => {
       return selectors[selector.name];
     });
 
-    const { result } = renderHook(() => useTalpaForm());
+    const { result } = renderHook(() => useTalpaForm(null));
 
     const values = result.current.getValues();
 

--- a/src/forms/useTalpaForm.ts
+++ b/src/forms/useTalpaForm.ts
@@ -10,7 +10,6 @@ import {
 } from '@/interfaces/talpaInterfaces';
 import { BudgetItemNumber } from '@/components/Project/ProjectTalpa/budgetItemNumber';
 import { useAppDispatch, useAppSelector } from '@/hooks/common';
-import { selectProject } from '@/reducers/projectSlice';
 import { selectPlanningClasses, selectPlanningSubClasses } from '@/reducers/classSlice';
 import { useEffect } from 'react';
 import { infraInvestmentTemplateProject } from '@/components/Project/ProjectTalpa/templateProjectOptions';
@@ -111,8 +110,7 @@ function useResponsiblePerson(project: IProject | null): {
   return { responsiblePersonName, responsiblePersonEmail };
 }
 
-const useTalpaProjectOpeningToFormValues = (): IProjectTalpaForm => {
-  const project = useAppSelector(selectProject);
+const useTalpaProjectOpeningToFormValues = (project: IProject | null): IProjectTalpaForm => {
   const talpaProject = useAppSelector(selectTalpaProject);
   const classes = useAppSelector(selectPlanningClasses);
   const subClasses = useAppSelector(selectPlanningSubClasses);
@@ -195,11 +193,10 @@ const useTalpaProjectOpeningToFormValues = (): IProjectTalpaForm => {
   };
 };
 
-export default function useTalpaForm() {
-  const project = useAppSelector(selectProject);
+export default function useTalpaForm(project: IProject | null) {
   const dispatch = useAppDispatch();
 
-  const formValues = useTalpaProjectOpeningToFormValues();
+  const formValues = useTalpaProjectOpeningToFormValues(project);
 
   const formMethods = useForm<IProjectTalpaForm>({
     values: formValues,

--- a/src/hooks/useGetProject.ts
+++ b/src/hooks/useGetProject.ts
@@ -1,0 +1,20 @@
+import { useParams } from 'react-router';
+import { useAppSelector } from './common';
+import { selectUser } from '@/reducers/authSlice';
+import { selectProjectMode } from '@/reducers/projectSlice';
+import { useGetProjectByIdQuery } from '@/api/projectApi';
+import { skipToken } from '@reduxjs/toolkit/query';
+
+export default function useGetProject() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const user = useAppSelector(selectUser);
+  const projectMode = useAppSelector(selectProjectMode);
+  const shouldFetchProject = Boolean(projectId && user && projectMode !== 'new');
+
+  const result = useGetProjectByIdQuery(shouldFetchProject && projectId ? projectId : skipToken);
+
+  return {
+    ...result,
+    shouldFetchProject,
+  };
+}

--- a/src/reducers/planningSlice.ts
+++ b/src/reducers/planningSlice.ts
@@ -7,15 +7,12 @@ import {
   PlanningMode,
 } from '@/interfaces/planningInterfaces';
 import { ILocation } from '@/interfaces/locationInterfaces';
-import { IProject, IProjectPatchRequestObject } from '@/interfaces/projectInterfaces';
+import { IProject } from '@/interfaces/projectInterfaces';
 import { RootState } from '@/store';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { getCoordinatorNotes, postCoordinatorNoteToProject } from '@/services/noteServices';
-import { IError, INotification } from '@/interfaces/common';
+import { IError } from '@/interfaces/common';
 import { ICoordinatorNote } from '@/interfaces/noteInterfaces';
-import { patchProject } from '@/services/projectServices';
-import { clearLoading, setLoading } from './loaderSlice';
-import { notifyError } from './notificationSlice';
 
 interface ICoordinatorNotesModalOpen {
   isOpen: boolean;
@@ -42,15 +39,6 @@ interface IPlanningState {
   coordinatorNotes: ICoordinatorNote[];
 }
 
-interface IProjectUpdateParams {
-  /** Request object containing the project data to update */
-  request: IProjectPatchRequestObject;
-  /** Optional error notification to display in case of failure */
-  errorNotification?: INotification;
-}
-
-const UPDATE_PROJECT = 'update-project';
-
 export const getCoordinatorNotesThunk = createAsyncThunk(
   'coordinatorNotes/getByProject',
   async (_, thunkAPI) => {
@@ -66,24 +54,6 @@ export const postCoordinatorNoteToProjectThunk = createAsyncThunk(
     return await postCoordinatorNoteToProject(request)
       .then((res) => res)
       .catch((err: IError) => thunkAPI.rejectWithValue(err));
-  },
-);
-
-export const updateProject = createAsyncThunk(
-  'projects/update',
-  async (params: IProjectUpdateParams, thunkAPI) => {
-    thunkAPI.dispatch(setLoading({ text: 'Update project data', id: UPDATE_PROJECT }));
-    return await patchProject(params.request)
-      .then((res) => res.data)
-      .catch((error) => {
-        if (params.errorNotification) {
-          thunkAPI.dispatch(notifyError(params.errorNotification));
-        }
-        return thunkAPI.rejectWithValue(error);
-      })
-      .finally(() => {
-        thunkAPI.dispatch(clearLoading(UPDATE_PROJECT));
-      });
   },
 );
 
@@ -242,17 +212,6 @@ export const planningSlice = createSlice({
         return { ...state, coordinatorNotesError: action.payload };
       },
     );
-    builder.addCase(updateProject.fulfilled, (state, action: PayloadAction<IProject>) => {
-      const updatedProject = action.payload;
-      const projectIndex = state.projects.findIndex((project) => project.id === updatedProject.id);
-      const originalProject = state.projects[projectIndex];
-      if (projectIndex !== -1) {
-        state.projects[projectIndex] = {
-          ...originalProject,
-          ...updatedProject,
-        };
-      }
-    });
   },
 });
 

--- a/src/reducers/projectSlice.ts
+++ b/src/reducers/projectSlice.ts
@@ -1,12 +1,10 @@
 import { projectApi } from '@/api/projectApi';
 import { IError } from '@/interfaces/common';
-import { IProject } from '@/interfaces/projectInterfaces';
 import { RootState } from '@/store';
 import { getErrorFromRejectedAction } from '@/utils/reduxErrorUtils';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface IProjectState {
-  selectedProject: IProject | null;
   count: number | null;
   page: number;
   error: IError | null;
@@ -15,7 +13,6 @@ interface IProjectState {
 }
 
 const initialState: IProjectState = {
-  selectedProject: null,
   count: null,
   error: null,
   page: 0,
@@ -33,12 +30,6 @@ export const projectSlice = createSlice({
         page: action.payload,
       };
     },
-    resetProject(state) {
-      return { ...state, selectedProject: null };
-    },
-    setSelectedProject(state, action: PayloadAction<IProject>) {
-      return { ...state, selectedProject: action.payload };
-    },
     setIsSaving(state, action: PayloadAction<boolean>) {
       return { ...state, isSaving: action.payload };
     },
@@ -50,26 +41,21 @@ export const projectSlice = createSlice({
     builder
       .addMatcher(projectApi.endpoints.getProjectById.matchPending, (state) => {
         state.error = null;
-        state.selectedProject = null;
       })
-      .addMatcher(projectApi.endpoints.getProjectById.matchFulfilled, (state, action) => {
-        state.selectedProject = action.payload;
+      .addMatcher(projectApi.endpoints.getProjectById.matchFulfilled, (state) => {
         state.error = null;
       })
       .addMatcher(projectApi.endpoints.getProjectById.matchRejected, (state, action) => {
-        state.selectedProject = null;
         state.error = getErrorFromRejectedAction(action);
       });
   },
 });
 
-export const selectProject = (state: RootState) => state.project.selectedProject;
 export const selectCount = (state: RootState) => state.project.count;
 export const selectPage = (state: RootState) => state.project.page;
 export const selectIsProjectSaving = (state: RootState) => state.project.isSaving;
 export const selectProjectMode = (state: RootState) => state.project.mode;
 
-export const { setPage, resetProject, setSelectedProject, setIsSaving, setProjectMode } =
-  projectSlice.actions;
+export const { setPage, setIsSaving, setProjectMode } = projectSlice.actions;
 
 export default projectSlice.reducer;

--- a/src/services/projectServices.ts
+++ b/src/services/projectServices.ts
@@ -1,9 +1,6 @@
 import { IFreeSearchResults } from '@/interfaces/common';
 import {
   IProject,
-  IProjectPatchRequestObject,
-  IProjectPostRequestObject,
-  IProjectResponse,
   IProjectsPatchRequestObject,
   IProjectsResponse,
 } from '@/interfaces/projectInterfaces';
@@ -15,37 +12,6 @@ import {
 import axios from 'axios';
 
 const { REACT_APP_API_URL } = process.env;
-
-export const deleteProject = async (id: string): Promise<{ id: string }> => {
-  try {
-    const res = await axios.delete(`${REACT_APP_API_URL}/projects/${id}/`);
-    return res.data;
-  } catch (e) {
-    return Promise.reject(e);
-  }
-};
-
-export const patchProject = async (
-  request: IProjectPatchRequestObject,
-): Promise<IProjectResponse> => {
-  try {
-    const res = await axios.patch(`${REACT_APP_API_URL}/projects/${request.id}/`, request.data);
-    return res;
-  } catch (e) {
-    return Promise.reject(e);
-  }
-};
-
-export const postProject = async (
-  request: IProjectPostRequestObject,
-): Promise<IProjectResponse> => {
-  try {
-    const res = await axios.post(`${REACT_APP_API_URL}/projects/`, request.data);
-    return res;
-  } catch (e) {
-    return Promise.reject(e);
-  }
-};
 
 export const getSearchResults = async (req: ISearchRequest): Promise<ISearchResults> => {
   try {

--- a/src/utils/mockGetResponseProvider.ts
+++ b/src/utils/mockGetResponseProvider.ts
@@ -64,6 +64,7 @@ const getMockResponseForUrl = (rawUrl?: string) => {
     case url === '/projects/':
       return Promise.resolve(mockProject);
     case url === `/projects/${mockProject.data.id}`:
+    case url === `/projects/${mockProject.data.id}/`:
       return Promise.resolve(mockProject);
     case url === '/project-hashtags/':
       return Promise.resolve(mockHashTags);

--- a/src/utils/routeAxiosConfigCallsToMethodMocks.ts
+++ b/src/utils/routeAxiosConfigCallsToMethodMocks.ts
@@ -1,0 +1,43 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+export const routeAxiosConfigCallsToMethodMocks = (mockedAxios: jest.Mocked<typeof axios>) => {
+  const mockedAxiosFn = mockedAxios as unknown as jest.MockedFunction<typeof axios>;
+
+  mockedAxiosFn.mockImplementation(async (...args: unknown[]) => {
+    const config = (
+      typeof args[0] === 'object' && args[0] !== null ? args[0] : args[1]
+    ) as AxiosRequestConfig;
+
+    const method = (config?.method ?? 'GET').toUpperCase();
+    const url = config?.url ?? '';
+
+    switch (method) {
+      case 'POST':
+        return mockedAxios.post(url, config?.data, {
+          params: config?.params,
+          headers: config?.headers,
+        });
+      case 'PUT':
+        return mockedAxios.put(url, config?.data, {
+          params: config?.params,
+          headers: config?.headers,
+        });
+      case 'PATCH':
+        return mockedAxios.patch(url, config?.data, {
+          params: config?.params,
+          headers: config?.headers,
+        });
+      case 'DELETE':
+        return mockedAxios.delete(url, {
+          data: config?.data,
+          params: config?.params,
+          headers: config?.headers,
+        });
+      default:
+        return mockedAxios.get(url, {
+          params: config?.params,
+          headers: config?.headers,
+        });
+    }
+  });
+};

--- a/src/views/PlanningView/PlanningView.test.tsx
+++ b/src/views/PlanningView/PlanningView.test.tsx
@@ -44,6 +44,7 @@ import { getToday, updateYear } from '@/utils/dates';
 import moment from 'moment';
 import { updateClass, updateMasterClass } from '@/reducers/classSlice';
 import { IGroup } from '@/interfaces/groupInterfaces';
+import { routeAxiosConfigCallsToMethodMocks } from '@/utils/routeAxiosConfigCallsToMethodMocks';
 
 jest.mock('axios');
 jest.mock('react-i18next', () => mockI18next());
@@ -57,6 +58,7 @@ jest.mock('@/components/shared', () => {
 jest.setTimeout(7000);
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
+
 const store = setupStore();
 
 const PlanningViewTestApp = () => {
@@ -145,6 +147,7 @@ describe('PlanningView', () => {
 
   beforeEach(() => {
     mockGetResponseProvider();
+    routeAxiosConfigCallsToMethodMocks(mockedAxios);
   });
 
   afterEach(() => {

--- a/src/views/ProjectView/ProjectView.test.tsx
+++ b/src/views/ProjectView/ProjectView.test.tsx
@@ -2,20 +2,17 @@ import mockI18next from '@/mocks/mockI18next';
 import axios from 'axios';
 import mockProject from '@/mocks/mockProject';
 import ProjectView from './ProjectView';
-import { renderWithProviders, sendProjectUpdateEvent } from '@/utils/testUtils';
+import { renderWithProviders } from '@/utils/testUtils';
 import { IError } from '@/interfaces/common';
 import { mockError } from '@/mocks/mockError';
 import { act } from 'react-dom/test-utils';
 import { mockGetResponseProvider } from '@/utils/mockGetResponseProvider';
 import { Route } from 'react-router';
 import { ProjectNotes } from '@/components/Project/ProjectNotes';
-import PlanningView from '../PlanningView/PlanningView';
 import { setupStore } from '@/store';
-import { IProject } from '@/interfaces/projectInterfaces';
-import { addProjectUpdateEventListener, removeProjectUpdateEventListener } from '@/utils/events';
-import { waitFor } from '@testing-library/react';
 import { ProjectBasics } from '@/components/Project/ProjectBasics';
 import { projectApi } from '@/api/projectApi';
+import { mockUser } from '@/mocks/mockUsers';
 
 const store = setupStore();
 
@@ -27,20 +24,19 @@ const mockedAxios = axios as jest.Mocked<typeof axios> & jest.MockedFunction<typ
 const render = async () =>
   await act(async () =>
     renderWithProviders(
-      <Route path="/" element={<ProjectView />}>
-        <Route path="/projects/:projectId" element={<ProjectView />}>
-          <Route path="basics" element={<ProjectBasics />} />
-          <Route path="new" element={<ProjectBasics />} />
-          <Route path="notes" element={<ProjectNotes />} />
-        </Route>
-        <Route path="/planning" element={<PlanningView />} />
+      <Route path="/projects/:projectId" element={<ProjectView />}>
+        <Route path="basics" element={<ProjectBasics />} />
+        <Route path="new" element={<ProjectBasics />} />
+        <Route path="notes" element={<ProjectNotes />} />
       </Route>,
 
       {
         preloadedState: {
-          project: { ...store.getState().project, selectedProject: mockProject.data },
+          project: { ...store.getState().project },
+          auth: { user: mockUser.data, error: null },
         },
       },
+      { route: `/projects/${mockProject.data.id}/basics` },
     ),
   );
 
@@ -53,27 +49,6 @@ describe('ProjectView', () => {
     jest.clearAllMocks();
   });
 
-  it('has all needed data in store', async () => {
-    const { store } = await render();
-
-    expect(store.getState().project.selectedProject).toStrictEqual(mockProject.data);
-  });
-
-  it('listens to projectUpdate in redux and sets the selectedProject when it changes: ', async () => {
-    const { store } = await render();
-
-    addProjectUpdateEventListener(store.dispatch);
-
-    const updatedProject: IProject = { ...mockProject.data, name: 'New name' };
-
-    await sendProjectUpdateEvent(updatedProject);
-
-    await waitFor(() => {
-      expect(store.getState().project.selectedProject).toStrictEqual(updatedProject);
-    });
-
-    removeProjectUpdateEventListener(store.dispatch);
-  });
   it('renders the parent container', async () => {
     const { getByTestId } = await render();
 
@@ -81,9 +56,9 @@ describe('ProjectView', () => {
   });
 
   it('renders the ProjectHeader', async () => {
-    const { getByTestId } = await render();
+    const { findByTestId } = await render();
 
-    expect(getByTestId('project-header')).toBeInTheDocument();
+    expect(await findByTestId('project-header')).toBeInTheDocument();
   });
 
   it('renders the ProjectTabs', async () => {
@@ -94,6 +69,8 @@ describe('ProjectView', () => {
 
   it('catches a failed project fetch', async () => {
     const { store } = await render();
+
+    store.dispatch(projectApi.util.resetApiState());
 
     mockedAxios.mockRejectedValueOnce({
       response: {

--- a/src/views/ProjectView/ProjectView.tsx
+++ b/src/views/ProjectView/ProjectView.tsx
@@ -1,14 +1,8 @@
 import { useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '@/hooks/common';
-import {
-  resetProject,
-  selectProjectMode,
-  selectProject,
-  setProjectMode,
-  setSelectedProject,
-} from '@/reducers/projectSlice';
+import { selectProjectMode } from '@/reducers/projectSlice';
 import ProjectDetailsForm from '@/components/ProjectDetailsForm';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ProjectHeader } from '@/components/Project/ProjectHeader';
 import { selectProjectUpdate } from '@/reducers/eventsSlice';
 import {
@@ -17,55 +11,43 @@ import {
   setIsProjectCardLoading,
   setLoading,
 } from '@/reducers/loaderSlice';
-import { selectUser } from '@/reducers/authSlice';
 import _ from 'lodash';
-import { useGetProjectByIdQuery } from '@/api/projectApi';
-import { skipToken } from '@reduxjs/toolkit/query';
+import useGetProject from '@/hooks/useGetProject';
 
 const LOADING_PROJECT = 'loading-project';
 
 const ProjectView = () => {
   const dispatch = useAppDispatch();
-  const { projectId } = useParams();
   const navigate = useNavigate();
-  const selectedProject = useAppSelector(selectProject);
   const projectUpdate = useAppSelector(selectProjectUpdate);
   const projectMode = useAppSelector(selectProjectMode);
-  const user = useAppSelector(selectUser);
-  const shouldFetchProject = Boolean(projectId && user && projectMode !== 'new');
-  const { isFetching: isProjectFetching, isError: isProjectError } = useGetProjectByIdQuery(
-    shouldFetchProject && projectId ? projectId : skipToken,
-  );
+  const {
+    isFetching: isProjectFetching,
+    isError: isProjectError,
+    data: project,
+    refetch,
+    shouldFetchProject,
+  } = useGetProject();
 
-  // Update selectedProject to redux with a project-update event
+  // Refetch project data when there is a project-update event
   useEffect(() => {
-    const project = projectUpdate?.project;
+    const updatedProject = projectUpdate?.project;
 
-    if (!project) {
+    if (!updatedProject) {
       return;
     }
 
-    // Don't update the selectedProject if the user is viewing another project
-    if (project.id !== selectedProject?.id) {
+    // Don't refetch if the user is viewing another project
+    if (updatedProject.id !== project?.id) {
       return;
     }
 
-    // Update the selectedProject if the project-update event gives different values
-    if (!_.isEqual(project, selectedProject)) {
-      dispatch(setSelectedProject(project));
+    // Refetch if the project-update event gives different values
+    if (!_.isEqual(project, updatedProject)) {
+      refetch();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectUpdate]);
-
-  useEffect(() => {
-    if (projectMode === 'new') {
-      if (projectId && user) {
-        dispatch(setProjectMode('edit'));
-      } else if (!projectId) {
-        dispatch(resetProject());
-      }
-    }
-  }, [projectId, projectMode, user, dispatch]);
 
   useEffect(() => {
     if (!shouldFetchProject) {
@@ -89,11 +71,19 @@ const ProjectView = () => {
     }
   }, [isProjectError, navigate, shouldFetchProject]);
 
+  // Clear view-specific loaders if route changes during a fetch/error transition.
+  useEffect(() => {
+    return () => {
+      dispatch(clearLoading(LOADING_PROJECT));
+      dispatch(clearIsProjectCardLoading());
+    };
+  }, [dispatch]);
+
   return (
     <div className="w-full" data-testid="project-view">
-      {(selectedProject || projectMode === 'new') && (
+      {(project || projectMode === 'new') && (
         <>
-          <ProjectHeader />
+          <ProjectHeader project={project ?? null} />
           <ProjectDetailsForm projectMode={projectMode} />
         </>
       )}


### PR DESCRIPTION
There was an issue with using selectedProject from Redux state that it might reference wrong project than what was viewed in project form. That would happen if first opening project A, then project B and then going back to project A. Data from project B would be shown as GET project would not be triggered again for project A as that data was already in cache because of RTK Query and so selectedProject in Redux would not be updated.

Fixed this by replacing using selectedProject in Redux state with useQuery from RTK Query so that correct project data would always be used. Also refactored POST, PATCH and DELETE project to use RTK Query.

https://helsinkisolutionoffice.atlassian.net/browse/IO-825