### PR TITLE
fix: IO-820 Fix emptying projectLocation when changing project class

### DIFF
--- a/src/components/Planning/GroupDialog/GroupProjectSearch.tsx
+++ b/src/components/Planning/GroupDialog/GroupProjectSearch.tsx
@@ -83,11 +83,11 @@ const GroupProjectSearch: FC<IProjectSearchProps> = ({ getValues, control }) => 
         project.projectClass === groupSubClass || project.projectClass === groupClass;
       const districtMatches =
         project.projectDistrict === groupDistrict ||
-        getLocationParent(projectSubDivisions, project.projectDistrict) === groupDivision ||
+        getLocationParent(projectSubDivisions, project.projectDistrict) === groupDistrict ||
         getLocationParent(
           projectDivisions,
           getLocationParent(projectSubDivisions, project.projectDistrict),
-        ) === groupDivision;
+        ) === groupDistrict;
       const divisionMatches =
         project.projectDistrict === groupDivision ||
         getLocationParent(projectSubDivisions, project.projectDistrict) === groupDivision;

--- a/src/components/Planning/PlanningTable/PlanningRow/HoverTooltip/HoverTooltip.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/HoverTooltip/HoverTooltip.tsx
@@ -85,6 +85,8 @@ const HoverTooltip: FC<IHoverTooltipProps> = ({ text, id }) => {
       data-testid={`hover-tooltip-${id}`}
       ref={elementRef}
       id="tooltip-view"
+      role="tooltip"
+      aria-hidden={!tooltip}
     >
       {tooltip}
       <div className="tooltip-arrow-container">

--- a/src/components/Planning/PlanningTable/PlanningRow/HoverTooltip/TooltipWrapper.tsx
+++ b/src/components/Planning/PlanningTable/PlanningRow/HoverTooltip/TooltipWrapper.tsx
@@ -16,7 +16,7 @@ export default function TooltipWrapper({
   const { showTooltip, hideTooltip } = useHoverTooltip();
 
   const handleShowTooltip = useCallback(
-    (e: React.SyntheticEvent<HTMLButtonElement>) => {
+    (e: React.SyntheticEvent<HTMLDivElement>) => {
       if (translationKey) {
         showTooltip(e, <Trans i18nKey={translationKey} />);
       } else {
@@ -27,7 +27,7 @@ export default function TooltipWrapper({
   );
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         handleShowTooltip(e);
@@ -41,9 +41,10 @@ export default function TooltipWrapper({
   );
 
   return (
-    <button
-      type="button"
+    <div
       className={className}
+      aria-describedby="tooltip-view"
+      tabIndex={0}
       onMouseEnter={handleShowTooltip}
       onMouseLeave={hideTooltip}
       onFocus={handleShowTooltip}
@@ -51,8 +52,9 @@ export default function TooltipWrapper({
       onKeyDown={handleKeyDown}
       onTouchStart={handleShowTooltip}
       onTouchEnd={hideTooltip}
+      onTouchCancel={hideTooltip}
     >
       {children}
-    </button>
+    </div>
   );
 }

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -259,12 +259,6 @@ const ProjectForm = () => {
             }
           }
 
-          /* If project is under a district and user changes the class, the district has to be removed or the
-             project will remain under that district in the new class, which isn't intended behavior */
-          if (data?.projectClass && project.projectLocation) {
-            data = { ...data, projectLocation: null };
-          }
-
           try {
             const response = await patchProject({ id: project?.id, data });
             if (response.status === 200) {


### PR DESCRIPTION
Do not empty projectLocation when changing project class in project form and submitting the form.

Also fix issue with searching projects in group form where projects would not be found even if group had division set as "Eri kaupunginosia".

https://helsinkisolutionoffice.atlassian.net/browse/IO-820