### PR TITLE
fix: IO-836 Fix problems with readonly select field

### DIFF
--- a/src/components/shared/SelectField.test.tsx
+++ b/src/components/shared/SelectField.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { useState } from 'react';
+import mockI18next from '@/mocks/mockI18next';
+import SelectField from './SelectField';
+
+jest.mock('react-i18next', () => mockI18next());
+
+jest.mock('hds-react', () => {
+  const actual = jest.requireActual('hds-react');
+
+  return {
+    ...actual,
+    Select: ({
+      onChange,
+      clearable,
+    }: {
+      onChange?: (selectedOptions: unknown[], clickedOption?: unknown) => void;
+      clearable?: boolean;
+    }) => (
+      <div>
+        <button type="button" onClick={() => onChange?.([], undefined)}>
+          clear selection
+        </button>
+        <span data-testid="clearable-flag">{String(clearable)}</span>
+      </div>
+    ),
+  };
+});
+
+type FormValue = { value: string; label: string };
+type FormData = {
+  first?: FormValue;
+  second?: FormValue;
+};
+
+const TestForm = () => {
+  const { control, getValues } = useForm<FormData>({
+    defaultValues: {
+      first: { value: 'test', label: 'Test' },
+    },
+  });
+  const [currentValue, setCurrentValue] = useState('');
+
+  return (
+    <div>
+      <SelectField
+        name="first"
+        control={control}
+        options={[{ value: 'test', label: 'Test' }]}
+        label="first"
+        clearable
+      />
+      <button type="button" onClick={() => setCurrentValue(JSON.stringify(getValues('first')))}>
+        read value
+      </button>
+      <div data-testid="current-value">{currentValue}</div>
+    </div>
+  );
+};
+
+const ReadOnlyForm = () => {
+  const { control } = useForm<FormData>({
+    defaultValues: {
+      first: { value: 'test', label: 'Test' },
+      second: undefined,
+    },
+  });
+
+  return (
+    <>
+      <SelectField
+        name="first"
+        control={control}
+        options={[{ value: 'test', label: 'Test' }]}
+        label="first"
+        readOnly
+      />
+      <SelectField name="second" control={control} options={[]} label="second" readOnly />
+    </>
+  );
+};
+
+describe('SelectField', () => {
+  it('handles clear event safely when clicked option is undefined', async () => {
+    render(<TestForm />);
+
+    expect(screen.getByTestId('clearable-flag')).toHaveTextContent('true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'clear selection' }));
+    fireEvent.click(screen.getByRole('button', { name: 'read value' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-value')).toHaveTextContent('{"value":"","label":""}');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('clearable-flag')).toHaveTextContent('false');
+    });
+  });
+
+  it('renders readonly value from selected option label', () => {
+    render(<ReadOnlyForm />);
+
+    expect(screen.getByDisplayValue('Test')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'clear selection' })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/SelectField.tsx
+++ b/src/components/shared/SelectField.tsx
@@ -83,22 +83,29 @@ const SelectField: FC<ISelectFieldProps> = ({
     [translateOption],
   );
 
-  const [icon, setIcon] = useState(optionIcon[iconKey as keyof typeof optionIcon]);
+  const resolveIcon = useCallback((key?: string) => {
+    if (!key || !(key in optionIcon)) {
+      return undefined;
+    }
+
+    return optionIcon[key as keyof typeof optionIcon];
+  }, []);
+
+  const [icon, setIcon] = useState(resolveIcon(iconKey));
 
   const updateIconBasedOnSelection = useCallback(
     (selectedValue: string) => {
       const selectedOption = options?.find((option) => option.value === selectedValue);
       if (selectedOption) {
-        const newIcon = optionIcon[selectedOption.label as keyof typeof optionIcon];
-        setIcon(newIcon);
+        setIcon(resolveIcon(selectedOption.label));
       }
     },
-    [options],
+    [options, resolveIcon],
   );
 
   useEffect(() => {
-    setIcon(optionIcon[iconKey as keyof typeof optionIcon]);
-  }, [iconKey]);
+    setIcon(resolveIcon(iconKey));
+  }, [iconKey, resolveIcon]);
 
   return (
     <Controller
@@ -109,7 +116,11 @@ const SelectField: FC<ISelectFieldProps> = ({
         field: { value, onChange, onBlur, disabled: fieldDisabled },
         fieldState: { error },
       }) => {
-        const handleChange = (selectedOptions: Option[], clickedOption: Option) => {
+        const translatedValue = translateValue(value);
+        const readOnlyValue = translatedValue.at(0)?.label;
+        const hasValue = Array.isArray(value) ? value.length > 0 : Boolean(value?.value);
+
+        const handleChange = (selectedOptions: Option[] = [], clickedOption?: Option) => {
           const options = multiSelect ? selectedOptions : clickedOption;
           onChange(options ?? { value: '', label: '' });
           if (shouldUpdateIcon && clickedOption?.value) {
@@ -135,13 +146,13 @@ const SelectField: FC<ISelectFieldProps> = ({
                   label={label ?? ''}
                   control={control}
                   readOnly={true}
-                  readOnlyValue={translateValue(value)[0].label}
+                  readOnlyValue={readOnlyValue}
                 />
               ) : (
                 <HDSSelect
                   id={`select-field-${name}`}
                   className={`custom-select ${iconKey ? 'icon' : ''}`}
-                  value={value ? translateValue(value) : []}
+                  value={translatedValue}
                   onChange={handleChange}
                   onBlur={onBlur}
                   invalid={error ? true : false}
@@ -156,7 +167,7 @@ const SelectField: FC<ISelectFieldProps> = ({
                     error: error?.message,
                     placeholder: placeholder ?? t('choose'),
                   }}
-                  clearable={clearable && value?.value}
+                  clearable={Boolean(clearable && hasValue)}
                   multiSelect={multiSelect}
                   {...rest}
                 />


### PR DESCRIPTION
Select field threw an error when trying to access label of undefined selected value in readonly field.

Added guard for that and for resolving icon so that further crashes could be avoided.

https://helsinkisolutionoffice.atlassian.net/browse/IO-836