### PR TITLE
fix: IO-826 Make sure budgets are updated correctly when changing planning and construction dates in project form

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.test.tsx
@@ -3,8 +3,9 @@ import axios from 'axios';
 import mockProject from '@/mocks/mockProject';
 import { renderWithProviders, sendProjectUpdateEvent } from '@/utils/testUtils';
 import { arrayHasValue, formatNumberToContainSpaces, matchExact } from '@/utils/common';
+import * as commonUtils from '@/utils/common';
 import { routeAxiosConfigCallsToMethodMocks } from '@/utils/routeAxiosConfigCallsToMethodMocks';
-import { IProject } from '@/interfaces/projectInterfaces';
+import { IProject, IProjectRequest } from '@/interfaces/projectInterfaces';
 import {
   mockBudgetOverrunReasons,
   mockConstructionPhaseDetails,
@@ -34,6 +35,7 @@ import * as projectApiHooks from '@/api/projectApi';
 import { mockUser } from '@/mocks/mockUsers';
 import { IPerson } from '@/interfaces/personsInterfaces';
 import { mockAllSapCostsProject, mockCurrentYearSapCostsProject } from '@/mocks/mockSapCosts';
+import { moveBudgetBackwards, moveBudgetForwards } from './financesUtils';
 
 jest.mock('axios');
 jest.mock('react-i18next', () => mockI18next());
@@ -126,6 +128,37 @@ const sendProjectUpdateEventForProject = async (project: IProject) => {
     console.log('Error setting project update event listener: ', e);
   }
 };
+
+const getProjectWithShiftableFinances = ({
+  planningStartYear = 2020,
+  estPlanningStart = '01.01.2020',
+  estPlanningEnd = '01.04.2028',
+  estConstructionStart = '10.04.2029',
+  estConstructionEnd = '10.04.2030',
+  constructionEndYear = 2030,
+}: Partial<IProject> = {}): IProject => ({
+  ...mockProject.data,
+  planningStartYear,
+  estPlanningStart,
+  estPlanningEnd,
+  estConstructionStart,
+  estConstructionEnd,
+  constructionEndYear,
+  finances: {
+    year: planningStartYear ?? 2020,
+    budgetProposalCurrentYearPlus0: '100.00',
+    budgetProposalCurrentYearPlus1: '200.00',
+    budgetProposalCurrentYearPlus2: '300.00',
+    preliminaryCurrentYearPlus3: '400.00',
+    preliminaryCurrentYearPlus4: '500.00',
+    preliminaryCurrentYearPlus5: '600.00',
+    preliminaryCurrentYearPlus6: '700.00',
+    preliminaryCurrentYearPlus7: '800.00',
+    preliminaryCurrentYearPlus8: '900.00',
+    preliminaryCurrentYearPlus9: '1000.00',
+    preliminaryCurrentYearPlus10: '1100.00',
+  },
+});
 
 describe('projectForm', () => {
   beforeEach(() => {
@@ -602,6 +635,220 @@ describe('projectForm', () => {
     expect(formPatchRequest.description).toEqual(expectedDescription);
     expect(formPatchRequest.hkrId).toEqual(expectedHkrId);
     expect(await findByDisplayValue(matchExact(expectedDescription))).toBeInTheDocument();
+  });
+
+  describe('finance updates from schedule changes', () => {
+    it('moves finances forwards when planningStartYear is increased', async () => {
+      const project = getProjectWithShiftableFinances();
+      const expectedPlanningStartYear = 2022;
+      const expectedFinances = moveBudgetForwards(
+        project.finances,
+        2020,
+        expectedPlanningStartYear,
+      );
+      const responseProject: { data: IProject } = {
+        data: {
+          ...project,
+          planningStartYear: expectedPlanningStartYear,
+          finances: expectedFinances,
+        },
+      };
+
+      mockedAxios.patch.mockResolvedValueOnce(responseProject);
+
+      const { user, findByRole, findByTestId } = await render({ project });
+
+      const planningStartYearField = await findByRole('spinbutton', {
+        name: getFormField('planningStartYear'),
+      });
+      const formSubmitButton = await findByTestId('submit-project-button');
+
+      await user.clear(planningStartYearField);
+      await user.type(planningStartYearField, expectedPlanningStartYear.toString());
+      await user.click(formSubmitButton);
+
+      const formPatchRequest = mockedAxios.patch.mock.lastCall[1] as IProject;
+      expect(formPatchRequest.finances).toEqual(expectedFinances);
+    });
+
+    it('moves finances backwards when estPlanningEnd is moved earlier', async () => {
+      const project = getProjectWithShiftableFinances();
+      const expectedPlanningEnd = '01.04.2027';
+      const expectedFinances = moveBudgetBackwards(project.finances, 2028, 2027);
+      const dirtyFieldsToRequestObjectSpy = jest
+        .spyOn(commonUtils, 'dirtyFieldsToRequestObject')
+        .mockReturnValueOnce({ estPlanningEnd: expectedPlanningEnd } as IProjectRequest);
+      const responseProject: { data: IProject } = {
+        data: {
+          ...project,
+          estPlanningEnd: expectedPlanningEnd,
+          finances: expectedFinances,
+        },
+      };
+
+      mockedAxios.patch.mockResolvedValueOnce(responseProject);
+
+      const { user, findByRole, findByTestId } = await render({ project });
+
+      const descriptionField = await findByRole('textbox', {
+        name: getFormField('description *'),
+      });
+      const formSubmitButton = await findByTestId('submit-project-button');
+
+      await user.clear(descriptionField);
+      await user.type(descriptionField, 'description update for submit');
+      await user.click(formSubmitButton);
+
+      await waitFor(() => expect(mockedAxios.patch).toHaveBeenCalled());
+      const formPatchRequest = mockedAxios.patch.mock.lastCall[1] as IProject;
+      expect(formPatchRequest.finances).toEqual(expectedFinances);
+      dirtyFieldsToRequestObjectSpy.mockRestore();
+    });
+
+    it('moves finances backwards from previous end year minus one when planning end overlaps construction start', async () => {
+      const project = getProjectWithShiftableFinances({
+        estPlanningEnd: '01.04.2028',
+        estConstructionStart: '10.04.2028',
+      });
+      const expectedPlanningEnd = '01.04.2026';
+      const expectedFinances = moveBudgetBackwards(project.finances, 2027, 2026);
+      const dirtyFieldsToRequestObjectSpy = jest
+        .spyOn(commonUtils, 'dirtyFieldsToRequestObject')
+        .mockReturnValueOnce({ estPlanningEnd: expectedPlanningEnd } as IProjectRequest);
+      const responseProject: { data: IProject } = {
+        data: {
+          ...project,
+          estPlanningEnd: expectedPlanningEnd,
+          finances: expectedFinances,
+        },
+      };
+
+      mockedAxios.patch.mockResolvedValueOnce(responseProject);
+
+      const { user, findByRole, findByTestId } = await render({ project });
+
+      const descriptionField = await findByRole('textbox', {
+        name: getFormField('description *'),
+      });
+      const formSubmitButton = await findByTestId('submit-project-button');
+
+      await user.clear(descriptionField);
+      await user.type(descriptionField, 'description update for overlap submit');
+      await user.click(formSubmitButton);
+
+      await waitFor(() => expect(mockedAxios.patch).toHaveBeenCalled());
+      const formPatchRequest = mockedAxios.patch.mock.lastCall[1] as IProject;
+      expect(formPatchRequest.finances).toEqual(expectedFinances);
+      dirtyFieldsToRequestObjectSpy.mockRestore();
+    });
+
+    it('moves finances forwards when estConstructionStart is moved later', async () => {
+      const project = getProjectWithShiftableFinances();
+      const expectedConstructionStart = '10.04.2030';
+      const expectedFinances = moveBudgetForwards(project.finances, 2029, 2030);
+      const dirtyFieldsToRequestObjectSpy = jest
+        .spyOn(commonUtils, 'dirtyFieldsToRequestObject')
+        .mockReturnValueOnce({
+          estConstructionStart: expectedConstructionStart,
+        } as IProjectRequest);
+      const responseProject: { data: IProject } = {
+        data: {
+          ...project,
+          estConstructionStart: expectedConstructionStart,
+          finances: expectedFinances,
+        },
+      };
+
+      mockedAxios.patch.mockResolvedValueOnce(responseProject);
+
+      const { user, findByRole, findByTestId } = await render({ project });
+
+      const descriptionField = await findByRole('textbox', {
+        name: getFormField('description *'),
+      });
+      const formSubmitButton = await findByTestId('submit-project-button');
+
+      await user.clear(descriptionField);
+      await user.type(descriptionField, 'description update for submit');
+      await user.click(formSubmitButton);
+
+      await waitFor(() => expect(mockedAxios.patch).toHaveBeenCalled());
+      const formPatchRequest = mockedAxios.patch.mock.lastCall[1] as IProject;
+      expect(formPatchRequest.finances).toEqual(expectedFinances);
+      dirtyFieldsToRequestObjectSpy.mockRestore();
+    });
+
+    it('moves finances forwards from previous start year plus one when construction start overlaps planning end', async () => {
+      const project = getProjectWithShiftableFinances({
+        estPlanningEnd: '01.04.2029',
+        estConstructionStart: '10.04.2029',
+      });
+      const expectedConstructionStart = '10.04.2031';
+      const expectedFinances = moveBudgetForwards(project.finances, 2030, 2031);
+      const dirtyFieldsToRequestObjectSpy = jest
+        .spyOn(commonUtils, 'dirtyFieldsToRequestObject')
+        .mockReturnValueOnce({
+          estConstructionStart: expectedConstructionStart,
+        } as IProjectRequest);
+      const responseProject: { data: IProject } = {
+        data: {
+          ...project,
+          estConstructionStart: expectedConstructionStart,
+          finances: expectedFinances,
+        },
+      };
+
+      mockedAxios.patch.mockResolvedValueOnce(responseProject);
+
+      const { user, findByRole, findByTestId } = await render({ project });
+
+      const descriptionField = await findByRole('textbox', {
+        name: getFormField('description *'),
+      });
+      const formSubmitButton = await findByTestId('submit-project-button');
+
+      await user.clear(descriptionField);
+      await user.type(descriptionField, 'description update for overlap construction submit');
+      await user.click(formSubmitButton);
+
+      await waitFor(() => expect(mockedAxios.patch).toHaveBeenCalled());
+      const formPatchRequest = mockedAxios.patch.mock.lastCall[1] as IProject;
+      expect(formPatchRequest.finances).toEqual(expectedFinances);
+      dirtyFieldsToRequestObjectSpy.mockRestore();
+    });
+
+    it('moves finances backwards when constructionEndYear is decreased', async () => {
+      const project = getProjectWithShiftableFinances();
+      const expectedConstructionEndYear = 2029;
+      const expectedFinances = moveBudgetBackwards(
+        project.finances,
+        2030,
+        expectedConstructionEndYear,
+      );
+      const responseProject: { data: IProject } = {
+        data: {
+          ...project,
+          constructionEndYear: expectedConstructionEndYear,
+          finances: expectedFinances,
+        },
+      };
+
+      mockedAxios.patch.mockResolvedValueOnce(responseProject);
+
+      const { user, findByRole, findByTestId } = await render({ project });
+
+      const constructionEndYearField = await findByRole('spinbutton', {
+        name: getFormField('constructionEndYear'),
+      });
+      const formSubmitButton = await findByTestId('submit-project-button');
+
+      await user.clear(constructionEndYearField);
+      await user.type(constructionEndYearField, expectedConstructionEndYear.toString());
+      await user.click(formSubmitButton);
+
+      const formPatchRequest = mockedAxios.patch.mock.lastCall[1] as IProject;
+      expect(formPatchRequest.finances).toEqual(expectedFinances);
+    });
   });
 
   it('can delete a project', async () => {

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -70,80 +70,70 @@ const ProjectForm = ({ project }: IProjectFormProps) => {
     when: isDirty,
   });
 
-  const updatePlanningStartYear = (
-    finances: IProjectFinances,
-    previousStartYear: number | null,
-    startYear: number,
-  ): IProjectFinances => {
-    let updatedFinances = finances;
-    // If new planning start year is bigger than the previous one, budget from years that are not within the schedule of the project
-    // need to be moved to the new planning start year
-    if (previousStartYear && startYear > previousStartYear) {
-      updatedFinances = moveBudgetForwards(finances, previousStartYear, startYear);
-    }
-    return updatedFinances;
-  };
-
-  const updateEstPlanningEndYear = (
+  /**
+   * Reallocates budget when a phase end year is moved earlier.
+   *
+   * The budget from years that are no longer inside the schedule is moved into the new end year.
+   * If the previous end year overlaps with the next phase start year, that overlapping year is kept
+   * untouched and only fully out-of-schedule years are moved.
+   *
+   * Returns the original values when there is no earlier end-year change or when
+   * there is no year range left to move.
+   */
+  const moveFinancesWhenEndYearMovesEarlier = (
     finances: IProjectFinances,
     previousEndYear: number | null,
     endYear: number | null,
     startYear: number | null,
   ): IProjectFinances => {
-    let updatedFinances = finances;
-    // If new planning end year is smaller that the previous one, budget from the years that are not within the schedule need to
-    // be moved backwards to the new end year
-    if (previousEndYear && endYear && endYear < previousEndYear) {
-      // If there was an overlap between planning end year and construction start year, budget shouldn't be moved from that year
-      // but still needs to be moved from all the years that are not within the schedule anymore
-      const yearIsOverlap = startYear == previousEndYear;
-      const isMoreThanOneYearDifference = previousEndYear - endYear > 1;
-
-      if (yearIsOverlap && isMoreThanOneYearDifference) {
-        updatedFinances = moveBudgetBackwards(finances, previousEndYear - 1, endYear);
-      } else if (!yearIsOverlap) {
-        updatedFinances = moveBudgetBackwards(finances, previousEndYear, endYear);
-      }
+    // No change needed unless the end year was moved earlier.
+    if (previousEndYear === null || endYear === null || endYear >= previousEndYear) {
+      return finances;
     }
-    return updatedFinances;
+
+    // If schedule phases overlap (e.g. planning end == construction start), keep the overlapping year in place
+    // and only move budgets that fall fully outside the updated schedule.
+    const overlapAtPreviousEndYear = startYear !== null && startYear === previousEndYear;
+    const sourceEndYear = overlapAtPreviousEndYear ? previousEndYear - 1 : previousEndYear;
+
+    if (sourceEndYear <= endYear) {
+      return finances;
+    }
+
+    return moveBudgetBackwards(finances, sourceEndYear, endYear);
   };
 
-  const updateEstConstructionStartYear = (
+  /**
+   * Reallocates budget when a phase start year is moved later.
+   *
+   * The budget from years that are no longer inside the schedule is moved into the new start year.
+   * If the previous start year overlaps with the preceding phase end year, that overlapping year is kept
+   * untouched and only fully out-of-schedule years are moved.
+   *
+   * Returns the original values when there is no later start-year change or when
+   * there is no year range left to move.
+   */
+  const moveFinancesWhenStartYearMovesLater = (
     finances: IProjectFinances,
     previousStartYear: number | null,
     startYear: number | null,
     endYear: number | null,
   ): IProjectFinances => {
-    let updatedFinances = finances;
-    // If new construction start year is bigger than the previous one, budget from years that are not within the schedule of the project
-    // need to be moved to the new construction start year
-    if (previousStartYear && startYear && startYear > previousStartYear) {
-      // If there was an overlap between planning end year and construction start year, budget shouldn't be moved from that year
-      // but still needs to be moved from all the years that are not within the schedule anymore
-      const yearIsOverlap = endYear == previousStartYear;
-      const isMoreThanOneYearDifference = startYear - previousStartYear > 1;
-
-      if (yearIsOverlap && isMoreThanOneYearDifference) {
-        updatedFinances = moveBudgetForwards(finances, previousStartYear + 1, startYear);
-      } else if (!yearIsOverlap) {
-        updatedFinances = moveBudgetForwards(finances, previousStartYear, startYear);
-      }
+    // No change needed unless the start year was moved later.
+    if (previousStartYear === null || startYear === null || startYear <= previousStartYear) {
+      return finances;
     }
-    return updatedFinances;
-  };
 
-  const updateConstructionEndYear = (
-    finances: IProjectFinances,
-    previousEndYear: number | null,
-    endYear: number,
-  ): IProjectFinances => {
-    let updatedFinances = finances;
-    // If new construction end year is smaller that the previous one, budget from the years that are not within the schedule need to
-    // be moved backwards to the new end year
-    if (previousEndYear && endYear < previousEndYear) {
-      updatedFinances = moveBudgetBackwards(finances, previousEndYear, endYear);
+    // If schedule phases overlap (e.g. planning end == construction start), keep the overlapping year in place
+    // and only move budgets that fall fully outside the updated schedule.
+    const overlapAtPreviousStartYear = endYear !== null && endYear === previousStartYear;
+    const sourceStartYear = overlapAtPreviousStartYear ? previousStartYear + 1 : previousStartYear;
+
+    if (sourceStartYear >= startYear) {
+      return finances;
     }
-    return updatedFinances;
+
+    return moveBudgetForwards(finances, sourceStartYear, startYear);
   };
 
   const updateFinances = (data: IProjectRequest, project: IProject) => {
@@ -152,17 +142,18 @@ const ProjectForm = ({ project }: IProjectFormProps) => {
 
       if (data.planningStartYear) {
         const planningStartYear = project.planningStartYear ?? null;
-        updatedFinances = updatePlanningStartYear(
+        updatedFinances = moveFinancesWhenStartYearMovesLater(
           updatedFinances,
           planningStartYear,
           data.planningStartYear,
+          null,
         );
       }
       if (data.estPlanningEnd) {
         const previousPlanningEndYear = getYear(project.estPlanningEnd);
         const planningEndYear = getYear(data.estPlanningEnd);
         const constructionStartYear = getYear(project.estConstructionStart);
-        updatedFinances = updateEstPlanningEndYear(
+        updatedFinances = moveFinancesWhenEndYearMovesEarlier(
           updatedFinances,
           previousPlanningEndYear,
           planningEndYear,
@@ -173,7 +164,7 @@ const ProjectForm = ({ project }: IProjectFormProps) => {
         const previousConstructionStartYear = getYear(project.estConstructionStart);
         const constructionStartYear = getYear(data.estConstructionStart);
         const planningEndYear = getYear(project.estPlanningEnd);
-        updatedFinances = updateEstConstructionStartYear(
+        updatedFinances = moveFinancesWhenStartYearMovesLater(
           updatedFinances,
           previousConstructionStartYear,
           constructionStartYear,
@@ -182,10 +173,11 @@ const ProjectForm = ({ project }: IProjectFormProps) => {
       }
       if (data.constructionEndYear) {
         const constructionEndYear = project.constructionEndYear;
-        updatedFinances = updateConstructionEndYear(
+        updatedFinances = moveFinancesWhenEndYearMovesEarlier(
           updatedFinances,
           constructionEndYear,
           data.constructionEndYear,
+          null,
         );
       }
 
@@ -249,7 +241,12 @@ const ProjectForm = ({ project }: IProjectFormProps) => {
 
         // Patch project
         if (project?.id && projectMode === 'edit') {
-          if (data.planningStartYear || data.constructionEndYear) {
+          if (
+            data.planningStartYear ||
+            data.estPlanningEnd ||
+            data.estConstructionStart ||
+            data.constructionEndYear
+          ) {
             data = updateFinances(data, project);
             data = updateDateBasedOnYear(data, project);
           }


### PR DESCRIPTION
There were issues when changing planning and construction dates in project form that budgets would not always be moved correctly and there would be budget left to years where there would not be planning or construction. That was caused by only updating finances when planning start or construction end year was changed but not when planning end or construction start dates were changed.

Also refactored ProjectForm component to use only two functions instead of four to update finances and renamed those functions and tried to make them clearer and added tests.

https://helsinkisolutionoffice.atlassian.net/browse/IO-826