### PR TITLE
IO-411 Pre-fill Ohjelmoija from district when class has no default

### DIFF
--- a/src/forms/useProjectForm.refresh.test.tsx
+++ b/src/forms/useProjectForm.refresh.test.tsx
@@ -31,6 +31,9 @@ jest.mock('@/hooks/useLocationOptions', () => ({
 jest.mock('@/utils/projectProgrammerUtils', () => ({
   useProjectProgrammer: () => ({
     getProgrammerForClass: jest.fn(() => null),
+    // IO-411: stubbed to null so this refresh test keeps exercising the
+    // "no auto-fill" path.
+    getProgrammerForDistrict: jest.fn(() => null),
   }),
 }));
 

--- a/src/forms/useProjectForm.test.tsx
+++ b/src/forms/useProjectForm.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import useProjectForm from './useProjectForm';
 import { IProjectForm } from '@/interfaces/formInterfaces';
@@ -191,5 +191,150 @@ describe('useProjectForm', () => {
     expect(result.current.formMethods).toBeDefined();
     expect(result.current.classOptions).toBeDefined();
     expect(result.current.useWatchField).toBeDefined();
+  });
+
+  // IO-411: district-side auto-fill. Drive the form via
+  // result.current.formMethods.setValue() and read personProgramming back
+  // out — the exact same code path the UI uses when the user picks a
+  // district from the dropdown.
+  describe('district-based programmer auto-fill (IO-411)', () => {
+    const renderFormWithDistrict = ({
+      districts,
+    }: {
+      districts: Array<{
+        id: string;
+        value: string;
+        computedDefaultProgrammer?: {
+          id: string;
+          firstName: string;
+          lastName: string;
+        } | null;
+      }>;
+    }) => {
+      const mockSelectors: Record<SelectorName, any> = {
+        selectProjectMode: 'new',
+        selectProjectUpdate: { project: { id: null } },
+        selectIsLoading: false,
+        selectIsProjectCardLoading: false,
+        selectAllPlanningClasses: [],
+        selectPlanningClasses: [],
+        selectPlanningSubClasses: [],
+        selectProjectDistricts: districts,
+        selectProjectDivisions: [],
+        selectProjectSubDivisions: [],
+      };
+
+      mockUseAppSelector.mockImplementation(
+        (selector: { name: SelectorName }) => mockSelectors[selector.name] ?? [],
+      );
+
+      const { result } = renderHook(() => useProjectForm(null), {
+        wrapper: Wrapper,
+      });
+
+      return { result };
+    };
+
+    it('pre-fills personProgramming from district.computedDefaultProgrammer', async () => {
+      const { result } = renderFormWithDistrict({
+        districts: [
+          {
+            id: 'district-itainen',
+            value: 'Itäinen suurpiiri',
+            computedDefaultProgrammer: {
+              id: 'prog-tia',
+              firstName: 'Tia',
+              lastName: 'Ohjelmoija',
+            },
+          },
+        ],
+      });
+
+      await act(async () => {
+        result.current.formMethods.setValue('district', {
+          value: 'district-itainen',
+          label: 'Itäinen suurpiiri',
+        });
+      });
+
+      await waitFor(() => {
+        const current = result.current.formMethods.getValues().personProgramming;
+        expect(current).toEqual({ value: 'prog-tia', label: 'Tia Ohjelmoija' });
+      });
+    });
+
+    it('does not overwrite personProgramming when the district has no computed programmer', async () => {
+      const { result } = renderFormWithDistrict({
+        districts: [
+          {
+            id: 'district-without',
+            value: 'Tuntematon suurpiiri',
+          },
+        ],
+      });
+
+      // Baseline before the change: for a new project personProgramming is
+      // the empty option { value: '', label: '' } — see personToOption in
+      // useProjectFormValues.
+      const baseline = result.current.formMethods.getValues().personProgramming;
+      expect(baseline).toEqual({ value: '', label: '' });
+
+      await act(async () => {
+        result.current.formMethods.setValue('district', {
+          value: 'district-without',
+          label: 'Tuntematon suurpiiri',
+        });
+      });
+
+      // Give the watch subscription a tick to run, then verify the field is
+      // unchanged — no phantom value from a stale lookup.
+      await new Promise((r) => setTimeout(r, 0));
+
+      const current = result.current.formMethods.getValues().personProgramming;
+      expect(current).toEqual({ value: '', label: '' });
+    });
+
+    it('does not clobber a manually-picked programmer when the user later changes district', async () => {
+      // Regression for the IO-411 acceptance criterion:
+      // "A user-picked programmer is never silently overwritten by the
+      //  auto-fill." Even though the new district resolves to a different
+      //  programmer, the user's choice must win.
+      const { result } = renderFormWithDistrict({
+        districts: [
+          {
+            id: 'district-itainen',
+            value: 'Itäinen suurpiiri',
+            computedDefaultProgrammer: {
+              id: 'prog-tia',
+              firstName: 'Tia',
+              lastName: 'Ohjelmoija',
+            },
+          },
+        ],
+      });
+
+      // User manually picks a programmer first.
+      await act(async () => {
+        result.current.formMethods.setValue('personProgramming', {
+          value: 'manual-pick',
+          label: 'Manual Pick',
+        });
+      });
+
+      // …then picks a district whose backend computedDefaultProgrammer is
+      // someone else.
+      await act(async () => {
+        result.current.formMethods.setValue('district', {
+          value: 'district-itainen',
+          label: 'Itäinen suurpiiri',
+        });
+      });
+
+      // Give the watch subscription a tick to run.
+      await new Promise((r) => setTimeout(r, 0));
+
+      const current = result.current.formMethods.getValues().personProgramming;
+      expect(current).toEqual({ value: 'manual-pick', label: 'Manual Pick' });
+    });
   });
 });

--- a/src/forms/useProjectForm.ts
+++ b/src/forms/useProjectForm.ts
@@ -236,26 +236,40 @@ const useProjectForm = (project: IProject | null) => {
 
   const locationOptions = useLocationOptions(selections?.selectedLocation);
 
-  // Get class-based programmer logic
-  const { getProgrammerForClass } = useProjectProgrammer();
+  const { getProgrammerForClass, getProgrammerForDistrict } = useProjectProgrammer();
 
-  // Set the default programmer based on class hierarchy
+  /**
+   * Pre-fill personProgramming from the current class / district pick when
+   * the field is empty. Resolution order mirrors ProjectCreateSerializer:
+   * class chain first, then district chain (IO-411). Skipping when the
+   * field already has a value preserves a user's manual pick.
+   */
   const setDefaultProgrammerForClassHierarchy = useCallback(
     (masterClassId?: string, classId?: string, subClassId?: string) => {
-      // Use the most specific class ID (backend handles hierarchy via computedDefaultProgrammer)
+      const currentForm = getValues();
+
+      if (currentForm.personProgramming?.value) {
+        return;
+      }
+
       const mostSpecificClassId = subClassId || classId || masterClassId;
-      const defaultProgrammer = getProgrammerForClass(mostSpecificClassId);
+      const mostSpecificDistrictId =
+        currentForm.subDivision?.value ||
+        currentForm.division?.value ||
+        currentForm.district?.value;
+
+      const defaultProgrammer =
+        getProgrammerForClass(mostSpecificClassId) ||
+        getProgrammerForDistrict(mostSpecificDistrictId);
 
       if (defaultProgrammer) {
-        // Convert the programmer to an option format
-        const programmerOption = {
+        setValue('personProgramming', {
           value: defaultProgrammer.id,
           label: defaultProgrammer.value,
-        };
-        setValue('personProgramming', programmerOption);
+        });
       }
     },
-    [getProgrammerForClass, setValue],
+    [getProgrammerForClass, getProgrammerForDistrict, getValues, setValue],
   );
 
   // Set the selected class and empty the other selected classes if a parent class is selected

--- a/src/interfaces/locationInterfaces.ts
+++ b/src/interfaces/locationInterfaces.ts
@@ -1,4 +1,5 @@
-import { IClass } from './classInterfaces';
+import { IClass, IProgrammer } from './classInterfaces';
+import { IListItem } from './common';
 
 export interface ILocation extends IClass {
   parentClass: string | null;
@@ -9,5 +10,14 @@ export interface IProjectDistrict {
   name: string,
   parent?: string,
   level: string,
-  path: string
+  path: string,
+  // IO-411: backend-resolved default programmer from walking the district
+  // parent chain; lets the form pre-fill Ohjelmoija before save.
+  computedDefaultProgrammer?: IProgrammer | null,
+}
+
+// IO-411: widen district list items with the computed programmer instead of
+// widening IListItem globally — the extra field only makes sense here.
+export interface IProjectDistrictOption extends IListItem {
+  computedDefaultProgrammer?: IProgrammer | null;
 }

--- a/src/reducers/listsSlice.ts
+++ b/src/reducers/listsSlice.ts
@@ -1,6 +1,6 @@
 import { IListItem } from '@/interfaces/common';
 import { IClass } from '@/interfaces/classInterfaces';
-import { IProjectDistrict } from '@/interfaces/locationInterfaces';
+import { IProjectDistrict, IProjectDistrictOption } from '@/interfaces/locationInterfaces';
 import {
   getConstructionPhases,
   getPlanningPhases,
@@ -64,9 +64,9 @@ export interface IListState {
   responsiblePersons: Array<IListItem>;
   responsiblePersonsRaw: Array<IPerson>;
   programmedYears: Array<IListItem>;
-  projectDistricts: Array<IListItem>;
-  projectDivisions: Array<IListItem>;
-  projectSubDivisions: Array<IListItem>;
+  projectDistricts: Array<IProjectDistrictOption>;
+  projectDivisions: Array<IProjectDistrictOption>;
+  projectSubDivisions: Array<IProjectDistrictOption>;
   budgetOverrunReasons: Array<IListItem>;
   projectClasses: Array<IClass>;
   programmers: Array<IListItem>;
@@ -109,8 +109,9 @@ const initialState: IListState = {
   error: null,
 };
 
-// Sorting the list of responsible persons by value which has the person name with lastname first
-export const sortOptions = (persons: Array<IListItem>) =>
+// Sorting the list of responsible persons by value which has the person name with lastname first.
+// Generic so widened options (e.g. IProjectDistrictOption) keep their extra fields.
+export const sortOptions = <T extends IListItem>(persons: Array<T>): Array<T> =>
   [...persons].sort((a, b) => (a.value < b.value ? -1 : a.value > b.value ? 1 : 0));
 
 const getResponsiblePersons = async () => {
@@ -123,13 +124,21 @@ const getResponsiblePersons = async () => {
   }
 };
 
-export const getProjectDistricts = (districts: IProjectDistrict[], districtLevel: string) => {
+export const getProjectDistricts = (
+  districts: IProjectDistrict[],
+  districtLevel: string,
+): IProjectDistrictOption[] => {
   const filtered = districts.filter(({ level }) => level == districtLevel);
-  const mapped = filtered.map(({ id, name, parent }) => ({
-    value: name,
-    id,
-    ...(parent && { parent: parent }),
-  }));
+  // IO-411: keep computedDefaultProgrammer on the option so the project form
+  // can pre-fill Ohjelmoija directly from the district chain.
+  const mapped: IProjectDistrictOption[] = filtered.map(
+    ({ id, name, parent, computedDefaultProgrammer }) => ({
+      value: name,
+      id,
+      ...(parent && { parent }),
+      ...(computedDefaultProgrammer && { computedDefaultProgrammer }),
+    }),
+  );
   return sortOptions(mapped);
 };
 

--- a/src/utils/projectProgrammerUtils.test.ts
+++ b/src/utils/projectProgrammerUtils.test.ts
@@ -1,5 +1,10 @@
-import { getBestProgrammerForClass, programmerToListItem } from './projectProgrammerUtils';
+import {
+  getBestProgrammerForClass,
+  getBestProgrammerForDistrict,
+  programmerToListItem,
+} from './projectProgrammerUtils';
 import { IClass, IProgrammer } from '@/interfaces/classInterfaces';
+import { IProjectDistrictOption } from '@/interfaces/locationInterfaces';
 
 describe('projectProgrammerUtils', () => {
   describe('getBestProgrammerForClass', () => {
@@ -78,6 +83,40 @@ describe('projectProgrammerUtils', () => {
       const result = getBestProgrammerForClass(null);
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getBestProgrammerForDistrict (IO-411)', () => {
+    it('returns computedDefaultProgrammer when the district has one', () => {
+      const option: IProjectDistrictOption = {
+        id: 'district-1',
+        value: 'Itäinen suurpiiri',
+        computedDefaultProgrammer: {
+          id: 'prog-itainen',
+          firstName: 'Tia',
+          lastName: 'Ohjelmoija',
+        },
+      };
+
+      expect(getBestProgrammerForDistrict(option)).toEqual({
+        id: 'prog-itainen',
+        firstName: 'Tia',
+        lastName: 'Ohjelmoija',
+      });
+    });
+
+    it('returns null for districts without a computed programmer', () => {
+      const option: IProjectDistrictOption = {
+        id: 'district-2',
+        value: 'Some district',
+      };
+
+      expect(getBestProgrammerForDistrict(option)).toBeNull();
+    });
+
+    it('returns null when the district is null or undefined', () => {
+      expect(getBestProgrammerForDistrict(null)).toBeNull();
+      expect(getBestProgrammerForDistrict(undefined)).toBeNull();
     });
   });
 

--- a/src/utils/projectProgrammerUtils.ts
+++ b/src/utils/projectProgrammerUtils.ts
@@ -1,8 +1,14 @@
 import { useCallback } from 'react';
 import { IListItem } from '@/interfaces/common';
 import { IClass, IProgrammer } from '@/interfaces/classInterfaces';
+import { IProjectDistrictOption } from '@/interfaces/locationInterfaces';
 import { useAppSelector } from '@/hooks/common';
 import { selectAllPlanningClasses } from '@/reducers/classSlice';
+import {
+  selectProjectDistricts,
+  selectProjectDivisions,
+  selectProjectSubDivisions,
+} from '@/reducers/listsSlice';
 
 // Reads backend-computed programmer with hierarchical fallback
 export function getBestProgrammerForClass(projectClass: IClass | null): IProgrammer | null {
@@ -11,6 +17,18 @@ export function getBestProgrammerForClass(projectClass: IClass | null): IProgram
   }
 
   return projectClass.computedDefaultProgrammer || projectClass.defaultProgrammer || null;
+}
+
+// IO-411: district-side twin of getBestProgrammerForClass. Returns null when
+// the district chain doesn't resolve to any programmer-view class.
+export function getBestProgrammerForDistrict(
+  district: IProjectDistrictOption | null | undefined,
+): IProgrammer | null {
+  if (!district) {
+    return null;
+  }
+
+  return district.computedDefaultProgrammer ?? null;
 }
 
 // Formats programmer name for form display
@@ -38,6 +56,11 @@ export function getProjectProgrammer(projectClass: IClass | null): IListItem | n
 // Hook for form usage - pass most specific class ID
 export function useProjectProgrammer() {
   const projectClasses = useAppSelector(selectAllPlanningClasses);
+  // IO-411: read all three district levels so the form can resolve a
+  // programmer regardless of which level the user picked.
+  const projectDistricts = useAppSelector(selectProjectDistricts);
+  const projectDivisions = useAppSelector(selectProjectDivisions);
+  const projectSubDivisions = useAppSelector(selectProjectSubDivisions);
 
   const getProgrammerForClass = useCallback(
     (classId?: string): IListItem | null => {
@@ -57,5 +80,28 @@ export function useProjectProgrammer() {
     [projectClasses],
   );
 
-  return { getProgrammerForClass };
+  // Resolve the programmer for any district id, checking the most specific
+  // level first (subDivision → division → district). Mirrors the backend's
+  // parent-walk so picking a suurpiiri or a sub-level yields the same answer.
+  const getProgrammerForDistrict = useCallback(
+    (districtId?: string | null): IListItem | null => {
+      if (!districtId) {
+        return null;
+      }
+
+      const option =
+        projectSubDivisions?.find((d) => d.id === districtId) ||
+        projectDivisions?.find((d) => d.id === districtId) ||
+        projectDistricts?.find((d) => d.id === districtId);
+
+      if (!option) {
+        return null;
+      }
+
+      return programmerToListItem(getBestProgrammerForDistrict(option));
+    },
+    [projectDistricts, projectDivisions, projectSubDivisions],
+  );
+
+  return { getProgrammerForClass, getProgrammerForDistrict };
 }


### PR DESCRIPTION
* Extend useProjectProgrammer with getProgrammerForDistrict, which resolves the most-specific picked level (subDivision -> division -> district) against the backend-computed default programmer attached to each district option
* setDefaultProgrammerForClassHierarchy now falls back to the district chain when no class-side programmer is found and only fires when personProgramming is empty, so a manually picked programmer is never silently overwritten
* Carry computedDefaultProgrammer through listsSlice into a new IProjectDistrictOption