### PR TITLE
IO-865 Show localized toast when PW-hanketunnus is not found in PW

### DIFF
--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectForm.tsx
@@ -33,6 +33,7 @@ import { AxiosError } from 'axios';
 import { selectPlanningGroups } from '@/reducers/groupSlice';
 import { moveBudgetBackwards, moveBudgetForwards } from './financesUtils';
 import { usePatchProjectMutation, usePostProjectMutation } from '@/api/projectApi';
+import { getProjectPatchErrorMessage } from '@/utils/projectErrorMessage';
 
 interface IProjectFormProps {
   project: IProject | null;
@@ -277,7 +278,7 @@ const ProjectForm = ({ project }: IProjectFormProps) => {
             }
             dispatch(
               notifyError({
-                message: 'formSaveError',
+                message: getProjectPatchErrorMessage(error),
                 title: 'saveError',
                 type: 'notification',
               }),

--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -13,6 +13,7 @@ import { selectPlanningGroups } from '@/reducers/groupSlice';
 import { notifyError } from '@/reducers/notificationSlice';
 import optionIcon from '@/utils/optionIcon';
 import { usePatchProjectMutation } from '@/api/projectApi';
+import { getProjectPatchErrorMessage } from '@/utils/projectErrorMessage';
 
 export interface IProjectHeaderFieldProps {
   control: HookFormControlType;
@@ -70,7 +71,7 @@ const ProjectHeader: FC<IProjectHeaderProps> = ({ project }) => {
             dispatch(setIsSaving(false));
             dispatch(
               notifyError({
-                message: 'formSaveError',
+                message: getProjectPatchErrorMessage(error),
                 title: 'saveError',
                 type: 'notification',
               }),

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -463,6 +463,7 @@
       "projectUpdated": "Hankkeen tietoja päivitettiin",
       "formSaveSuccess": "Lomake tallennettu onnistuneesti.",
       "formSaveError": "Lomakkeen tallennus ei onnistunut.",
+      "pwProjectNotFound": "Hankekortille merkittyä PW-hanketunnusta ei löydy – poista tai muokkaa PW-hanketunnus.",
       "projectCreatingError": "Uuden hankkeen luominen epäonnistui.",
       "formFillError": "Pakollisia kenttiä puuttuu.",
       "noteAddedToClass": "Muistiinpano lisätty luokkaan {{parameter}}",

--- a/src/utils/projectErrorMessage.test.ts
+++ b/src/utils/projectErrorMessage.test.ts
@@ -1,0 +1,46 @@
+import {
+  PW_PROJECT_NOT_FOUND_CODE,
+  getProjectPatchErrorMessage,
+} from './projectErrorMessage';
+
+describe('getProjectPatchErrorMessage', () => {
+  it('returns "pwProjectNotFound" when backend signals PW project not found', () => {
+    const error = {
+      status: 400,
+      data: { hkrId: [PW_PROJECT_NOT_FOUND_CODE] },
+    };
+    expect(getProjectPatchErrorMessage(error)).toBe('pwProjectNotFound');
+  });
+
+  it('returns "formSaveError" for the legacy generic sync failure body', () => {
+    const error = {
+      status: 400,
+      data: {
+        hkrId:
+          'Project updated successfully but failed to sync to ProjectWise: timeout. Please use \'Update to PW\' button to retry.',
+      },
+    };
+    expect(getProjectPatchErrorMessage(error)).toBe('formSaveError');
+  });
+
+  it('returns "formSaveError" for unrelated 400 validation errors', () => {
+    const error = {
+      status: 400,
+      data: { phase: ['planningStartYear and constructionEndYear must be populated'] },
+    };
+    expect(getProjectPatchErrorMessage(error)).toBe('formSaveError');
+  });
+
+  it('returns "formSaveError" for non-axios errors and missing data', () => {
+    expect(getProjectPatchErrorMessage(undefined)).toBe('formSaveError');
+    expect(getProjectPatchErrorMessage(null)).toBe('formSaveError');
+    expect(getProjectPatchErrorMessage('boom')).toBe('formSaveError');
+    expect(getProjectPatchErrorMessage(new Error('boom'))).toBe('formSaveError');
+    expect(getProjectPatchErrorMessage({ status: 500 })).toBe('formSaveError');
+  });
+
+  it('does not match when hkrId is a bare string (API always sends a list)', () => {
+    const error = { data: { hkrId: PW_PROJECT_NOT_FOUND_CODE } };
+    expect(getProjectPatchErrorMessage(error)).toBe('formSaveError');
+  });
+});

--- a/src/utils/projectErrorMessage.test.ts
+++ b/src/utils/projectErrorMessage.test.ts
@@ -43,4 +43,12 @@ describe('getProjectPatchErrorMessage', () => {
     const error = { data: { hkrId: PW_PROJECT_NOT_FOUND_CODE } };
     expect(getProjectPatchErrorMessage(error)).toBe('formSaveError');
   });
+
+  it('matches when the PW code is present but not first in the array', () => {
+    const error = {
+      status: 400,
+      data: { hkrId: ['SOME_OTHER_CODE', PW_PROJECT_NOT_FOUND_CODE] },
+    };
+    expect(getProjectPatchErrorMessage(error)).toBe('pwProjectNotFound');
+  });
 });

--- a/src/utils/projectErrorMessage.ts
+++ b/src/utils/projectErrorMessage.ts
@@ -1,0 +1,24 @@
+// IO-865: pick the toast for a patchProject failure. The API marks the
+// "PW-hanketunnusta ei löydy" case with a 400 body of
+// `{ hkrId: ["PW_PROJECT_NOT_FOUND"] }`; everything else falls through to
+// the generic formSaveError. RTK baseQuery wraps the axios error so the
+// response body lives at `error.data`, not `error.response.data`.
+
+export const PW_PROJECT_NOT_FOUND_CODE = 'PW_PROJECT_NOT_FOUND';
+
+export type ProjectPatchErrorMessageKey = 'pwProjectNotFound' | 'formSaveError';
+
+export const getProjectPatchErrorMessage = (
+  error: unknown,
+): ProjectPatchErrorMessageKey => {
+  if (error && typeof error === 'object') {
+    const data = (error as { data?: unknown }).data;
+    if (data && typeof data === 'object') {
+      const hkrId = (data as { hkrId?: unknown }).hkrId;
+      if (Array.isArray(hkrId) && hkrId[0] === PW_PROJECT_NOT_FOUND_CODE) {
+        return 'pwProjectNotFound';
+      }
+    }
+  }
+  return 'formSaveError';
+};

--- a/src/utils/projectErrorMessage.ts
+++ b/src/utils/projectErrorMessage.ts
@@ -3,6 +3,11 @@
 // `{ hkrId: ["PW_PROJECT_NOT_FOUND"] }`; everything else falls through to
 // the generic formSaveError. RTK baseQuery wraps the axios error so the
 // response body lives at `error.data`, not `error.response.data`.
+//
+// We scan the hkrId array with .includes() rather than checking the first
+// element, so that a future validator stacking another code onto the same
+// field (e.g. ["SOME_OTHER", "PW_PROJECT_NOT_FOUND"]) does not silently
+// fall through to the generic toast.
 
 export const PW_PROJECT_NOT_FOUND_CODE = 'PW_PROJECT_NOT_FOUND';
 
@@ -15,7 +20,7 @@ export const getProjectPatchErrorMessage = (
     const data = (error as { data?: unknown }).data;
     if (data && typeof data === 'object') {
       const hkrId = (data as { hkrId?: unknown }).hkrId;
-      if (Array.isArray(hkrId) && hkrId[0] === PW_PROJECT_NOT_FOUND_CODE) {
+      if (Array.isArray(hkrId) && hkrId.includes(PW_PROJECT_NOT_FOUND_CODE)) {
         return 'pwProjectNotFound';
       }
     }


### PR DESCRIPTION
* Add getProjectPatchErrorMessage helper that maps {"hkrId": ["PW_PROJECT_NOT_FOUND"]} to "pwProjectNotFound" toast, falls back to "formSaveError" for all other failures
* Add helper into ProjectForm and ProjectHeader (both use patchProject and both were showing the generic toast)
* Add "pwProjectNotFound" i18n key to fi.json