### PR TITLE
feat: IO-858 Implement getting, creating and updating Construction handover draft

### DIFF
--- a/src/api/constructionHandoverApi.ts
+++ b/src/api/constructionHandoverApi.ts
@@ -1,0 +1,64 @@
+import { infraohjelmointiApi } from './infraohjelmointiApi';
+import {
+  IConstructionHandover,
+  IConstructionHandoverPatchRequest,
+} from '@/interfaces/constructionHandoverInterfaces';
+import { notifySuccess } from '@/reducers/notificationSlice';
+
+export const constructionHandoverApi = infraohjelmointiApi.injectEndpoints({
+  endpoints: (build) => ({
+    getConstructionHandoversByProject: build.query<IConstructionHandover[], string>({
+      query: (projectId: string) => ({
+        url: `/projects/${projectId}/construction-handovers/`,
+      }),
+      providesTags: ['ConstructionHandovers'],
+    }),
+    postConstructionHandover: build.mutation<IConstructionHandover, { project: string | null }>({
+      query: (handover: { project: string | null }) => ({
+        url: '/construction-handovers/',
+        method: 'POST',
+        data: handover,
+      }),
+      invalidatesTags: ['ConstructionHandovers'],
+    }),
+    patchConstructionHandover: build.mutation<
+      IConstructionHandover,
+      IConstructionHandoverPatchRequest
+    >({
+      query: (request: IConstructionHandoverPatchRequest) => ({
+        url: `/construction-handovers/${request.id}/`,
+        method: 'PATCH',
+        data: request.data,
+      }),
+      async onQueryStarted(_, { dispatch, queryFulfilled }) {
+        try {
+          await queryFulfilled;
+          dispatch(
+            notifySuccess({
+              title: 'patchSuccess',
+              message: 'constructionHandoverPatchSuccess',
+              type: 'toast',
+            }),
+          );
+        } catch (error) {
+          console.error('Error patching construction handover: ', error);
+        }
+      },
+      invalidatesTags: ['ConstructionHandovers'],
+    }),
+    deleteConstructionHandover: build.mutation<{ success: boolean }, string>({
+      query: (id: string) => ({
+        url: `/construction-handovers/${id}/`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['ConstructionHandovers'],
+    }),
+  }),
+});
+
+export const {
+  useGetConstructionHandoversByProjectQuery,
+  usePostConstructionHandoverMutation,
+  usePatchConstructionHandoverMutation,
+  useDeleteConstructionHandoverMutation,
+} = constructionHandoverApi;

--- a/src/api/infraohjelmointiApi.ts
+++ b/src/api/infraohjelmointiApi.ts
@@ -41,7 +41,7 @@ const axiosBaseQuery =
 export const infraohjelmointiApi = createApi({
   reducerPath: 'infraohjelmointiApi',
   baseQuery: axiosBaseQuery({ baseUrl: process.env.REACT_APP_API_URL || '' }),
-  tagTypes: ['Notes', 'User', 'Projects'],
+  tagTypes: ['Notes', 'User', 'Projects', 'ConstructionHandovers'],
   // Endpoints are injected in other files in order to keep them modular
   endpoints: () => ({}),
 });

--- a/src/components/Project/ConstructionHandover/ConstructionHandoverContainer.tsx
+++ b/src/components/Project/ConstructionHandover/ConstructionHandoverContainer.tsx
@@ -3,11 +3,25 @@ import StartConstructionHandover from './StartConstructionHandover';
 import ConstructionHandoverForm from './ConstructionHandoverForm';
 import { ProjectFormSidePanel } from '../ProjectBasics/ProjectFormSidePanel';
 import useGetProject from '@/hooks/useGetProject';
+import {
+  useGetConstructionHandoversByProjectQuery,
+  usePostConstructionHandoverMutation,
+} from '@/api/constructionHandoverApi';
+import { skipToken } from '@reduxjs/toolkit/query';
+import ConstructionHandoverStatusLabel from './ConstructionHandoverStatusLabel';
 
 export default function ConstructionHandoverContainer() {
   const { t } = useTranslation();
   const { data: project } = useGetProject();
-  const isConstructionHandoverStarted = true; // NOTE: Placeholder, will be implemented later based on if construction handover data is available for the project
+  const { data: constructionHandovers, isLoading } = useGetConstructionHandoversByProjectQuery(
+    project?.id ?? skipToken,
+  );
+  // NOTE: Currently there can only be one construction handover per project, so we take the first one if it exists.
+  // If in the future there can be multiple handovers, this will need to be changed.
+  const constructionHandover =
+    constructionHandovers && constructionHandovers.length > 0 ? constructionHandovers[0] : null;
+  const [postConstructionHandover] = usePostConstructionHandoverMutation();
+  const isConstructionHandoverStarted = constructionHandover !== null;
 
   const navItems = [
     { route: '#nameAndDescription', label: t('nav.nameAndDescription') },
@@ -16,8 +30,16 @@ export default function ConstructionHandoverContainer() {
   ];
 
   const handleStartHandover = () => {
-    // NOTE: Will be implemented later
+    if (project?.id) {
+      postConstructionHandover({
+        project: project.id,
+      });
+    }
   };
+
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <div className="flex" data-testid="construction-handover-container">
@@ -27,11 +49,19 @@ export default function ConstructionHandoverContainer() {
           project={null}
           showSaveIndicator={false}
           showPwFolderLink={false}
+          formStatusSection={
+            constructionHandover ? (
+              <ConstructionHandoverStatusLabel status={constructionHandover.status} />
+            ) : null
+          }
         />
       </div>
       <div className="project-form max-w-xl pr-4" data-testid="construction-handover-form">
         {isConstructionHandoverStarted ? (
-          <ConstructionHandoverForm project={project ?? null} />
+          <ConstructionHandoverForm
+            constructionHandover={constructionHandover}
+            project={project ?? null}
+          />
         ) : (
           <StartConstructionHandover onStartHandover={handleStartHandover} />
         )}

--- a/src/components/Project/ConstructionHandover/ConstructionHandoverForm.test.tsx
+++ b/src/components/Project/ConstructionHandover/ConstructionHandoverForm.test.tsx
@@ -5,6 +5,13 @@ import { Route } from 'react-router';
 import { act } from 'react-dom/test-utils';
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import ConstructionHandoverForm from './ConstructionHandoverForm';
+import { createConstructionHandover, createProject } from '@/mocks/createMocks';
+
+const mockPatchConstructionHandover = jest.fn();
+
+jest.mock('@/api/constructionHandoverApi', () => ({
+  usePatchConstructionHandoverMutation: () => [mockPatchConstructionHandover],
+}));
 
 jest.mock('react-i18next', () => mockI18next());
 
@@ -32,9 +39,16 @@ jest.mock('hds-react', () => {
 
 describe('ConstructionHandoverForm copy link', () => {
   it('copies to clipboard and dispatches success notification when copy button is clicked', async () => {
+    const constructionHandover = createConstructionHandover();
+
     const { store } = await act(async () =>
       renderWithProviders(
-        <Route path="/" element={<ConstructionHandoverForm project={null} />} />,
+        <Route
+          path="/"
+          element={
+            <ConstructionHandoverForm project={null} constructionHandover={constructionHandover} />
+          }
+        />,
       ),
     );
 
@@ -65,9 +79,16 @@ describe('ConstructionHandoverForm copy link', () => {
   });
 
   it('dispatches error notification when clipboard write fails', async () => {
+    const constructionHandover = createConstructionHandover();
+
     const { store } = await act(async () =>
       renderWithProviders(
-        <Route path="/" element={<ConstructionHandoverForm project={null} />} />,
+        <Route
+          path="/"
+          element={
+            <ConstructionHandoverForm project={null} constructionHandover={constructionHandover} />
+          }
+        />,
       ),
     );
 
@@ -96,5 +117,90 @@ describe('ConstructionHandoverForm copy link', () => {
     });
 
     writeTextSpy.mockRestore();
+  });
+});
+
+describe('ConstructionHandoverForm submit', () => {
+  beforeEach(() => {
+    mockPatchConstructionHandover.mockClear();
+  });
+
+  it('submits form and calls patch mutation with mapped payload', async () => {
+    const constructionHandover = createConstructionHandover({
+      constructionStart: '2026-01-01',
+      constructionEnd: '2026-02-01',
+    });
+    const project = createProject({ id: 'project-123' });
+
+    await act(async () =>
+      renderWithProviders(
+        <Route
+          path="/"
+          element={
+            <ConstructionHandoverForm
+              project={project}
+              constructionHandover={constructionHandover}
+            />
+          }
+        />,
+      ),
+    );
+
+    const submitButton = screen.getByRole('button', {
+      name: 'constructionHandoverForm.saveDraft',
+    });
+
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(mockPatchConstructionHandover).toHaveBeenCalledWith({
+        id: 'handover-1',
+        data: {
+          name: 'Test Handover',
+          description: 'This is a test construction handover.',
+          constructionProcurementMethod: '',
+          constructionStart: '01.01.2026',
+          constructionEnd: '01.02.2026',
+          otherTimelineNotes: '',
+          personPlanning: '',
+          personFinancing: '',
+          project: 'project-123',
+          totalCost: null,
+          linkDesignDrawings: null,
+          linkCostAllocation: null,
+          linkContractBoundaries: null,
+          constructionProjectManager: null,
+        },
+      });
+    });
+  });
+
+  it('does not submit when project is missing', async () => {
+    const constructionHandover = createConstructionHandover();
+
+    await act(async () =>
+      renderWithProviders(
+        <Route
+          path="/"
+          element={
+            <ConstructionHandoverForm project={null} constructionHandover={constructionHandover} />
+          }
+        />,
+      ),
+    );
+
+    const submitButton = screen.getByRole('button', {
+      name: 'constructionHandoverForm.saveDraft',
+    });
+
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(mockPatchConstructionHandover).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/Project/ConstructionHandover/ConstructionHandoverForm.tsx
+++ b/src/components/Project/ConstructionHandover/ConstructionHandoverForm.tsx
@@ -2,7 +2,6 @@ import { memo } from 'react';
 import { FieldPath, FormProvider } from 'react-hook-form';
 import NameAndDescriptionSection from './NameAndDescriptionSection';
 import useConstructionHandoverForm from '@/forms/useConstructionHandoverForm';
-import { IProject } from '@/interfaces/projectInterfaces';
 import { IConstructionHandoverForm } from '@/interfaces/formInterfaces';
 import ScheduleSection from './ScheduleSection';
 import ContactsSection from './ContactsSection';
@@ -10,6 +9,12 @@ import { useTranslation } from 'react-i18next';
 import { Button, ButtonVariant, IconLink } from 'hds-react';
 import { useAppDispatch } from '@/hooks/common';
 import { notifyError, notifySuccess } from '@/reducers/notificationSlice';
+import { usePatchConstructionHandoverMutation } from '@/api/constructionHandoverApi';
+import {
+  IConstructionHandover,
+  IConstructionHandoverRequest,
+} from '@/interfaces/constructionHandoverInterfaces';
+import { IProject } from '@/interfaces/projectInterfaces';
 
 export function getFieldProps(name: FieldPath<IConstructionHandoverForm>) {
   return {
@@ -18,14 +23,42 @@ export function getFieldProps(name: FieldPath<IConstructionHandoverForm>) {
   };
 }
 
+function mapFormToRequest(
+  formData: IConstructionHandoverForm,
+  projectId: string,
+): IConstructionHandoverRequest {
+  return {
+    name: formData.name,
+    description: formData.description,
+    constructionProcurementMethod: formData.constructionProcurementMethod.value,
+    constructionStart: formData.constructionStart,
+    constructionEnd: formData.constructionEnd,
+    otherTimelineNotes: formData.otherTimelineNotes,
+    personPlanning: formData.personPlanning.value,
+    personFinancing: formData.personFinancing.value,
+    project: projectId,
+    totalCost: null,
+    linkDesignDrawings: null,
+    linkCostAllocation: null,
+    linkContractBoundaries: null,
+    constructionProjectManager: null,
+  };
+}
+
 interface IConstructionHandoverFormProps {
+  constructionHandover: IConstructionHandover;
   project: IProject | null;
 }
 
-function ConstructionHandoverForm({ project }: Readonly<IConstructionHandoverFormProps>) {
+function ConstructionHandoverForm({
+  constructionHandover,
+  project,
+}: Readonly<IConstructionHandoverFormProps>) {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const formMethods = useConstructionHandoverForm(project);
+  const formMethods = useConstructionHandoverForm(constructionHandover);
+  const { handleSubmit } = formMethods;
+  const [patchConstructionHandover] = usePatchConstructionHandoverMutation();
 
   function onCopyLinkClick() {
     navigator.clipboard
@@ -52,23 +85,35 @@ function ConstructionHandoverForm({ project }: Readonly<IConstructionHandoverFor
       });
   }
 
+  async function submitForm(data: IConstructionHandoverForm) {
+    if (data.id && project?.id) {
+      const requestData = mapFormToRequest(data, project.id);
+      patchConstructionHandover({ id: data.id, data: requestData });
+    }
+  }
+
   return (
     <FormProvider {...formMethods}>
-      <form>
+      <form onSubmit={handleSubmit(submitForm)}>
         <NameAndDescriptionSection />
         <ScheduleSection />
         <ContactsSection />
 
         <div className="project-form-banner">
           <div className="project-form-banner-container">
-            <Button
-              variant={ButtonVariant.Secondary}
-              iconStart={<IconLink />}
-              type="button"
-              onClick={onCopyLinkClick}
-            >
-              {t('copyLink')}
-            </Button>
+            <div className="flex gap-6">
+              <Button variant={ButtonVariant.Secondary} type="submit">
+                {t('constructionHandoverForm.saveDraft')}
+              </Button>
+              <Button
+                variant={ButtonVariant.Secondary}
+                iconStart={<IconLink />}
+                type="button"
+                onClick={onCopyLinkClick}
+              >
+                {t('copyLink')}
+              </Button>
+            </div>
           </div>
         </div>
       </form>

--- a/src/components/Project/ConstructionHandover/ConstructionHandoverStatusLabel.tsx
+++ b/src/components/Project/ConstructionHandover/ConstructionHandoverStatusLabel.tsx
@@ -1,0 +1,54 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ConstructionHandoverStatus } from '@/interfaces/constructionHandoverInterfaces';
+import { IconArrowTopRight, IconCheckCircle, IconHammers, IconPen, StatusLabel } from 'hds-react';
+
+interface IConstructionHandoverStatusLabelProps {
+  status: ConstructionHandoverStatus;
+}
+
+function ConstructionHandoverStatusLabel({
+  status,
+}: Readonly<IConstructionHandoverStatusLabelProps>) {
+  const { t } = useTranslation();
+
+  if (status === ConstructionHandoverStatus.DRAFT) {
+    return (
+      <StatusLabel iconStart={<IconPen />}>
+        {t('constructionHandoverForm.status.draft')}
+      </StatusLabel>
+    );
+  }
+  if (status === ConstructionHandoverStatus.SUBMITTED_TO_PROGRAMMER) {
+    return (
+      <StatusLabel type="info" iconStart={<IconArrowTopRight />}>
+        {t('constructionHandoverForm.status.submittedToProgrammer')}
+      </StatusLabel>
+    );
+  }
+  if (status === ConstructionHandoverStatus.SUBMITTED_TO_CONSTRUCTION) {
+    return (
+      <StatusLabel type="info" iconStart={<IconArrowTopRight />}>
+        {t('constructionHandoverForm.status.submittedToConstruction')}
+      </StatusLabel>
+    );
+  }
+  if (status === ConstructionHandoverStatus.PROJECT_MANAGER_NAMED) {
+    return (
+      <StatusLabel type="info" iconStart={<IconHammers />}>
+        {t('constructionHandoverForm.status.projectManagerNamed')}
+      </StatusLabel>
+    );
+  }
+  if (status === ConstructionHandoverStatus.MOVED_TO_CONSTRUCTION_PREPARATION) {
+    return (
+      <StatusLabel type="success" iconStart={<IconCheckCircle />}>
+        {t('constructionHandoverForm.status.movedToConstructionPreparation')}
+      </StatusLabel>
+    );
+  }
+
+  return null;
+}
+
+export default memo(ConstructionHandoverStatusLabel);

--- a/src/components/Project/ProjectBasics/ProjectFormSidePanel/styles.css
+++ b/src/components/Project/ProjectBasics/ProjectFormSidePanel/styles.css
@@ -23,5 +23,8 @@
 
 .project-form-side-panel .form-status-container {
   @apply py-5;
+}
+
+.project-form-side-panel .form-status-container:not(:last-child) {
   border-bottom: 1px solid var(--color-black-20);
 }

--- a/src/components/ProjectDetailsForm/style.css
+++ b/src/components/ProjectDetailsForm/style.css
@@ -12,10 +12,10 @@
   display: inline-block;
   padding: 11px 27px;
   color: var(--color-bus) !important;
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 .buttonHighlighted {
-  border: none;
+  border: none !important;
   border-bottom: 5px solid var(--color-bus) !important;
 }

--- a/src/forms/useConstructionHandoverForm.test.tsx
+++ b/src/forms/useConstructionHandoverForm.test.tsx
@@ -1,34 +1,44 @@
 import { renderHook } from '@testing-library/react';
 import useConstructionHandoverForm from './useConstructionHandoverForm';
-import { IProject } from '@/interfaces/projectInterfaces';
+import { IConstructionHandover } from '@/interfaces/constructionHandoverInterfaces';
 
 describe('useConstructionHandoverForm', () => {
-  it('sets default form values from project data', () => {
-    const project = {
+  it('sets default form values from construction handover data', () => {
+    const constructionHandover = {
+      id: 'handover-1',
       name: 'Testihanke',
       description: 'Peruskorjaus ja valaistuksen uusinta',
       constructionProcurementMethod: {
         id: '7eedb495-7d42-4511-b4bf-c54f3698d415',
         value: 'Yhteistoiminnalliset',
       },
-      estConstructionStart: '01.01.2026',
-      estConstructionEnd: '30.09.2028',
+      constructionStart: '2026-01-01',
+      constructionEnd: '2028-09-30',
+      otherTimelineNotes: '',
       personPlanning: {
         id: 'person-planning-1',
         firstName: 'Erkki',
         lastName: 'Esimerkki',
       },
-      personProgramming: {
+      personFinancing: {
         id: 'person-programming-1',
         firstName: 'Matti',
         lastName: 'Mallikas',
       },
-    } as IProject;
+      project: 'project-123',
+      status: 'DRAFT',
+      linkDesignDrawings: null,
+      linkCostAllocation: null,
+      linkContractBoundaries: null,
+      constructionProjectManager: null,
+      totalCost: null,
+    } as IConstructionHandover;
 
-    const { result } = renderHook(() => useConstructionHandoverForm(project));
+    const { result } = renderHook(() => useConstructionHandoverForm(constructionHandover));
     const values = result.current.getValues();
 
     expect(values).toEqual({
+      id: 'handover-1',
       name: 'Testihanke',
       description: 'Peruskorjaus ja valaistuksen uusinta',
       constructionProcurementMethod: {

--- a/src/forms/useConstructionHandoverForm.ts
+++ b/src/forms/useConstructionHandoverForm.ts
@@ -1,25 +1,29 @@
 import { useForm } from 'react-hook-form';
 import { IConstructionHandoverForm } from '@/interfaces/formInterfaces';
-import { IProject } from '@/interfaces/projectInterfaces';
 import { listItemToOption, personToOption } from '@/utils/common';
+import { IConstructionHandover } from '@/interfaces/constructionHandoverInterfaces';
+import { formatDateToHds } from '@/utils/dates';
 
-function useConstructionHandoverFormValues(project: IProject | null): IConstructionHandoverForm {
-  const defaultValues: IConstructionHandoverForm = {
-    name: project?.name || '',
-    description: project?.description || '',
-    constructionProcurementMethod: listItemToOption(project?.constructionProcurementMethod),
-    constructionStart: project?.estConstructionStart || null,
-    constructionEnd: project?.estConstructionEnd || null,
-    otherTimelineNotes: '',
-    personPlanning: personToOption(project?.personPlanning),
-    personFinancing: personToOption(project?.personProgramming),
+function useConstructionHandoverFormValues(
+  constructionHandover: IConstructionHandover,
+): IConstructionHandoverForm {
+  return {
+    id: constructionHandover.id,
+    name: constructionHandover.name || '',
+    description: constructionHandover.description || '',
+    constructionProcurementMethod: listItemToOption(
+      constructionHandover?.constructionProcurementMethod,
+    ),
+    constructionStart: formatDateToHds(constructionHandover.constructionStart),
+    constructionEnd: formatDateToHds(constructionHandover.constructionEnd),
+    otherTimelineNotes: constructionHandover.otherTimelineNotes || '',
+    personPlanning: personToOption(constructionHandover.personPlanning),
+    personFinancing: personToOption(constructionHandover.personFinancing),
   };
-
-  return defaultValues;
 }
 
-export default function useConstructionHandoverForm(project: IProject | null) {
-  const formValues = useConstructionHandoverFormValues(project);
+export default function useConstructionHandoverForm(constructionHandover: IConstructionHandover) {
+  const formValues = useConstructionHandoverFormValues(constructionHandover);
 
   const formMethods = useForm<IConstructionHandoverForm>({
     values: formValues,

--- a/src/forms/useTalpaForm.ts
+++ b/src/forms/useTalpaForm.ts
@@ -1,5 +1,4 @@
 import { useForm } from 'react-hook-form';
-import moment from 'moment';
 import { IProjectTalpaForm } from '@/interfaces/formInterfaces';
 import {
   ITalpaAssetClass,

--- a/src/forms/useTalpaForm.ts
+++ b/src/forms/useTalpaForm.ts
@@ -15,25 +15,11 @@ import { useEffect } from 'react';
 import { infraInvestmentTemplateProject } from '@/components/Project/ProjectTalpa/templateProjectOptions';
 import { InvestmentProfile } from '@/components/Project/ProjectTalpa/investmentProfile';
 import { getTalpaProjectOpeningByProjectThunk, selectTalpaProject } from '@/reducers/talpaSlice';
-import { addYears } from '@/utils/dates';
+import { addYears, formatDateToHds } from '@/utils/dates';
 import { IProject } from '@/interfaces/projectInterfaces';
 import { TalpaProfileName } from '@/components/Project/ProjectTalpa/profileName';
 import { selectResponsiblePersonsRaw } from '@/reducers/listsSlice';
 import { usePostalCode } from '@/hooks/usePostalCode';
-
-const formatDateToHds = (date?: string | null) => {
-  if (!date) {
-    return null;
-  }
-
-  const parsed = moment(date, ['YYYY-MM-DD', 'DD.MM.YYYY'], true);
-  if (parsed.isValid()) {
-    return parsed.format('DD.MM.YYYY');
-  }
-
-  const fallback = moment(date);
-  return fallback.isValid() ? fallback.format('DD.MM.YYYY') : null;
-};
 
 const buildProjectRangeOption = (
   projectRange: ITalpaProjectRange | null,

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -423,7 +423,15 @@
     "otherTimelineNotesTooltip": "Kuvaa hankkeen ja aikataulutuksen välitavoitteita",
     "contacts": "Yhteyshenkilöt",
     "personPlanning": "Suunnittelu ja tekniset asiat",
-    "personFinancing": "Rahoitus ja aikataulu"
+    "personFinancing": "Rahoitus ja aikataulu",
+    "saveDraft": "Tallenna luonnoksena ",
+    "status": {
+      "draft": "Luonnos",
+      "submittedToProgrammer": "Siirretty ohjelmoijalle",
+      "submittedToConstruction": "Siirretty rakennuttajalle",
+      "projectManagerNamed": "Projektipäällikkö nimetty",
+      "movedToConstructionPreparation": "Siirretty rakentamisen valmisteluun"
+    }
   },
   "notification": {
     "title": {
@@ -470,6 +478,7 @@
       "notePatchSuccess": "Muistiinpano muokattu onnistuneesti",
       "talpaProjectPostSuccess": "Projektin avauspyyntö-excel luotu onnistuneesti.",
       "talpaProjectPatchSuccess": "Projektin avauspyyntö-excel muokattu onnistuneesti.",
+      "constructionHandoverPatchSuccess": "Rakennuttamiseen siirron luonnos muokattu onnistuneesti.",
       "Request failed with status code 400": "Pyyntö epäonnistui virhekoodilla 400",
       "Request failed with status code 401": "Pyyntö epäonnistui virhekoodilla 401",
       "Request failed with status code 403": "Pyyntö epäonnistui virhekoodilla 403",

--- a/src/interfaces/constructionHandoverInterfaces.ts
+++ b/src/interfaces/constructionHandoverInterfaces.ts
@@ -1,3 +1,4 @@
+import { IListItem } from './common';
 import { IPerson } from './personsInterfaces';
 
 export enum ConstructionHandoverStatus {
@@ -14,7 +15,7 @@ export interface IConstructionHandover {
   status: ConstructionHandoverStatus;
   name: string | null;
   description: string | null;
-  constructionProcurementMethod: string | null;
+  constructionProcurementMethod: IListItem | null;
   constructionStart: string | null;
   constructionEnd: string | null;
   otherTimelineNotes: string;
@@ -25,4 +26,20 @@ export interface IConstructionHandover {
   linkCostAllocation: string | null;
   linkContractBoundaries: string | null;
   constructionProjectManager: IPerson | null;
+}
+
+export interface IConstructionHandoverRequest
+  extends Omit<
+    IConstructionHandover,
+    'id' | 'status' | 'constructionProcurementMethod' | 'personPlanning' | 'personFinancing'
+  > {
+  project: string;
+  constructionProcurementMethod: string;
+  personPlanning: string;
+  personFinancing: string;
+}
+
+export interface IConstructionHandoverPatchRequest {
+  id: string;
+  data: IConstructionHandoverRequest;
 }

--- a/src/interfaces/formInterfaces.ts
+++ b/src/interfaces/formInterfaces.ts
@@ -162,6 +162,7 @@ export interface IProjectTalpaForm {
 }
 
 export interface IConstructionHandoverForm {
+  id?: string;
   name: string; // Hankkeen nimi
   description: string; // Hankkeen kuvaus
   constructionProcurementMethod: IOption; // Hankintatapa

--- a/src/mocks/createMocks.ts
+++ b/src/mocks/createMocks.ts
@@ -1,4 +1,8 @@
 import { IListItem } from '@/interfaces/common';
+import {
+  ConstructionHandoverStatus,
+  IConstructionHandover,
+} from '@/interfaces/constructionHandoverInterfaces';
 import { IProject } from '@/interfaces/projectInterfaces';
 import { IProjectSapCost } from '@/interfaces/sapCostsInterfaces';
 
@@ -104,3 +108,27 @@ export const createProject = (overrides: ProjectOverrides = {}): IProject => {
     },
   };
 };
+
+export function createConstructionHandover(
+  overrides?: Partial<IConstructionHandover>,
+): IConstructionHandover {
+  return {
+    id: 'handover-1',
+    name: 'Test Handover',
+    description: 'This is a test construction handover.',
+    constructionProcurementMethod: null,
+    constructionStart: null,
+    constructionEnd: null,
+    otherTimelineNotes: '',
+    personPlanning: null,
+    personFinancing: null,
+    linkDesignDrawings: null,
+    linkCostAllocation: null,
+    linkContractBoundaries: null,
+    constructionProjectManager: null,
+    project: 'project-1',
+    status: ConstructionHandoverStatus.DRAFT,
+    totalCost: null,
+    ...overrides,
+  };
+}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -17,7 +17,7 @@ export const removeDotsFromString = (value: string) => value.replace('.', '');
 export const formatNumberToContainSpaces = (number: number) => {
   return String(new Intl.NumberFormat('de-DE').format(number)).replace(/\./g, ' ');
 };
-export const listItemToOption = (listItem: IListItem | undefined): Option => ({
+export const listItemToOption = (listItem: IListItem | undefined | null): Option => ({
   label: listItem?.value ?? '',
   value: listItem?.id ?? '',
   selected: false,
@@ -69,7 +69,7 @@ export const groupOptions = <T>(
     return groups;
   }, []);
 
-export const personToOption = (person?: IPerson): IOption => ({
+export const personToOption = (person?: IPerson | null): IOption => ({
   label: person ? `${person.firstName} ${person.lastName}` : '',
   value: person ? person.id : '',
 });

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -161,3 +161,20 @@ export const isSameOrBefore = (start?: string | null, end?: string | null) => {
   }
   return true;
 };
+
+/**
+ * Formats a date string to HDS format if possible, otherwise returns null
+ */
+export const formatDateToHds = (date?: string | null) => {
+  if (!date) {
+    return null;
+  }
+
+  const parsed = moment(date, ['YYYY-MM-DD', 'DD.MM.YYYY'], true);
+  if (parsed.isValid()) {
+    return parsed.format('DD.MM.YYYY');
+  }
+
+  const fallback = moment(date);
+  return fallback.isValid() ? fallback.format('DD.MM.YYYY') : null;
+};


### PR DESCRIPTION
If construction handover for project does not exist, create handover button is displayed and pressing it calls POST /construction-handovers/ and form is then displayed.

Implemented save draft button which submits the form, calling PATCH /construction-handovers/{id}.

https://helsinkisolutionoffice.atlassian.net/browse/IO-858

API PR (to test this against): https://github.com/City-of-Helsinki/infraohjelmointi-api/pull/446