### PR TITLE
IO-896 Use full window-year budget check for forced-to-frame report

### DIFF
--- a/src/utils/reportHelpers.test.ts
+++ b/src/utils/reportHelpers.test.ts
@@ -1,5 +1,7 @@
 import { IProject } from '@/interfaces/projectInterfaces';
 import {
+  checkGroupHasBudgets,
+  checkProjectHasBudgets,
   convertToGroupValues,
   frameBudgetHandler,
   getIsGroupOnSchedule,
@@ -7,6 +9,7 @@ import {
   isProjectOnSchedule,
 } from './reportHelpers';
 import { createListItem, createProject, createSapCost } from '@/mocks/createMocks';
+import { IConstructionProgramTableRow, Reports } from '@/interfaces/reportInterfaces';
 
 jest.mock('i18next', () => ({
   t: (key: string) => key,
@@ -547,6 +550,112 @@ describe('reportHelpers', () => {
         ];
 
         expect(getIsGroupOnSchedule(projects)).toBe('option.false');
+      });
+    });
+  });
+
+  // IO-896: items funded only in window years +1/+2 (not Plus0) appeared in the
+  // planning report but were dropped from the forced-to-frame report, because
+  // the forced-to-frame budget check only looked at Plus0. Both reports must
+  // now use the full three-window-year check; the forecast report stays
+  // current-year-only.
+  describe('forced-to-frame budget checks (IO-896)', () => {
+    const budgetCheck = (
+      type: Reports,
+      plus0: string,
+      plus1: string,
+      plus2: string,
+    ) => ({
+      budgetProposalCurrentYearPlus0: plus0,
+      budgetProposalCurrentYearPlus1: plus1,
+      budgetProposalCurrentYearPlus2: plus2,
+      forcedToFrameProject: undefined,
+      type,
+    });
+
+    const groupRow = (
+      plus0: string,
+      plus1: string,
+      plus2: string,
+    ): IConstructionProgramTableRow =>
+      ({
+        id: 'g1',
+        name: 'Group',
+        parent: null,
+        children: [],
+        projects: [],
+        type: 'groupWithValues',
+        budgetProposalCurrentYearPlus0: plus0,
+        budgetProposalCurrentYearPlus1: plus1,
+        budgetProposalCurrentYearPlus2: plus2,
+        costForcedToFrameBudget: undefined,
+      } as unknown as IConstructionProgramTableRow);
+
+    describe('checkProjectHasBudgets', () => {
+      it('keeps a forced-to-frame project funded only in +2 (regression)', () => {
+        expect(
+          checkProjectHasBudgets(
+            budgetCheck(Reports.ConstructionProgramForcedToFrame, '0,0', '0,0', '200,0'),
+          ),
+        ).toBeTruthy();
+      });
+
+      it('keeps a forced-to-frame project funded only in +1', () => {
+        expect(
+          checkProjectHasBudgets(
+            budgetCheck(Reports.ConstructionProgramForcedToFrame, '0,0', '1900,0', '0,0'),
+          ),
+        ).toBeTruthy();
+      });
+
+      it('drops a forced-to-frame project with no budget in any window year', () => {
+        expect(
+          checkProjectHasBudgets(
+            budgetCheck(Reports.ConstructionProgramForcedToFrame, '0,0', '0,0', '0,0'),
+          ),
+        ).toBeFalsy();
+      });
+
+      it('matches the planning report for the same finances', () => {
+        const finances: [string, string, string] = ['0,0', '0,0', '200,0'];
+        expect(
+          checkProjectHasBudgets(
+            budgetCheck(Reports.ConstructionProgram, ...finances),
+          ),
+        ).toBeTruthy();
+        expect(
+          checkProjectHasBudgets(
+            budgetCheck(Reports.ConstructionProgramForcedToFrame, ...finances),
+          ),
+        ).toBeTruthy();
+      });
+
+      it('leaves the forecast report current-year-only', () => {
+        expect(
+          checkProjectHasBudgets(
+            budgetCheck(Reports.ConstructionProgramForecast, '0,0', '1900,0', '200,0'),
+          ),
+        ).toBeFalsy();
+      });
+    });
+
+    describe('checkGroupHasBudgets', () => {
+      it('keeps a forced-to-frame group funded only in +1/+2 (regression)', () => {
+        expect(
+          checkGroupHasBudgets(
+            groupRow('0,0', '1900,0', '2000,0'),
+            Reports.ConstructionProgramForcedToFrame,
+          ),
+        ).toBeTruthy();
+      });
+
+      it('drops a forced-to-frame group with no budget in any window year', () => {
+        expect(
+          checkGroupHasBudgets(
+            groupRow('0,0', '0,0', '0,0'),
+            Reports.ConstructionProgramForcedToFrame,
+          ),
+        ).toBeFalsy();
       });
     });
   });

--- a/src/utils/reportHelpers.ts
+++ b/src/utils/reportHelpers.ts
@@ -693,8 +693,11 @@ const checkYearRange = (props: IYearCheck) => {
   }
 };
 
-const checkProjectHasBudgets = (projectFinances: IBudgetCheck) => {
-  if (projectFinances.type === Reports.ConstructionProgram) {
+export const checkProjectHasBudgets = (projectFinances: IBudgetCheck) => {
+  if (
+    projectFinances.type === Reports.ConstructionProgram ||
+    projectFinances.type === Reports.ConstructionProgramForcedToFrame
+  ) {
     return (
       parseFloat((projectFinances.budgetProposalCurrentYearPlus0 ?? '0').replace(',', '.')) > 0 ||
       parseFloat((projectFinances.budgetProposalCurrentYearPlus1 ?? '0').replace(',', '.')) > 0 ||
@@ -712,8 +715,11 @@ const checkProjectHasBudgets = (projectFinances: IBudgetCheck) => {
   );
 };
 
-const checkGroupHasBudgets = (group: IConstructionProgramTableRow, reportType: ReportType) => {
-  if (reportType === Reports.ConstructionProgram) {
+export const checkGroupHasBudgets = (group: IConstructionProgramTableRow, reportType: ReportType) => {
+  if (
+    reportType === Reports.ConstructionProgram ||
+    reportType === Reports.ConstructionProgramForcedToFrame
+  ) {
     return (
       parseFloat((group.budgetProposalCurrentYearPlus0 ?? '0').replace(',', '.')) > 0 ||
       parseFloat((group.budgetProposalCurrentYearPlus1 ?? '0').replace(',', '.')) > 0 ||
@@ -738,8 +744,8 @@ export const getInvestmentPart = (forcedToFrameHierarchy: IBudgetBookSummaryTabl
     objectType: '',
   };
 
-  /* Loop through the financeProperties of each "classGrandparent" and create an object (investmentPart) that contains the summed values 
-    e.g. each classGrandparent has a property called budgetEstimation --> here we take the budgetEstimation of every classGrandParent and sum them 
+  /* Loop through the financeProperties of each "classGrandparent" and create an object (investmentPart) that contains the summed values
+    e.g. each classGrandparent has a property called budgetEstimation --> here we take the budgetEstimation of every classGrandParent and sum them
     together and the same thing is done to the other financeProperties as well */
 
   const investmentPart = forcedToFrameHierarchy.reduce(
@@ -780,7 +786,7 @@ const classOrChildrenHasBudgets = (cells: IPlanningCell[]) => {
 
 const getBudgetBookSummaryProperties = (coordinatorRows: IPlanningRow[]) => {
   const properties = [];
-  /* We want to show only those lower level items that start with some number or one letter and a space after that. 
+  /* We want to show only those lower level items that start with some number or one letter and a space after that.
     This rule is meant for the lower level items but every item in the hierarchy in forced to frame view data should match this */
   const nameCheckPattern = /^(\d+|\w)\s/;
   for (const c of coordinatorRows) {
@@ -1363,7 +1369,7 @@ export const convertToReportRows = (
             c.children.some((child) => child.type !== 'subClass');
 
           const isClassWithoutChildren = c.children.length === 0 && typeIsClass;
-          /* 
+          /*
             In general: if the class is on the fourth level, we want to add some extra rows there.
             isClassWithoutChildren: if the class is on a higher level and it doesn't contain children, it might have projects
             that aren't under any subClass so we need to take that into account as well


### PR DESCRIPTION
* The forced-to-frame report only checked the first window year (Plus0), while planning checked all three, so projects funded only in +1/+2 were dropped
* Make checkProjectHasBudgets and checkGroupHasBudgets use the same Plus0 || Plus1 || Plus2 check for ConstructionProgramForcedToFrame. Forecast stays current-year-only