### PR TITLE
IO-909 Fixed showing pw-error on form submit

### DIFF
--- a/src/api/infraohjelmointiApi.test.ts
+++ b/src/api/infraohjelmointiApi.test.ts
@@ -1,0 +1,88 @@
+import axios from 'axios';
+import { axiosBaseQuery } from './infraohjelmointiApi';
+
+jest.mock('axios');
+
+describe('axiosBaseQuery', () => {
+  const mockedAxios = axios as jest.MockedFunction<typeof axios>;
+
+  beforeEach(() => {
+    mockedAxios.mockReset();
+  });
+
+  it('returns response status and response data from AxiosError-like shape', async () => {
+    mockedAxios.mockRejectedValue({
+      response: {
+        status: 400,
+        data: { hkrId: ['PW_PROJECT_NOT_FOUND'] },
+      },
+      message: 'Request failed with status code 400',
+    });
+
+    const baseQuery = axiosBaseQuery({ baseUrl: 'https://example.test' });
+    const result = await baseQuery({ url: '/projects/1', method: 'patch' }, {} as never, {});
+
+    expect(result).toEqual({
+      error: {
+        status: 400,
+        data: { hkrId: ['PW_PROJECT_NOT_FOUND'] },
+      },
+    });
+  });
+
+  it('falls back to flattened status/data when response object is missing', async () => {
+    mockedAxios.mockRejectedValue({
+      status: 400,
+      data: { hkrId: ['SOME_OTHER_CODE', 'PW_PROJECT_NOT_FOUND'] },
+      message: 'Request failed with status code 400',
+    });
+
+    const baseQuery = axiosBaseQuery({ baseUrl: 'https://example.test' });
+    const result = await baseQuery({ url: '/projects/1', method: 'patch' }, {} as never, {});
+
+    expect(result).toEqual({
+      error: {
+        status: 400,
+        data: { hkrId: ['SOME_OTHER_CODE', 'PW_PROJECT_NOT_FOUND'] },
+      },
+    });
+  });
+
+  it('preserves top-level hkrId payload when data is missing', async () => {
+    mockedAxios.mockRejectedValue({
+      status: 400,
+      hkrId: ['PW_PROJECT_NOT_FOUND'],
+      message: 'Request failed with status code 400',
+    });
+
+    const baseQuery = axiosBaseQuery({ baseUrl: 'https://example.test' });
+    const result = await baseQuery({ url: '/projects/1', method: 'patch' }, {} as never, {});
+
+    expect(result).toEqual({
+      error: {
+        status: 400,
+        data: {
+          status: 400,
+          hkrId: ['PW_PROJECT_NOT_FOUND'],
+          message: 'Request failed with status code 400',
+        },
+      },
+    });
+  });
+
+  it('falls back to error message when no structured data is available', async () => {
+    mockedAxios.mockRejectedValue({
+      message: 'Network Error',
+    });
+
+    const baseQuery = axiosBaseQuery({ baseUrl: 'https://example.test' });
+    const result = await baseQuery({ url: '/projects/1', method: 'patch' }, {} as never, {});
+
+    expect(result).toEqual({
+      error: {
+        status: undefined,
+        data: 'Network Error',
+      },
+    });
+  });
+});

--- a/src/api/infraohjelmointiApi.ts
+++ b/src/api/infraohjelmointiApi.ts
@@ -1,7 +1,7 @@
 import { BaseQueryFn, createApi } from '@reduxjs/toolkit/query/react';
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 
-const axiosBaseQuery =
+export const axiosBaseQuery =
   ({
     baseUrl,
   }: {
@@ -28,11 +28,27 @@ const axiosBaseQuery =
       });
       return { data: result.data };
     } catch (axiosError) {
-      const err = axiosError as AxiosError;
+      const parsedError = axiosError as AxiosError & {
+        data?: unknown;
+        status?: number;
+        hkrId?: unknown;
+      };
+
+      const status = parsedError.response?.status ?? parsedError.status;
+
+      let data: unknown = parsedError.response?.data ?? parsedError.data;
+      if (data === undefined && parsedError.hkrId !== undefined) {
+        data = parsedError;
+      }
+
+      if (data === undefined) {
+        data = parsedError.message;
+      }
+
       return {
         error: {
-          status: err.response?.status,
-          data: err.response?.data || err.message,
+          status,
+          data,
         },
       };
     }

--- a/src/utils/projectErrorMessage.test.ts
+++ b/src/utils/projectErrorMessage.test.ts
@@ -44,11 +44,26 @@ describe('getProjectPatchErrorMessage', () => {
     expect(getProjectPatchErrorMessage(error)).toBe('formSaveError');
   });
 
+  it('matches when the flattened error keeps the backend payload under data', () => {
+    const error = {
+      status: 400,
+      data: {
+        status: 400,
+        hkrId: ['SOME_OTHER_CODE', PW_PROJECT_NOT_FOUND_CODE],
+        message: 'Request failed with status code 400',
+      },
+    };
+
+    expect(getProjectPatchErrorMessage(error)).toBe('pwProjectNotFound');
+  });
+
   it('matches when the PW code is present but not first in the array', () => {
     const error = {
       status: 400,
       data: { hkrId: ['SOME_OTHER_CODE', PW_PROJECT_NOT_FOUND_CODE] },
+      message: 'Request failed with status code 400',
     };
+
     expect(getProjectPatchErrorMessage(error)).toBe('pwProjectNotFound');
   });
 });


### PR DESCRIPTION
Changes made: 

- Error normalization in RTK base query was improved, so patch failures keep useful status/data (including flattened error shapes and hkrId cases) instead of falling back too early to a generic message.
- PW-specific error handling test coverage was expanded for flattened payload and mixed error-code arrays.
- New direct unit tests were added for baseQuery error shaping

Related tickets:
https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/IO/boards/302?selectedIssue=IO-909 + 
https://helsinkisolutionoffice.atlassian.net/browse/IO-865?search_id=13cad2ce-bf42-4794-ba2e-edc06141d278