### PR TITLE
IO-883 Add construction-handover change-history UI

### DIFF
--- a/src/api/constructionHandoverApi.ts
+++ b/src/api/constructionHandoverApi.ts
@@ -4,6 +4,8 @@ import {
   FinancingRowRequest,
   IConstructionHandover,
   IConstructionHandoverFinancing,
+  IConstructionHandoverHistoryRequest,
+  IConstructionHandoverHistoryResponse,
   IConstructionHandoverPatchRequest,
   IConstructionHandoverTransitionResponse,
 } from '@/interfaces/constructionHandoverInterfaces';
@@ -16,6 +18,17 @@ export const constructionHandoverApi = infraohjelmointiApi.injectEndpoints({
       query: (projectId: string) => ({
         url: `/projects/${projectId}/construction-handovers/`,
       }),
+      providesTags: ['ConstructionHandovers'],
+    }),
+    getConstructionHandoverHistory: build.query<
+      IConstructionHandoverHistoryResponse,
+      IConstructionHandoverHistoryRequest
+    >({
+      query: ({ handoverId, pageSize }: IConstructionHandoverHistoryRequest) => ({
+        url: `/construction-handovers/${handoverId}/history/?pageSize=${pageSize ?? 100}`,
+      }),
+      // Tie the history cache to the handover tag so any edit/status transition
+      // (which invalidates 'ConstructionHandovers') refetches the log.
       providesTags: ['ConstructionHandovers'],
     }),
     postConstructionHandover: build.mutation<IConstructionHandover, { project: string | null }>({
@@ -118,6 +131,7 @@ export const constructionHandoverApi = infraohjelmointiApi.injectEndpoints({
 
 export const {
   useGetConstructionHandoversByProjectQuery,
+  useGetConstructionHandoverHistoryQuery,
   usePostConstructionHandoverMutation,
   usePostConstructionHandoverFinancingMutation,
   usePatchConstructionHandoverMutation,

--- a/src/components/Project/ConstructionHandover/ConstructionHandoverContainer.tsx
+++ b/src/components/Project/ConstructionHandover/ConstructionHandoverContainer.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import StartConstructionHandover from './StartConstructionHandover';
 import ConstructionHandoverForm from './ConstructionHandoverForm';
+import ConstructionHandoverHistoryPanel from './ConstructionHandoverHistoryPanel';
 import { ProjectFormSidePanel } from '../ProjectBasics/ProjectFormSidePanel';
 import useGetProject from '@/hooks/useGetProject';
 import {
@@ -23,6 +25,7 @@ export default function ConstructionHandoverContainer() {
   const constructionHandover =
     constructionHandovers && constructionHandovers.length > 0 ? constructionHandovers[0] : null;
   const [postConstructionHandover] = usePostConstructionHandoverMutation();
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const isConstructionHandoverStarted = constructionHandover !== null;
 
   const showHandoverFinalizingForm =
@@ -58,6 +61,9 @@ export default function ConstructionHandoverContainer() {
           project={null}
           showSaveIndicator={false}
           showPwFolderLink={false}
+          onOpenChangeHistory={
+            constructionHandover ? () => setIsHistoryOpen(true) : undefined
+          }
           formStatusSection={
             constructionHandover ? (
               <ConstructionHandoverStatusLabel status={constructionHandover.status} />
@@ -78,6 +84,13 @@ export default function ConstructionHandoverContainer() {
           <StartConstructionHandover onStartHandover={handleStartHandover} />
         )}
       </div>
+      {constructionHandover && (
+        <ConstructionHandoverHistoryPanel
+          isOpen={isHistoryOpen}
+          onClose={() => setIsHistoryOpen(false)}
+          handoverId={constructionHandover.id}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Project/ConstructionHandover/ConstructionHandoverHistoryPanel.test.tsx
+++ b/src/components/Project/ConstructionHandover/ConstructionHandoverHistoryPanel.test.tsx
@@ -1,0 +1,154 @@
+import { renderWithProviders } from '@/utils/testUtils';
+import mockI18next from '@/mocks/mockI18next';
+import { screen } from '@testing-library/react';
+import { Route } from 'react-router';
+import { IConstructionHandoverHistoryEntry } from '@/interfaces/constructionHandoverInterfaces';
+import ConstructionHandoverHistoryPanel from './ConstructionHandoverHistoryPanel';
+import { useGetConstructionHandoverHistoryQuery } from '@/api/constructionHandoverApi';
+
+jest.mock('react-i18next', () => mockI18next());
+jest.mock('@/api/constructionHandoverApi', () => ({
+  __esModule: true,
+  ...jest.requireActual('@/api/constructionHandoverApi'),
+  useGetConstructionHandoverHistoryQuery: jest.fn(),
+}));
+
+const mockedQuery = useGetConstructionHandoverHistoryQuery as jest.Mock;
+
+const statusEntry: IConstructionHandoverHistoryEntry = {
+  id: 'entry-status',
+  actor: 'actor-1',
+  actor_username: 'anna',
+  actor_first_name: 'Anna',
+  actor_last_name: 'Hakala',
+  operation: 'UPDATE',
+  old_values: { status: 'DRAFT' },
+  new_values: { status: 'SUBMITTED_TO_PROGRAMMER' },
+  changed_fields: ['status'],
+  createdDate: '2026-03-12T14:08:00Z',
+};
+
+const fieldEntry: IConstructionHandoverHistoryEntry = {
+  ...statusEntry,
+  id: 'entry-name',
+  old_values: { name: 'Vanha nimi' },
+  new_values: { name: 'Uusi nimi' },
+  changed_fields: ['name'],
+};
+
+const createEntry: IConstructionHandoverHistoryEntry = {
+  ...statusEntry,
+  id: 'entry-create',
+  operation: 'CREATE',
+  old_values: {},
+  new_values: {},
+  changed_fields: [],
+};
+
+const renderPanel = () =>
+  renderWithProviders(
+    <Route
+      path="/"
+      element={<ConstructionHandoverHistoryPanel isOpen onClose={jest.fn()} handoverId="h1" />}
+    />,
+  );
+
+describe('ConstructionHandoverHistoryPanel (IO-883)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders status changes as before → after pills', async () => {
+    mockedQuery.mockReturnValue({
+      data: { count: 1, next: null, previous: null, results: [statusEntry] },
+      isFetching: false,
+      isError: false,
+    });
+
+    renderPanel();
+
+    expect(await screen.findByTestId('handover-history-entry-entry-status')).toBeInTheDocument();
+    expect(screen.getByTestId('handover-history-field-status')).toBeInTheDocument();
+    expect(screen.getByText('Anna Hakala')).toBeInTheDocument();
+    // actor initials avatar
+    expect(screen.getByText('AH')).toBeInTheDocument();
+    // Status values are resolved via the localised status catalogue (the i18n
+    // test mock echoes the key, proving the translation path is used).
+    expect(screen.getByText('constructionHandoverForm.status.draft')).toBeInTheDocument();
+    expect(
+      screen.getByText('constructionHandoverForm.status.submittedToProgrammer'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a non-status field as an old → new diff', async () => {
+    mockedQuery.mockReturnValue({
+      data: { count: 1, next: null, previous: null, results: [fieldEntry] },
+      isFetching: false,
+      isError: false,
+    });
+
+    renderPanel();
+
+    expect(await screen.findByTestId('handover-history-field-name')).toBeInTheDocument();
+    expect(screen.getByText('Vanha nimi')).toBeInTheDocument();
+    expect(screen.getByText('Uusi nimi')).toBeInTheDocument();
+  });
+
+  it('shows the creation event with no field diffs', async () => {
+    mockedQuery.mockReturnValue({
+      data: { count: 1, next: null, previous: null, results: [createEntry] },
+      isFetching: false,
+      isError: false,
+    });
+
+    renderPanel();
+
+    expect(await screen.findByTestId('handover-history-entry-entry-create')).toBeInTheDocument();
+    expect(
+      screen.getByText('constructionHandoverForm.changeHistory.action.created'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there is no history', async () => {
+    mockedQuery.mockReturnValue({
+      data: { count: 0, next: null, previous: null, results: [] },
+      isFetching: false,
+      isError: false,
+    });
+
+    renderPanel();
+
+    expect(await screen.findByTestId('handover-history-empty')).toBeInTheDocument();
+  });
+
+  it('shows a loading state while fetching', async () => {
+    mockedQuery.mockReturnValue({ data: undefined, isFetching: true, isError: false });
+
+    renderPanel();
+
+    expect(
+      await screen.findByText('constructionHandoverForm.changeHistory.loading'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows an error state on failure', async () => {
+    mockedQuery.mockReturnValue({ data: undefined, isFetching: false, isError: true });
+
+    renderPanel();
+
+    expect(await screen.findByTestId('handover-history-error')).toBeInTheDocument();
+  });
+
+  it('does not render anything when closed', () => {
+    mockedQuery.mockReturnValue({ data: undefined, isFetching: false, isError: false });
+
+    renderWithProviders(
+      <Route
+        path="/"
+        element={
+          <ConstructionHandoverHistoryPanel isOpen={false} onClose={jest.fn()} handoverId="h1" />
+        }
+      />,
+    );
+
+    expect(screen.queryByTestId('handover-history-content')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Project/ConstructionHandover/ConstructionHandoverHistoryPanel.tsx
+++ b/src/components/Project/ConstructionHandover/ConstructionHandoverHistoryPanel.tsx
@@ -1,0 +1,62 @@
+import { FC, memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useGetConstructionHandoverHistoryQuery } from '@/api/constructionHandoverApi';
+import { IConstructionHandoverHistoryEntry } from '@/interfaces/constructionHandoverInterfaces';
+import HistoryPanel from '@/components/shared/HistoryPanel';
+import {
+  changedFieldsOf,
+  historyActionOf,
+  historyFieldLabel,
+  PILL_FIELDS,
+  resolveHistoryValue,
+} from './constructionHandoverHistoryUtils';
+
+interface IConstructionHandoverHistoryPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  handoverId: string;
+}
+
+/**
+ * IO-883: change-history side panel for a construction handover ("rakennuttamiseen
+ * siirto"). Consumes GET /construction-handovers/{id}/history/ (IO-882), whose
+ * values are already resolved server-side, and renders them through the shared
+ * HistoryPanel — status changes as before → after pills, other fields as diffs.
+ */
+const ConstructionHandoverHistoryPanel: FC<IConstructionHandoverHistoryPanelProps> = ({
+  isOpen,
+  onClose,
+  handoverId,
+}) => {
+  const { t } = useTranslation();
+
+  const { data, isFetching, isError } = useGetConstructionHandoverHistoryQuery(
+    { handoverId, pageSize: 100 },
+    { skip: !isOpen || !handoverId },
+  );
+
+  const entries = useMemo(() => data?.results ?? [], [data]);
+
+  return (
+    <HistoryPanel<IConstructionHandoverHistoryEntry>
+      isOpen={isOpen}
+      onClose={onClose}
+      t={t}
+      testIdPrefix="handover-history"
+      i18nPrefix="constructionHandoverForm.changeHistory"
+      entries={entries}
+      isFetching={isFetching}
+      isError={isError}
+      pillFields={PILL_FIELDS}
+      fieldsOf={changedFieldsOf}
+      fieldLabel={(field) => historyFieldLabel(field, t)}
+      resolveValue={(entry, field, side) =>
+        resolveHistoryValue(field, (side === 'old' ? entry.old_values : entry.new_values)?.[field], t)
+      }
+      classifyAction={historyActionOf}
+      entryDate={(entry) => entry.createdDate}
+    />
+  );
+};
+
+export default memo(ConstructionHandoverHistoryPanel);

--- a/src/components/Project/ConstructionHandover/constructionHandoverHistoryUtils.test.ts
+++ b/src/components/Project/ConstructionHandover/constructionHandoverHistoryUtils.test.ts
@@ -1,0 +1,99 @@
+import { TFunction } from 'i18next';
+import { IConstructionHandoverHistoryEntry } from '@/interfaces/constructionHandoverInterfaces';
+import {
+  changedFieldsOf,
+  historyActionOf,
+  historyFieldLabel,
+  resolveHistoryValue,
+} from './constructionHandoverHistoryUtils';
+
+// Echo the i18n key so we can assert the catalogue is consulted.
+const t = ((key: string) => key) as unknown as TFunction;
+
+const entry = (
+  over: Partial<IConstructionHandoverHistoryEntry>,
+): IConstructionHandoverHistoryEntry => ({
+  id: 'e',
+  actor: 'a',
+  actor_username: 'u',
+  actor_first_name: 'Anna',
+  actor_last_name: 'Hakala',
+  operation: 'UPDATE',
+  old_values: {},
+  new_values: {},
+  changed_fields: [],
+  createdDate: '2026-03-12T14:08:00Z',
+  ...over,
+});
+
+describe('resolveHistoryValue', () => {
+  it('maps a status enum to its localised label key', () => {
+    expect(resolveHistoryValue('status', 'SUBMITTED_TO_PROGRAMMER', t)).toBe(
+      'constructionHandoverForm.status.submittedToProgrammer',
+    );
+  });
+
+  it('formats an ISO date field into HDS format', () => {
+    expect(resolveHistoryValue('constructionStart', '2026-07-22', t)).toBe('22.07.2026');
+  });
+
+  it('formats totalCost as euro currency', () => {
+    expect(resolveHistoryValue('totalCost', '150000', t)).toMatch(/150\s?000,00€/);
+  });
+
+  it('runs relation values through the option catalogue', () => {
+    expect(resolveHistoryValue('constructionProcurementMethod', 'openTender', t)).toBe(
+      'option.openTender',
+    );
+    expect(resolveHistoryValue('previousProjectPhase', 'programming', t)).toBe('option.programming');
+  });
+
+  it('passes a plain text value through unchanged', () => {
+    expect(resolveHistoryValue('name', 'Urakka A', t)).toBe('Urakka A');
+  });
+
+  it('treats the backend "None" / null sentinels as empty', () => {
+    expect(resolveHistoryValue('description', 'None', t)).toBe('');
+    expect(resolveHistoryValue('personPlanning', null, t)).toBe('');
+  });
+});
+
+describe('changedFieldsOf', () => {
+  it('returns the backend-ordered changed fields', () => {
+    expect(changedFieldsOf(entry({ changed_fields: ['status', 'name'] }))).toEqual([
+      'status',
+      'name',
+    ]);
+  });
+});
+
+describe('historyActionOf', () => {
+  it('labels a CREATE event', () => {
+    expect(historyActionOf(entry({ operation: 'CREATE' })).key).toBe('created');
+  });
+
+  it('labels a status-only change', () => {
+    expect(historyActionOf(entry({ changed_fields: ['status'] })).key).toBe('changedStatus');
+  });
+
+  it('labels a single non-status field edit', () => {
+    expect(historyActionOf(entry({ changed_fields: ['name'] }))).toEqual({
+      key: 'editedField',
+      field: 'name',
+    });
+  });
+
+  it('labels a multi-field edit', () => {
+    expect(historyActionOf(entry({ changed_fields: ['name', 'description'] })).key).toBe(
+      'editedForm',
+    );
+  });
+});
+
+describe('historyFieldLabel', () => {
+  it('builds a field-label i18n key', () => {
+    expect(historyFieldLabel('status', t)).toBe(
+      'constructionHandoverForm.changeHistory.fields.status',
+    );
+  });
+});

--- a/src/components/Project/ConstructionHandover/constructionHandoverHistoryUtils.ts
+++ b/src/components/Project/ConstructionHandover/constructionHandoverHistoryUtils.ts
@@ -1,0 +1,81 @@
+import { TFunction } from 'i18next';
+import { IConstructionHandoverHistoryEntry } from '@/interfaces/constructionHandoverInterfaces';
+import { formatBudgetEuro } from '@/utils/constructionHandoverUtils';
+import { formatDateToHds } from '@/utils/dates';
+import { normalizeHistoryValue } from '@/utils/historyPanelUtils';
+
+const I18N_PREFIX = 'constructionHandoverForm.changeHistory';
+
+// Fields rendered as state "pills" (old → new) instead of a text diff. Status
+// transitions are the headline events of a handover's life, so they get pills.
+export const PILL_FIELDS = new Set<string>(['status']);
+
+// Date fields the backend serialises as ISO ("2026-07-22"); shown in HDS format.
+const DATE_FIELDS = new Set<string>(['constructionStart', 'constructionEnd']);
+
+// Relations the backend resolves to a related row's enum `value`; run through
+// the shared `option.<value>` catalogue for a readable, localised label.
+const OPTION_FIELDS = new Set<string>(['constructionProcurementMethod', 'previousProjectPhase']);
+
+// The handover status enum is audited as its raw SCREAMING_SNAKE value; the
+// i18n catalogue keys it in camelCase (see constructionHandoverForm.status.*).
+const STATUS_I18N_KEY: Record<string, string> = {
+  DRAFT: 'draft',
+  SUBMITTED_TO_PROGRAMMER: 'submittedToProgrammer',
+  SUBMITTED_TO_CONSTRUCTION: 'submittedToConstruction',
+  PROJECT_MANAGER_NAMED: 'projectManagerNamed',
+  MOVED_TO_CONSTRUCTION_PREPARATION: 'movedToConstructionPreparation',
+};
+
+export const historyFieldLabel = (field: string, t: TFunction): string =>
+  t(`${I18N_PREFIX}.fields.${field}`, { defaultValue: field });
+
+// The handover feed resolves relations server-side, so values arrive as
+// display-ready strings — no id→name lookup is needed. We only localise the
+// status/option enums, format dates and money, and pass text through as-is.
+export const resolveHistoryValue = (field: string, value: unknown, t: TFunction): string => {
+  const raw = normalizeHistoryValue(value);
+  if (raw === null) {
+    return '';
+  }
+
+  if (field === 'status') {
+    return t(`constructionHandoverForm.status.${STATUS_I18N_KEY[raw] ?? raw}`, {
+      defaultValue: raw,
+    });
+  }
+  if (DATE_FIELDS.has(field)) {
+    return formatDateToHds(raw) ?? raw;
+  }
+  if (field === 'totalCost') {
+    return formatBudgetEuro(raw) || raw;
+  }
+  if (OPTION_FIELDS.has(field)) {
+    return t(`option.${raw}`, { defaultValue: raw });
+  }
+  return raw;
+};
+
+// The fields this entry changed, in the backend's stable (sorted) order.
+export const changedFieldsOf = (entry: IConstructionHandoverHistoryEntry): Array<string> =>
+  entry.changed_fields ?? [];
+
+export type HistoryActionKey = 'created' | 'changedStatus' | 'editedField' | 'editedForm';
+
+// Decide the human phrasing for an entry: created the handover, changed its
+// status, edited a single named field, or edited several fields.
+export const historyActionOf = (
+  entry: IConstructionHandoverHistoryEntry,
+): { key: HistoryActionKey; field?: string } => {
+  if (entry.operation === 'CREATE') {
+    return { key: 'created' };
+  }
+  const fields = changedFieldsOf(entry);
+  if (fields.length > 0 && fields.every((field) => PILL_FIELDS.has(field))) {
+    return { key: 'changedStatus' };
+  }
+  if (fields.length === 1) {
+    return { key: 'editedField', field: fields[0] };
+  }
+  return { key: 'editedForm' };
+};

--- a/src/components/Project/ProjectBasics/ProjectForm/ProjectHistoryPanel.tsx
+++ b/src/components/Project/ProjectBasics/ProjectForm/ProjectHistoryPanel.tsx
@@ -1,5 +1,4 @@
-import { FC, memo, useEffect, useMemo, useRef } from 'react';
-import { IconClock, IconCross, LoadingSpinner } from 'hds-react';
+import { FC, memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppSelector } from '@/hooks/common';
 import { selectLists } from '@/reducers/listsSlice';
@@ -7,20 +6,15 @@ import { selectAllPlanningClasses } from '@/reducers/classSlice';
 import { useGetProjectHistoryQuery } from '@/api/projectApi';
 import { IProjectHistoryEntry } from '@/interfaces/projectInterfaces';
 import optionIcon from '@/utils/optionIcon';
+import HistoryPanel from '@/components/shared/HistoryPanel';
 import {
-  actorNameOf,
-  avatarColor,
   formFieldsOf,
-  historyFieldLabel,
   historyActionOf,
+  historyFieldLabel,
   historyOptionKey,
-  initialsOf,
-  NO_PREVIOUS_VALUE,
   PILL_FIELDS,
-  relativeHistoryDateTime,
   resolveHistoryValue,
 } from './projectHistoryUtils';
-import './projectHistoryPanel.css';
 
 interface IProjectHistoryPanelProps {
   isOpen: boolean;
@@ -29,16 +23,15 @@ interface IProjectHistoryPanelProps {
 }
 
 /**
- * IO-883: form-level change-history side panel. Slides in from the right over the
- * project form and lists who changed what and when as a timeline — phase changes
- * render as before → after pills, other fields as a struck-through old → new
- * diff. Financial (year-keyed) edits are left to the planning view history.
+ * IO-883: form-level change-history side panel. Renders the project history feed
+ * through the shared HistoryPanel — phase changes as before → after pills, other
+ * fields as a struck-through old → new diff. Financial (year-keyed) edits are
+ * left to the planning view history.
  */
 const ProjectHistoryPanel: FC<IProjectHistoryPanelProps> = ({ isOpen, onClose, projectId }) => {
   const { t } = useTranslation();
   const lists = useAppSelector(selectLists);
   const classes = useAppSelector(selectAllPlanningClasses);
-  const closeRef = useRef<HTMLButtonElement>(null);
 
   const { data, isFetching, isError } = useGetProjectHistoryQuery(
     { projectId, pageSize: 100 },
@@ -51,170 +44,37 @@ const ProjectHistoryPanel: FC<IProjectHistoryPanelProps> = ({ isOpen, onClose, p
     [data],
   );
 
-  useEffect(() => {
-    if (!isOpen) {
-      return undefined;
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', onKeyDown);
-    closeRef.current?.focus();
-    return () => document.removeEventListener('keydown', onKeyDown);
-  }, [isOpen, onClose]);
-
-  if (!isOpen) {
-    return null;
-  }
-
-  const unknownActor = t('projectForm.changeHistory.unknownActor');
-
-  const renderChange = (entry: IProjectHistoryEntry, field: string) => {
-    const oldValue = resolveHistoryValue(field, entry.old_values?.[field], lists, classes, t);
-    const newValue = resolveHistoryValue(field, entry.new_values?.[field], lists, classes, t);
-    const fieldLabel = historyFieldLabel(field, t);
-
-    if (PILL_FIELDS.has(field)) {
-      const oldIcon =
-        optionIcon[historyOptionKey(field, entry.old_values?.[field], lists) as keyof typeof optionIcon];
-      const newIcon =
-        optionIcon[historyOptionKey(field, entry.new_values?.[field], lists) as keyof typeof optionIcon];
-      return (
-        <div
-          key={field}
-          className="project-history-change project-history-change--pills"
-          data-testid={`project-history-field-${field}`}
-        >
-          {oldValue && (
-            <span className="project-history-pill is-old">
-              {oldIcon}
-              {oldValue}
-            </span>
-          )}
-          {oldValue && <span className="project-history-arrow" aria-hidden="true">→</span>}
-          <span className="project-history-pill is-new">
-            {newIcon}
-            {newValue || NO_PREVIOUS_VALUE}
-          </span>
-        </div>
-      );
-    }
-
-    return (
-      <div
-        key={field}
-        className="project-history-change"
-        data-testid={`project-history-field-${field}`}
-      >
-        <span className="project-history-field-label">{fieldLabel}</span>
-        <span className="project-history-diff">
-          <span className="project-history-old-value">{oldValue || NO_PREVIOUS_VALUE}</span>
-          <span className="project-history-arrow" aria-hidden="true">→</span>
-          <span className="project-history-new-value">{newValue || NO_PREVIOUS_VALUE}</span>
-        </span>
-      </div>
-    );
-  };
-
-  const renderEntry = (entry: IProjectHistoryEntry) => {
-    const actorName = actorNameOf(entry, unknownActor);
-    const action = historyActionOf(entry);
-    const actionText =
-      action.key === 'editedField'
-        ? t('projectForm.changeHistory.action.editedField', {
-            field: historyFieldLabel(action.field ?? '', t),
-          })
-        : t(`projectForm.changeHistory.action.${action.key}`);
-    const fields = formFieldsOf(entry);
-
-    return (
-      <li
-        key={entry.id}
-        className="project-history-entry"
-        data-testid={`project-history-entry-${entry.id}`}
-      >
-        <span
-          className="project-history-avatar"
-          style={{ backgroundColor: avatarColor(entry.actor ?? actorName) }}
-          aria-hidden="true"
-        >
-          {initialsOf(entry.actor_first_name, entry.actor_last_name)}
-        </span>
-        <div className="project-history-entry-body">
-          <div className="project-history-entry-header">
-            <span className="project-history-actor">{actorName}</span>
-            <span className="project-history-action">{actionText}</span>
-            <span className="project-history-date">
-              {relativeHistoryDateTime(entry.createdDate, t)}
-            </span>
-          </div>
-          {fields.length > 0 && (
-            <div className="project-history-changes">
-              {fields.map((field) => renderChange(entry, field))}
-            </div>
-          )}
-        </div>
-      </li>
-    );
+  const pillIcon = (entry: IProjectHistoryEntry, field: string, side: 'old' | 'new') => {
+    const values = side === 'old' ? entry.old_values : entry.new_values;
+    return optionIcon[historyOptionKey(field, values?.[field], lists) as keyof typeof optionIcon];
   };
 
   return (
-    <div className="project-history-overlay" data-testid="project-history-overlay">
-      <button
-        type="button"
-        className="project-history-scrim"
-        aria-label={t('projectForm.changeHistory.close')}
-        onClick={onClose}
-        tabIndex={-1}
-      />
-      <aside
-        className="project-history-panel"
-        role="dialog"
-        aria-modal="true"
-        aria-label={t('projectForm.changeHistory.title')}
-      >
-        <header className="project-history-panel-header">
-          <span className="project-history-panel-title">
-            <IconClock aria-hidden="true" />
-            {t('projectForm.changeHistory.title')}
-          </span>
-          <button
-            ref={closeRef}
-            type="button"
-            className="project-history-close"
-            onClick={onClose}
-            aria-label={t('projectForm.changeHistory.close')}
-            data-testid="close-project-history-button"
-          >
-            <IconCross aria-hidden="true" />
-          </button>
-        </header>
-
-        <div className="project-history-content" data-testid="project-history-content">
-          {isFetching && (
-            <div className="project-history-status">
-              <LoadingSpinner small />
-              <span>{t('projectForm.changeHistory.loading')}</span>
-            </div>
-          )}
-          {!isFetching && isError && (
-            <p className="project-history-status" data-testid="project-history-error">
-              {t('projectForm.changeHistory.error')}
-            </p>
-          )}
-          {!isFetching && !isError && entries.length === 0 && (
-            <p className="project-history-status" data-testid="project-history-empty">
-              {t('projectForm.changeHistory.empty')}
-            </p>
-          )}
-          {!isFetching && !isError && entries.length > 0 && (
-            <ol className="project-history-timeline">{entries.map(renderEntry)}</ol>
-          )}
-        </div>
-      </aside>
-    </div>
+    <HistoryPanel<IProjectHistoryEntry>
+      isOpen={isOpen}
+      onClose={onClose}
+      t={t}
+      testIdPrefix="project-history"
+      i18nPrefix="projectForm.changeHistory"
+      entries={entries}
+      isFetching={isFetching}
+      isError={isError}
+      pillFields={PILL_FIELDS}
+      fieldsOf={formFieldsOf}
+      fieldLabel={(field) => historyFieldLabel(field, t)}
+      resolveValue={(entry, field, side) =>
+        resolveHistoryValue(
+          field,
+          (side === 'old' ? entry.old_values : entry.new_values)?.[field],
+          lists,
+          classes,
+          t,
+        )
+      }
+      pillIcon={pillIcon}
+      classifyAction={historyActionOf}
+      entryDate={(entry) => entry.createdDate}
+    />
   );
 };
 

--- a/src/components/Project/ProjectBasics/ProjectForm/projectHistoryUtils.test.ts
+++ b/src/components/Project/ProjectBasics/ProjectForm/projectHistoryUtils.test.ts
@@ -1,12 +1,7 @@
-import moment from 'moment';
 import { TFunction } from 'i18next';
 import { IClass } from '@/interfaces/classInterfaces';
 import { IListState } from '@/reducers/listsSlice';
-import {
-  historyOptionKey,
-  relativeHistoryDateTime,
-  resolveHistoryValue,
-} from './projectHistoryUtils';
+import { historyOptionKey, resolveHistoryValue } from './projectHistoryUtils';
 
 // Echo the i18n key so we can assert the option catalogue is consulted.
 const t = ((key: string) => key) as unknown as TFunction;
@@ -60,23 +55,5 @@ describe('historyOptionKey', () => {
 
   it('passes an enum value (non-UUID) through unchanged', () => {
     expect(historyOptionKey('phase', 'proposal', lists)).toBe('proposal');
-  });
-});
-
-describe('relativeHistoryDateTime', () => {
-  it('formats a timestamp from today as "today HH:mm"', () => {
-    const iso = moment().hour(12).minute(22).second(0).millisecond(0).toISOString();
-    const result = relativeHistoryDateTime(iso, t);
-    expect(result).toContain('projectForm.changeHistory.today');
-    expect(result).toContain(moment(iso).format('HH:mm'));
-  });
-
-  it('formats a timestamp from yesterday as "yesterday HH:mm"', () => {
-    const iso = moment().subtract(1, 'day').hour(13).minute(25).second(0).toISOString();
-    expect(relativeHistoryDateTime(iso, t)).toContain('projectForm.changeHistory.yesterday');
-  });
-
-  it('formats an older timestamp as an absolute date-time', () => {
-    expect(relativeHistoryDateTime('2025-03-12T14:08:00', t)).toBe('12.3.2025 14:08');
   });
 });

--- a/src/components/Project/ProjectBasics/ProjectForm/projectHistoryUtils.ts
+++ b/src/components/Project/ProjectBasics/ProjectForm/projectHistoryUtils.ts
@@ -1,11 +1,9 @@
-import moment from 'moment';
 import { TFunction } from 'i18next';
 import { IClass } from '@/interfaces/classInterfaces';
 import { IListItem } from '@/interfaces/common';
 import { IListState } from '@/reducers/listsSlice';
 import { IProjectHistoryEntry } from '@/interfaces/projectInterfaces';
-
-export const NO_PREVIOUS_VALUE = '—';
+import { normalizeHistoryValue } from '@/utils/historyPanelUtils';
 
 // Financial figures are stored keyed by calendar year ("2026"); form-field
 // changes are keyed by field name. The form-level panel only shows the latter —
@@ -43,11 +41,6 @@ export const historyFieldLabel = (field: string, t: TFunction): string =>
 // class UUID; resolve against the class hierarchy to a readable name.
 const CLASS_FIELDS = new Set<string>(['projectClass']);
 
-// The backend stringifies an absent relation as "None" (and may send "null"),
-// so treat those as "no value" and let the panel render the em dash instead.
-const isEmptyHistoryValue = (raw: string): boolean =>
-  raw === '' || raw === 'None' || raw === 'null' || raw === 'undefined';
-
 export const resolveHistoryValue = (
   field: string,
   value: unknown,
@@ -55,14 +48,8 @@ export const resolveHistoryValue = (
   classes: Array<IClass>,
   t: TFunction,
 ): string => {
-  if (value === null || value === undefined) {
-    return '';
-  }
-  const raw =
-    typeof value === 'object'
-      ? JSON.stringify(value)
-      : String(value as string | number | boolean);
-  if (isEmptyHistoryValue(raw)) {
+  const raw = normalizeHistoryValue(value);
+  if (raw === null) {
     return '';
   }
 
@@ -99,23 +86,6 @@ export const historyOptionKey = (field: string, value: unknown, lists: IListStat
   return match?.value ?? raw;
 };
 
-// Format an audit timestamp the way the design shows it: "tänään HH:mm" /
-// "eilen HH:mm" for the last two days, otherwise "D.M.YYYY HH:mm".
-export const relativeHistoryDateTime = (iso: string, t: TFunction): string => {
-  const m = moment(iso);
-  if (!m.isValid()) {
-    return iso;
-  }
-  const time = m.format('HH:mm');
-  if (m.isSame(moment(), 'day')) {
-    return `${t('projectForm.changeHistory.today')} ${time}`;
-  }
-  if (m.isSame(moment().subtract(1, 'day'), 'day')) {
-    return `${t('projectForm.changeHistory.yesterday')} ${time}`;
-  }
-  return m.format('D.M.YYYY HH:mm');
-};
-
 // The non-financial fields this entry changed, in a stable order.
 export const formFieldsOf = (entry: IProjectHistoryEntry): Array<string> =>
   (entry.changed_fields ?? []).filter((field) => !isYearKey(field));
@@ -146,38 +116,4 @@ export const historyActionOf = (
     return { key: 'editedField', field: fields[0] };
   }
   return { key: 'editedForm' };
-};
-
-const AVATAR_COLORS = [
-  'var(--color-coat-of-arms)',
-  'var(--color-bus)',
-  'var(--color-success)',
-  'var(--color-gold)',
-  'var(--color-suomenlinna)',
-  'var(--color-tram)',
-  'var(--color-copper)',
-  'var(--color-error)',
-];
-
-export const avatarColor = (seed: string): string => {
-  let hash = 0;
-  for (let i = 0; i < seed.length; i += 1) {
-    hash = (hash * 31 + (seed.codePointAt(i) ?? 0)) >>> 0;
-  }
-  return AVATAR_COLORS[hash % AVATAR_COLORS.length];
-};
-
-export const initialsOf = (first?: string | null, last?: string | null): string => {
-  const f = (first ?? '').trim();
-  const l = (last ?? '').trim();
-  const initials = `${f.charAt(0)}${l.charAt(0)}`.toUpperCase();
-  return initials || '?';
-};
-
-export const actorNameOf = (
-  entry: IProjectHistoryEntry,
-  fallback: string,
-): string => {
-  const name = `${entry.actor_first_name ?? ''} ${entry.actor_last_name ?? ''}`.trim();
-  return name || fallback;
 };

--- a/src/components/shared/HistoryPanel.tsx
+++ b/src/components/shared/HistoryPanel.tsx
@@ -1,0 +1,237 @@
+import { ReactNode, useEffect, useRef } from 'react';
+import { IconClock, IconCross, LoadingSpinner } from 'hds-react';
+import { TFunction } from 'i18next';
+import {
+  actorNameOf,
+  avatarColor,
+  IHistoryActor,
+  initialsOf,
+  NO_PREVIOUS_VALUE,
+  relativeHistoryDateTime,
+} from '@/utils/historyPanelUtils';
+import './historyPanel.css';
+
+// The minimum shape a history entry must have for the shared panel to render its
+// timeline row. Feature-specific fields (old_values, operation, …) are read by
+// the caller's callbacks, so they stay off this base type.
+export interface IHistoryPanelEntry extends IHistoryActor {
+  id: string;
+  actor: string | null;
+}
+
+export interface IHistoryPanelProps<E extends IHistoryPanelEntry> {
+  isOpen: boolean;
+  onClose: () => void;
+  t: TFunction;
+  // Distinguishes the two panels' data-testids (e.g. 'project-history').
+  testIdPrefix: string;
+  // i18n namespace for the panel chrome and action phrasing
+  // (e.g. 'projectForm.changeHistory').
+  i18nPrefix: string;
+  entries: Array<E>;
+  isFetching: boolean;
+  isError: boolean;
+  // Fields rendered as before → after "pills" instead of a struck-through diff.
+  pillFields: Set<string>;
+  fieldsOf: (entry: E) => Array<string>;
+  fieldLabel: (field: string) => string;
+  // Resolve the old/new side of a field to a display string.
+  resolveValue: (entry: E, field: string, side: 'old' | 'new') => string;
+  // Optional leading icon for a pill value (e.g. the project phase icon).
+  pillIcon?: (entry: E, field: string, side: 'old' | 'new') => ReactNode;
+  // Classify what an entry did, so the panel can phrase it via the i18n
+  // namespace ({i18nPrefix}.action.{key}, with an `editedField` special case).
+  classifyAction: (entry: E) => { key: string; field?: string };
+  entryDate: (entry: E) => string | null;
+}
+
+/**
+ * IO-883: shared change-history side panel. Slides in from the right and lists
+ * who changed what and when as an actor timeline — configured "pill" fields
+ * render as before → after pills, other fields as a struck-through old → new
+ * diff. The project form and the construction handover both drive it with their
+ * own value resolution while sharing the layout, styling and keyboard handling.
+ */
+const HistoryPanel = <E extends IHistoryPanelEntry>({
+  isOpen,
+  onClose,
+  t,
+  testIdPrefix,
+  i18nPrefix,
+  entries,
+  isFetching,
+  isError,
+  pillFields,
+  fieldsOf,
+  fieldLabel,
+  resolveValue,
+  pillIcon,
+  classifyAction,
+  entryDate,
+}: IHistoryPanelProps<E>) => {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    closeRef.current?.focus();
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const label = (key: string) => t(`${i18nPrefix}.${key}`);
+
+  const actionText = (entry: E) => {
+    const action = classifyAction(entry);
+    return action.key === 'editedField'
+      ? t(`${i18nPrefix}.action.editedField`, { field: fieldLabel(action.field ?? '') })
+      : t(`${i18nPrefix}.action.${action.key}`);
+  };
+
+  const renderChange = (entry: E, field: string) => {
+    const oldValue = resolveValue(entry, field, 'old');
+    const newValue = resolveValue(entry, field, 'new');
+
+    if (pillFields.has(field)) {
+      return (
+        <div
+          key={field}
+          className="project-history-change project-history-change--pills"
+          data-testid={`${testIdPrefix}-field-${field}`}
+        >
+          {oldValue && (
+            <span className="project-history-pill is-old">
+              {pillIcon?.(entry, field, 'old')}
+              {oldValue}
+            </span>
+          )}
+          {oldValue && (
+            <span className="project-history-arrow" aria-hidden="true">
+              →
+            </span>
+          )}
+          <span className="project-history-pill is-new">
+            {pillIcon?.(entry, field, 'new')}
+            {newValue || NO_PREVIOUS_VALUE}
+          </span>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        key={field}
+        className="project-history-change"
+        data-testid={`${testIdPrefix}-field-${field}`}
+      >
+        <span className="project-history-field-label">{fieldLabel(field)}</span>
+        <span className="project-history-diff">
+          <span className="project-history-old-value">{oldValue || NO_PREVIOUS_VALUE}</span>
+          <span className="project-history-arrow" aria-hidden="true">
+            →
+          </span>
+          <span className="project-history-new-value">{newValue || NO_PREVIOUS_VALUE}</span>
+        </span>
+      </div>
+    );
+  };
+
+  const renderEntry = (entry: E) => {
+    const actorName = actorNameOf(entry, label('unknownActor'));
+    const fields = fieldsOf(entry);
+
+    return (
+      <li
+        key={entry.id}
+        className="project-history-entry"
+        data-testid={`${testIdPrefix}-entry-${entry.id}`}
+      >
+        <span
+          className="project-history-avatar"
+          style={{ backgroundColor: avatarColor(entry.actor ?? actorName) }}
+          aria-hidden="true"
+        >
+          {initialsOf(entry.actor_first_name, entry.actor_last_name)}
+        </span>
+        <div className="project-history-entry-body">
+          <div className="project-history-entry-header">
+            <span className="project-history-actor">{actorName}</span>
+            <span className="project-history-action">{actionText(entry)}</span>
+            <span className="project-history-date">
+              {relativeHistoryDateTime(entryDate(entry), t, i18nPrefix)}
+            </span>
+          </div>
+          {fields.length > 0 && (
+            <div className="project-history-changes">
+              {fields.map((field) => renderChange(entry, field))}
+            </div>
+          )}
+        </div>
+      </li>
+    );
+  };
+
+  return (
+    <div className="project-history-overlay" data-testid={`${testIdPrefix}-overlay`}>
+      <button
+        type="button"
+        className="project-history-scrim"
+        aria-label={label('close')}
+        onClick={onClose}
+        tabIndex={-1}
+      />
+      <dialog open className="project-history-panel" aria-modal="true" aria-label={label('title')}>
+        <header className="project-history-panel-header">
+          <span className="project-history-panel-title">
+            <IconClock aria-hidden="true" />
+            {label('title')}
+          </span>
+          <button
+            ref={closeRef}
+            type="button"
+            className="project-history-close"
+            onClick={onClose}
+            aria-label={label('close')}
+            data-testid={`close-${testIdPrefix}-button`}
+          >
+            <IconCross aria-hidden="true" />
+          </button>
+        </header>
+
+        <div className="project-history-content" data-testid={`${testIdPrefix}-content`}>
+          {isFetching && (
+            <div className="project-history-status">
+              <LoadingSpinner small />
+              <span>{label('loading')}</span>
+            </div>
+          )}
+          {!isFetching && isError && (
+            <p className="project-history-status" data-testid={`${testIdPrefix}-error`}>
+              {label('error')}
+            </p>
+          )}
+          {!isFetching && !isError && entries.length === 0 && (
+            <p className="project-history-status" data-testid={`${testIdPrefix}-empty`}>
+              {label('empty')}
+            </p>
+          )}
+          {!isFetching && !isError && entries.length > 0 && (
+            <ol className="project-history-timeline">{entries.map(renderEntry)}</ol>
+          )}
+        </div>
+      </dialog>
+    </div>
+  );
+};
+
+export default HistoryPanel;

--- a/src/components/shared/historyPanel.css
+++ b/src/components/shared/historyPanel.css
@@ -8,7 +8,8 @@
 }
 
 .project-history-panel {
-  @apply relative flex h-full w-full max-w-[28rem] flex-col bg-white;
+  /* border-0/m-0/p-0 reset the native <dialog> user-agent styles. */
+  @apply relative m-0 flex h-full w-full max-w-[28rem] flex-col border-0 bg-white p-0;
   box-shadow: -2px 0 12px rgba(0, 0, 0, 0.15);
   animation: project-history-slide-in 0.2s ease-out;
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -515,6 +515,39 @@
         "budget": "Budjetti"
       },
       "projectNumberWarning": "Projektinumeroa ei voitu hakea tietokannasta. Kirjaa se käsin tai yritä myöhemmin uudelleen."
+    },
+    "changeHistory": {
+      "title": "Rakennuttamiseen siirron muutoshistoria",
+      "loading": "Ladataan muutoshistoriaa…",
+      "empty": "Tälle rakennuttamiseen siirrolle ei ole tallennettua muutoshistoriaa.",
+      "error": "Muutoshistorian lataaminen epäonnistui.",
+      "close": "Sulje",
+      "today": "tänään",
+      "yesterday": "eilen",
+      "unknownActor": "Tuntematon käyttäjä",
+      "action": {
+        "created": "loi rakennuttamiseen siirron",
+        "changedStatus": "muutti tilaa",
+        "editedField": "muokkasi {{field}}-kenttää",
+        "editedForm": "muokkasi lomaketta"
+      },
+      "fields": {
+        "status": "Tila",
+        "name": "Hankkeen nimi",
+        "description": "Hankkeen kuvaus",
+        "constructionProcurementMethod": "Hankintatapa",
+        "constructionStart": "Aloitus viimeistään",
+        "constructionEnd": "Valmis viimeistään",
+        "otherTimelineNotes": "Muut aikataulun sidonnaisuudet ja välitavoitteet",
+        "totalCost": "Kokonaiskustannus",
+        "personPlanning": "Suunnittelu ja tekniset asiat",
+        "personFinancing": "Rahoitus ja aikataulu",
+        "constructionProjectManager": "Projektipäällikkö",
+        "linkDesignDrawings": "Suunnitelmapiirustukset",
+        "linkCostAllocation": "Kustannusjako",
+        "linkContractBoundaries": "Urakkarajat",
+        "previousProjectPhase": "Edellinen hankevaihe"
+      }
     }
   },
   "notification": {

--- a/src/interfaces/constructionHandoverInterfaces.ts
+++ b/src/interfaces/constructionHandoverInterfaces.ts
@@ -58,6 +58,36 @@ export interface IConstructionHandoverTransitionResponse {
   currentStatus: ConstructionHandoverStatus;
   possibleTransitions: ConstructionHandoverStatus[];
 }
+
+// IO-883: a single change event from GET /construction-handovers/{id}/history/
+// (IO-882). Relations are already resolved server-side to display strings
+// (person names, related-row `value`, ISO dates), so no id→name lookup is needed
+// here. Mirrors the project-history feed shape (IProjectHistoryEntry).
+export interface IConstructionHandoverHistoryEntry {
+  id: string;
+  actor: string | null;
+  actor_username: string | null;
+  actor_first_name: string | null;
+  actor_last_name: string | null;
+  operation: 'CREATE' | 'UPDATE';
+  old_values: Record<string, unknown>;
+  new_values: Record<string, unknown>;
+  changed_fields: Array<string>;
+  createdDate: string | null;
+}
+
+export interface IConstructionHandoverHistoryResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: Array<IConstructionHandoverHistoryEntry>;
+}
+
+export interface IConstructionHandoverHistoryRequest {
+  handoverId: string;
+  pageSize?: number;
+}
+
 export interface FinancingDialogState {
   open: boolean;
   mode: DialogMode;

--- a/src/utils/historyPanelUtils.test.ts
+++ b/src/utils/historyPanelUtils.test.ts
@@ -1,0 +1,84 @@
+import moment from 'moment';
+import { TFunction } from 'i18next';
+import {
+  actorNameOf,
+  avatarColor,
+  initialsOf,
+  normalizeHistoryValue,
+  relativeHistoryDateTime,
+} from './historyPanelUtils';
+
+// Echo the i18n key so we can assert the catalogue is consulted.
+const t = ((key: string) => key) as unknown as TFunction;
+
+const PREFIX = 'someForm.changeHistory';
+
+describe('normalizeHistoryValue', () => {
+  it('returns null for null/undefined and the backend "None"/"null" sentinels', () => {
+    expect(normalizeHistoryValue(null)).toBeNull();
+    expect(normalizeHistoryValue(undefined)).toBeNull();
+    expect(normalizeHistoryValue('None')).toBeNull();
+    expect(normalizeHistoryValue('null')).toBeNull();
+    expect(normalizeHistoryValue('')).toBeNull();
+  });
+
+  it('stringifies primitives and objects', () => {
+    expect(normalizeHistoryValue('Urakka A')).toBe('Urakka A');
+    expect(normalizeHistoryValue(42)).toBe('42');
+    expect(normalizeHistoryValue({ a: 1 })).toBe('{"a":1}');
+  });
+});
+
+describe('relativeHistoryDateTime', () => {
+  it('formats a timestamp from today as "today HH:mm" under the given namespace', () => {
+    const iso = moment().hour(12).minute(22).second(0).millisecond(0).toISOString();
+    const result = relativeHistoryDateTime(iso, t, PREFIX);
+    expect(result).toContain(`${PREFIX}.today`);
+    expect(result).toContain(moment(iso).format('HH:mm'));
+  });
+
+  it('formats a timestamp from yesterday as "yesterday HH:mm"', () => {
+    const iso = moment().subtract(1, 'day').hour(13).minute(25).second(0).toISOString();
+    expect(relativeHistoryDateTime(iso, t, PREFIX)).toContain(`${PREFIX}.yesterday`);
+  });
+
+  it('formats an older timestamp as an absolute date-time', () => {
+    expect(relativeHistoryDateTime('2025-03-12T14:08:00', t, PREFIX)).toBe('12.3.2025 14:08');
+  });
+
+  it('returns an empty string for a null timestamp', () => {
+    expect(relativeHistoryDateTime(null, t, PREFIX)).toBe('');
+  });
+});
+
+describe('actor helpers', () => {
+  it('derives initials, falling back to "?"', () => {
+    expect(initialsOf('Anna', 'Hakala')).toBe('AH');
+    expect(initialsOf('', '')).toBe('?');
+    expect(initialsOf(null, null)).toBe('?');
+  });
+
+  it('builds an actor name, falling back when both names are missing', () => {
+    expect(actorNameOf({ actor_first_name: 'Anna', actor_last_name: 'Hakala' }, 'X')).toBe(
+      'Anna Hakala',
+    );
+    expect(actorNameOf({ actor_first_name: null, actor_last_name: null }, 'Tuntematon')).toBe(
+      'Tuntematon',
+    );
+  });
+
+  it('returns a stable colour from the palette for a given seed', () => {
+    const palette = new Set([
+      'var(--color-coat-of-arms)',
+      'var(--color-bus)',
+      'var(--color-success)',
+      'var(--color-gold)',
+      'var(--color-suomenlinna)',
+      'var(--color-tram)',
+      'var(--color-copper)',
+      'var(--color-error)',
+    ]);
+    expect(avatarColor('Anna Hakala')).toBe(avatarColor('Anna Hakala'));
+    expect(palette.has(avatarColor('Anna Hakala'))).toBe(true);
+  });
+});

--- a/src/utils/historyPanelUtils.ts
+++ b/src/utils/historyPanelUtils.ts
@@ -1,0 +1,92 @@
+import moment from 'moment';
+import { TFunction } from 'i18next';
+
+// Shared building blocks for the change-history side panels (project form and
+// construction handover). These are the field-agnostic pieces both feeds have
+// in common; the domain-specific value resolution lives in each feature's own
+// `*HistoryUtils` module.
+
+export const NO_PREVIOUS_VALUE = '—';
+
+// The backend stringifies an absent relation as "None" (and may send "null"),
+// so treat those as "no value" and let the panel render the em dash instead.
+const isEmptyHistoryValue = (raw: string): boolean =>
+  raw === '' || raw === 'None' || raw === 'null' || raw === 'undefined';
+
+// Normalise a raw audit value to a display string, or `null` when it represents
+// "no value" (null/undefined or one of the backend sentinels above). Object
+// values are stringified so relation payloads still show something readable.
+export const normalizeHistoryValue = (value: unknown): string | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const raw =
+    typeof value === 'object' ? JSON.stringify(value) : String(value as string | number | boolean);
+  return isEmptyHistoryValue(raw) ? null : raw;
+};
+
+// Format an audit timestamp the way the design shows it: "tänään HH:mm" /
+// "eilen HH:mm" for the last two days, otherwise "D.M.YYYY HH:mm". The
+// today/yesterday labels are read from the caller's i18n namespace.
+export const relativeHistoryDateTime = (
+  iso: string | null,
+  t: TFunction,
+  i18nPrefix: string,
+): string => {
+  if (!iso) {
+    return '';
+  }
+  const m = moment(iso);
+  if (!m.isValid()) {
+    return iso;
+  }
+  const time = m.format('HH:mm');
+  if (m.isSame(moment(), 'day')) {
+    const today = t(`${i18nPrefix}.today`);
+    return `${today} ${time}`;
+  }
+  if (m.isSame(moment().subtract(1, 'day'), 'day')) {
+    const yesterday = t(`${i18nPrefix}.yesterday`);
+    return `${yesterday} ${time}`;
+  }
+  return m.format('D.M.YYYY HH:mm');
+};
+
+const AVATAR_COLORS = [
+  'var(--color-coat-of-arms)',
+  'var(--color-bus)',
+  'var(--color-success)',
+  'var(--color-gold)',
+  'var(--color-suomenlinna)',
+  'var(--color-tram)',
+  'var(--color-copper)',
+  'var(--color-error)',
+];
+
+// Pick a stable avatar colour from a seed (actor id or name) so the same actor
+// always gets the same colour across a session.
+export const avatarColor = (seed: string): string => {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash = (hash * 31 + (seed.codePointAt(i) ?? 0)) >>> 0;
+  }
+  return AVATAR_COLORS[hash % AVATAR_COLORS.length];
+};
+
+export const initialsOf = (first?: string | null, last?: string | null): string => {
+  const f = (first ?? '').trim();
+  const l = (last ?? '').trim();
+  const initials = `${f.charAt(0)}${l.charAt(0)}`.toUpperCase();
+  return initials || '?';
+};
+
+// The subset of a history entry the shared helpers need to name the actor.
+export interface IHistoryActor {
+  actor_first_name?: string | null;
+  actor_last_name?: string | null;
+}
+
+export const actorNameOf = (entry: IHistoryActor, fallback: string): string => {
+  const name = `${entry.actor_first_name ?? ''} ${entry.actor_last_name ?? ''}`.trim();
+  return name || fallback;
+};


### PR DESCRIPTION
Add a muutoshistoria side panel to the construction-handover form, consuming GET /construction-handovers/{id}/history/ (IO-882). Mirrors the shipped project-history pattern (IO-881): status changes render as before -> after pills, other fields as an old -> new diff, on an actor timeline. Wired into the existing ProjectFormSidePanel button; fi-only i18n.